### PR TITLE
Backward Sync, reduce retries from 20 to 2

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class BackwardSyncContext {
   private static final Logger LOG = LoggerFactory.getLogger(BackwardSyncContext.class);
   public static final int BATCH_SIZE = 200;
-  private static final int DEFAULT_MAX_RETRIES = 20;
+  private static final int DEFAULT_MAX_RETRIES = 2;
   private static final long MILLIS_DELAY_BETWEEN_PROGRESS_LOG = 10_000L;
   private static final long DEFAULT_MILLIS_BETWEEN_RETRIES = 5000;
   private static final int DEFAULT_MAX_CHAIN_EVENT_ENTRIES = BadBlockManager.MAX_BAD_BLOCKS_SIZE;


### PR DESCRIPTION
## PR description
The backward sync uses the RetryingGetBlockFromPeersTask, which will try to get the block from each of the current peers. 
Only if none of the current peers can provide that block we need to retry.
If for any reason we are trying to get a block that is no longer available (reorg) we would try each of out current peers 20 times, each of our peers responding with an empty response. On an EthPeer that is responding with an empty response we will call `recordUselessResponse()`  and if we have accumulated 5 useless responses for a peer within a minute we will disconnect it.
To make sure that we do not disconnect all of our current peers this PR reduces the retries for requesting that block to 2.
