### PR TITLE
perf(eth): reduce per-tx allocations in constructGetPooledTransactionsResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@
 
 ### Additions and Improvements
 - Add `eth_baseFee` JSON-RPC method, returning the calculated base fee of the next block [#10457](https://github.com/besu-eth/besu/pull/10457)
+- Reduce per-transaction allocations and copies in `EthServer.constructGetPooledTransactionsResponse` by using `SimpleNoCopyRlpEncoder` instead of per-transaction `BytesValueRLPOutput` [#10469](https://github.com/besu-eth/besu/issues/10469)
 - Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
+
 - Add `enableReturnData` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`, and include `returnData` in `StructLog` when captured; the field is omitted when return data is empty or not captured. [#10172](https://github.com/besu-eth/besu/pull/10172)
 - Updated `Bouncycastle` to 1.84 and `maven-artifact` to 3.9.15 to resolve CVEs reported in those libraries. Besu's usage patterns are not affected by these vulnerabilities. [#10420](https://github.com/besu-eth/besu/pull/10420)
 - Improve native memory handling in RocksDB storage: `LRUCache`, `ColumnFamilyOptions`, and temporary options-file loading objects are now explicitly closed [#10456](https://github.com/besu-eth/besu/pull/10456)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthServer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthServer.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.manager;
 import static org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason.INVALID_FIRST_BLOCK_RECEIPT_INDEX;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.TransactionType;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -48,6 +49,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.rlp.SimpleNoCopyRlpEncoder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -434,10 +436,10 @@ class EthServer {
       hashesToProcess = hashes;
     }
 
-    int responseSizeEstimate = RLP.MAX_PREFIX_SIZE;
-    final BytesValueRLPOutput rlp = new BytesValueRLPOutput();
-    rlp.startList();
+    final SimpleNoCopyRlpEncoder enc = new SimpleNoCopyRlpEncoder();
+    final List<Bytes> encodedTxs = new ArrayList<>();
     final List<Hash> returnedHashes = traceEnabled ? new ArrayList<>() : null;
+    int responseSizeEstimate = RLP.MAX_PREFIX_SIZE;
     int requestedCount = 0;
     int returnedCount = 0;
     for (final Hash hash : hashesToProcess) {
@@ -450,21 +452,24 @@ class EthServer {
         continue;
       }
 
-      final BytesValueRLPOutput txRlp = new BytesValueRLPOutput();
-      TransactionEncoder.encodeRLP(maybeTx.get(), txRlp, EncodingContext.POOLED_TRANSACTION);
-      final int encodedSize = txRlp.encodedSize();
-      if (responseSizeEstimate + encodedSize > maxMessageSize) {
+      final Transaction tx = maybeTx.get();
+      final Bytes opaqueBytes =
+          TransactionEncoder.encodeOpaqueBytes(tx, EncodingContext.POOLED_TRANSACTION);
+      // FRONTIER opaque bytes are the complete RLP list item (written raw into the outer list).
+      // Typed transaction opaque bytes are wrapped as an RLP byte-string inside the list.
+      final Bytes encodedTx =
+          tx.getType() == TransactionType.FRONTIER ? opaqueBytes : enc.encode(opaqueBytes);
+      if (responseSizeEstimate + encodedTx.size() > maxMessageSize) {
         break;
       }
 
-      responseSizeEstimate += encodedSize;
-      rlp.writeRaw(txRlp.encoded());
+      responseSizeEstimate += encodedTx.size();
+      encodedTxs.add(encodedTx);
       returnedCount++;
       if (returnedHashes != null) {
         returnedHashes.add(hash);
       }
     }
-    rlp.endList();
 
     if (traceEnabled) {
       LOG.atTrace()
@@ -475,6 +480,6 @@ class EthServer {
           .log();
     }
 
-    return PooledTransactionsMessage.createUnsafe(rlp.encoded());
+    return PooledTransactionsMessage.createUnsafe(enc.encodeList(encodedTxs));
   }
 }


### PR DESCRIPTION
Closes #10469

#### PR description

This PR optimizes the hot path for handling `GetPooledTransactions` P2P messages (EIP-2464) by replacing per-transaction `BytesValueRLPOutput` allocations with a single `SimpleNoCopyRlpEncoder` that accumulates zero-copy `Bytes` references. 

#### Problem
The current implementation in `EthServer.constructGetPooledTransactionsResponse` allocates a fresh `BytesValueRLPOutput` **per transaction**, encodes into it, and immediately invokes `.encoded()` to copy bytes out before discarding the buffer. Under heavy transaction pool syncing load, this causes:
* **1 heap allocation** per transaction for the `BytesValueRLPOutput` context.
* **1 byte-array copy** per transaction to extract the encoded bytes.

For a batch of 256 transactions (the default network request limit), this leads to 256 unnecessary allocations and 256 array copies directly on the P2P message delivery path, intensifying Garbage Collection (GC) pressure.

#### Solution
We leverage `SimpleNoCopyRlpEncoder`, which is designed precisely to build zero-copy `Bytes` reference trees that defer actual byte-copying to Netty's wire layer. 

The encoding logic maps to transaction types as follows:
* **FRONTIER (Legacy) transactions:** `TransactionEncoder.encodeOpaqueBytes()` returns the complete RLP list item directly. This is added to the list without additional wrapping.
* **Typed (EIP-2718) transactions:** Opaque bytes (`type_byte || rlp(...)`) are wrapped as an RLP byte-string via `enc.encode()`, constructing a `Bytes.wrap()` tree.
* **Finalization:** `enc.encodeList(encodedTxs)` finalizes the outer list wrapper at the very end, resulting in exactly one allocation for the list header and a `Bytes.wrap()` over all items.

> **Note on Cut-off Semantics:** The message size constraint checking preserves identical cut-off behavior by using the exact same `RLP.MAX_PREFIX_SIZE`-based running estimate found in all other message-building paths within `EthServer`.

#### Fixed Issue(s)
fixes #10469

#### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

#### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


#### Changes

File | Change 

`ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthServer.java` Replace per-tx `BytesValueRLPOutput` with `SimpleNoCopyRlpEncoder` loop. 
`CHANGELOG.md` | Added entry under `## Unreleased → Additions and Improvements`. 

#### Testing

Executed the `EthServerTest` suite locally to ensure that size-bound breaking, count-bound breaking, and typed transaction serialization integrity remain completely unaltered.

```bash
./gradlew :ethereum:eth:test --tests "org.hyperledger.besu.ethereum.eth.manager.EthServerTest"