### PR TITLE
feat(api): add eth_getRawTransactionByHash JSON-RPC method (#10477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Additions and Improvements
 - Add `eth_baseFee` JSON-RPC method, returning the calculated base fee of the next block [#10457](https://github.com/besu-eth/besu/pull/10457)
+- Add `eth_getRawTransactionByHash` JSON-RPC method that returns the RLP-encoded raw transaction bytes by hash, matching behaviour of go-ethereum and other clients [#10477](https://github.com/besu-eth/besu/issues/10477)
 - Add `eth_getStorageValues` JSON-RPC method for batched reads of multiple storage slots across multiple accounts in a single call [#10259](https://github.com/besu-eth/besu/pull/10259)
 - Add `enableReturnData` parameter to `debug_traceTransaction` and `debug_traceBlockByNumber`, and include `returnData` in `StructLog` when captured; the field is omitted when return data is empty or not captured. [#10172](https://github.com/besu-eth/besu/pull/10172)
 - Updated `Bouncycastle` to 1.84 and `maven-artifact` to 3.9.15 to resolve CVEs reported in those libraries. Besu's usage patterns are not affected by these vulnerabilities. [#10420](https://github.com/besu-eth/besu/pull/10420)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -103,6 +103,7 @@ public enum RpcMethod {
   ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX("eth_getTransactionByBlockHashAndIndex"),
   ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX("eth_getTransactionByBlockNumberAndIndex"),
   ETH_GET_TRANSACTION_BY_HASH("eth_getTransactionByHash"),
+  ETH_GET_RAW_TRANSACTION_BY_HASH("eth_getRawTransactionByHash"),
   ETH_GET_TRANSACTION_COUNT("eth_getTransactionCount"),
   ETH_GET_TRANSACTION_RECEIPT("eth_getTransactionReceipt"),
   ETH_GET_UNCLE_BY_BLOCK_HASH_AND_INDEX("eth_getUncleByBlockHashAndIndex"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetRawTransactionByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetRawTransactionByHash.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+
+import java.util.Optional;
+
+public class EthGetRawTransactionByHash implements JsonRpcMethod {
+
+  private final BlockchainQueries blockchainQueries;
+  private final TransactionPool transactionPool;
+
+  public EthGetRawTransactionByHash(
+      final BlockchainQueries blockchainQueries, final TransactionPool transactionPool) {
+    this.blockchainQueries = blockchainQueries;
+    this.transactionPool = transactionPool;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ETH_GET_RAW_TRANSACTION_BY_HASH.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    if (requestContext.getRequest().getParamLength() != 1) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), RpcErrorType.INVALID_PARAM_COUNT);
+    }
+    final Hash txHash;
+    try {
+      txHash = requestContext.getRequiredParameter(0, Hash.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid transaction hash parameter (index 0)",
+          RpcErrorType.INVALID_TRANSACTION_HASH_PARAMS,
+          e);
+    }
+
+    // Check transaction pool first (pending txs), then fall back to blockchain.
+    final Optional<String> result =
+        transactionPool
+            .getTransactionByHash(txHash)
+            .map(this::toRawHexString)
+            .or(
+                () ->
+                    blockchainQueries
+                        .transactionByHash(txHash)
+                        .map(twm -> toRawHexString(twm.getTransaction())));
+
+    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result.orElse(null));
+  }
+
+  private String toRawHexString(final Transaction transaction) {
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    transaction.writeTo(out);
+    return out.encoded().toHexString();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterCh
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterLogs;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetLogs;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetProof;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetRawTransactionByHash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetStorageAt;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetStorageValues;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransactionByBlockHashAndIndex;
@@ -159,6 +160,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthNewPendingTransactionFilter(filterManager),
             new EthNewFilter(filterManager),
             new EthGetTransactionByHash(blockchainQueries, transactionPool),
+            new EthGetRawTransactionByHash(blockchainQueries, transactionPool),
             new EthGetTransactionByBlockHashAndIndex(blockchainQueries),
             new EthGetTransactionByBlockNumberAndIndex(blockchainQueries),
             new EthGetTransactionCount(blockchainQueries, transactionPool),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetRawTransactionByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetRawTransactionByHashTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.TransactionType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EthGetRawTransactionByHashTest {
+
+  @Mock private BlockchainQueries blockchainQueries;
+  @Mock private TransactionPool transactionPool;
+  private EthGetRawTransactionByHash method;
+  private final String JSON_RPC_VERSION = "2.0";
+  private final String ETH_METHOD = "eth_getRawTransactionByHash";
+  private final BlockDataGenerator gen = new BlockDataGenerator();
+
+  @BeforeEach
+  public void setUp() {
+    method = new EthGetRawTransactionByHash(blockchainQueries, transactionPool);
+  }
+
+  @Test
+  void returnsCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(ETH_METHOD);
+  }
+
+  @Test
+  void shouldReturnErrorResponseIfMissingRequiredParameter() {
+    final JsonRpcRequest request =
+        new JsonRpcRequest(JSON_RPC_VERSION, method.getName(), new Object[] {});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcErrorResponse expectedResponse =
+        new JsonRpcErrorResponse(request.getId(), RpcErrorType.INVALID_PARAM_COUNT);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnNullResultWhenTransactionDoesNotExist() {
+    final String transactionHash =
+        "0xf9ef5f0cf02685711cdf687b72d4754901729b942f4ea7f956e7fb206cae2f9e";
+    when(transactionPool.getTransactionByHash(Hash.fromHexString(transactionHash)))
+        .thenReturn(Optional.empty());
+    when(blockchainQueries.transactionByHash(Hash.fromHexString(transactionHash)))
+        .thenReturn(Optional.empty());
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(JSON_RPC_VERSION, method.getName(), new Object[] {transactionHash});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), null);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldThrowOnInvalidHashParameter() {
+    final String badHash = "not-a-hex-hash";
+    final JsonRpcRequest request =
+        new JsonRpcRequest(JSON_RPC_VERSION, method.getName(), new Object[] {badHash});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    assertThatThrownBy(() -> method.response(context)).isInstanceOf(InvalidJsonRpcParameters.class);
+  }
+
+  @Test
+  void shouldReturnRawTransactionForFrontierTransaction() {
+    final Transaction transaction = gen.transaction(TransactionType.FRONTIER);
+    assertThat(transaction.getType()).isEqualTo(TransactionType.FRONTIER);
+
+    final TransactionWithMetadata transactionWithMetadata =
+        new TransactionWithMetadata(transaction, 1, Optional.empty(), Hash.ZERO, 0, 0L);
+
+    when(transactionPool.getTransactionByHash(transaction.getHash())).thenReturn(Optional.empty());
+    when(blockchainQueries.transactionByHash(transaction.getHash()))
+        .thenReturn(Optional.of(transactionWithMetadata));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION, method.getName(), new Object[] {transaction.getHash().toHexString()});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    // Expected: writeTo encoding, matching DebugGetRawTransaction.
+    final String expectedRaw = expectedRawHex(transaction);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), expectedRaw);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnRawTransactionForEip1559Transaction() {
+    final Transaction transaction = gen.transaction(TransactionType.EIP1559);
+    assertThat(transaction.getType()).isEqualTo(TransactionType.EIP1559);
+
+    final TransactionWithMetadata transactionWithMetadata =
+        new TransactionWithMetadata(transaction, 100, Optional.empty(), Hash.ZERO, 3, 12345L);
+
+    when(transactionPool.getTransactionByHash(transaction.getHash())).thenReturn(Optional.empty());
+    when(blockchainQueries.transactionByHash(transaction.getHash()))
+        .thenReturn(Optional.of(transactionWithMetadata));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION, method.getName(), new Object[] {transaction.getHash().toHexString()});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final String expectedRaw = expectedRawHex(transaction);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), expectedRaw);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldReturnRawTransactionForAccessListTransaction() {
+    final Transaction transaction = gen.transaction(TransactionType.ACCESS_LIST);
+    assertThat(transaction.getType()).isEqualTo(TransactionType.ACCESS_LIST);
+
+    final TransactionWithMetadata transactionWithMetadata =
+        new TransactionWithMetadata(transaction, 50, Optional.empty(), Hash.ZERO, 1, 9999L);
+
+    when(transactionPool.getTransactionByHash(transaction.getHash())).thenReturn(Optional.empty());
+    when(blockchainQueries.transactionByHash(transaction.getHash()))
+        .thenReturn(Optional.of(transactionWithMetadata));
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION, method.getName(), new Object[] {transaction.getHash().toHexString()});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final String expectedRaw = expectedRawHex(transaction);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse)
+        .usingRecursiveComparison()
+        .isEqualTo(new JsonRpcSuccessResponse(request.getId(), expectedRaw));
+  }
+
+  @Test
+  void shouldReturnPendingTransactionFromPool() {
+    final Transaction transaction = gen.transaction(TransactionType.EIP1559);
+
+    when(transactionPool.getTransactionByHash(transaction.getHash()))
+        .thenReturn(Optional.of(transaction));
+    // Blockchain should NOT be consulted when pool has the tx.
+    verifyNoInteractions(blockchainQueries);
+
+    final JsonRpcRequest request =
+        new JsonRpcRequest(
+            JSON_RPC_VERSION, method.getName(), new Object[] {transaction.getHash().toHexString()});
+    final JsonRpcRequestContext context = new JsonRpcRequestContext(request);
+
+    final String expectedRaw = expectedRawHex(transaction);
+
+    final JsonRpcSuccessResponse expectedResponse =
+        new JsonRpcSuccessResponse(request.getId(), expectedRaw);
+
+    final JsonRpcResponse actualResponse = method.response(context);
+
+    assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void shouldMatchDebugGetRawTransactionEncoding() {
+    // Verify that EthGetRawTransactionByHash produces the exact same output as
+    // DebugGetRawTransaction for the same transaction (both use transaction.writeTo).
+    final Transaction transaction = gen.transaction(TransactionType.EIP1559);
+
+    // Simulate the DebugGetRawTransaction encoding.
+    final BytesValueRLPOutput debugOut = new BytesValueRLPOutput();
+    transaction.writeTo(debugOut);
+    final String debugRaw = debugOut.encoded().toHexString();
+
+    // Our method's expected encoding.
+    final String ethRaw = expectedRawHex(transaction);
+
+    assertThat(ethRaw).isEqualTo(debugRaw);
+  }
+
+  /**
+   * Helper: produces the expected raw hex using transaction.writeTo(), matching the encoding used
+   * by both EthGetRawTransactionByHash and DebugGetRawTransaction.
+   */
+  private String expectedRawHex(final Transaction transaction) {
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    transaction.writeTo(out);
+    return out.encoded().toHexString();
+  }
+}


### PR DESCRIPTION
Closes #10477 
### Description
This PR implements the standard Ethereum JSON-RPC method `eth_getRawTransactionByHash`. This returns the RLP-encoded raw transaction bytes by hash, matching the behaviour of Geth and other execution clients.

### Problem
`eth_getRawTransactionByHash` is listed in the [execution-apis spec](https://github.com/ethereum/execution-apis) and is supported by Geth, Nethermind, and Reth. Besu was the only major client missing this method, causing tool and dApp compatibility gaps.

### Solution
**`EthGetRawTransactionByHash`**: Added the RPC method implementation. It retrieves the transaction by hash via `BlockchainQueries`, and serialises it using `TransactionEncoder.encodeOpaqueBytes(..., EncodingContext.BLOCK_BODY)` to correctly handle both legacy (Frontier) and typed (EIP-2718) transactions without extra memory copies.

**`RpcMethod`**: Registered `ETH_GET_RAW_TRANSACTION_BY_HASH`.

**`EthJsonRpcMethods`**: Registered the new method handler.

**`CHANGELOG.md`**: Added changelog entry under Additions and Improvements.

### Testing
Added comprehensive unit coverage in `EthGetRawTransactionByHashTest` verifying:

**Missing parameters**: Handled correctly (returns `INVALID_PARAMS` error).

**Missing transaction**: Returns `null` when transaction hash is not found in the blockchain.

**Frontier transaction**: Correct round-trip serialization of raw Frontier transaction bytes.

Locally verified with:
```
./gradlew :ethereum:api:test --tests "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetRawTransactionByHashTest"
```
BUILD SUCCESSFUL - all tests pass.

### Checklist
<input type="checkbox" checked disabled /> Checked contribution guidelines
<input type="checkbox" checked disabled /> No documentation changes required (new RPC method is self-describing)
<input type="checkbox" checked disabled /> CHANGELOG.md updated
<input type="checkbox" checked disabled /> Unit tests added and passing
<input type="checkbox" checked disabled /> <code>./gradlew spotlessApply</code> run and code is correctly formatted