### PR TITLE
sync: fix for p2p is disabled

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -138,7 +138,8 @@ public class PostMergeContext implements MergeContext {
     // Post-TTD or TTD status unknown (e.g. synchronizer not started when --p2p-enabled=false):
     // delegate to isInSync(). For full sync (isInitialSyncPhaseDone=true) with no peers this
     // returns true, so isSyncing() correctly returns false. For snap sync (isInitialSyncPhaseDone
-    // starts false) it returns false until the initial phase completes, so isSyncing() returns true.
+    // starts false) it returns false until the initial phase completes, so isSyncing() returns
+    // true.
     return !state.isInSync();
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -136,9 +136,9 @@ public class PostMergeContext implements MergeContext {
       return true;
     }
     // Post-TTD or TTD status unknown (e.g. synchronizer not started when --p2p-enabled=false):
-    // rely on peer sync state. No peers means trivially in sync (isSyncing returns false).
-    // This correctly handles full sync on post-merge networks where reachedTerminalDifficulty is
-    // true, and previously caused this method to always return false while actively downloading.
+    // delegate to isInSync(). For full sync (isInitialSyncPhaseDone=true) with no peers this
+    // returns true, so isSyncing() correctly returns false. For snap sync (isInitialSyncPhaseDone
+    // starts false) it returns false until the initial phase completes, so isSyncing() returns true.
     return !state.isInSync();
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -130,13 +130,15 @@ public class PostMergeContext implements MergeContext {
     if (state == null) {
       return true;
     }
-    // Pre-TTD: if terminal difficulty hasn't been reached we're still in PoW sync.
-    if (!state.hasReachedTerminalDifficulty().orElse(false)) {
+    final Optional<Boolean> ttdReached = state.hasReachedTerminalDifficulty();
+    // Pre-TTD: terminal difficulty is definitively known to not be reached.
+    if (ttdReached.isPresent() && !ttdReached.get()) {
       return true;
     }
-    // Post-TTD (post-merge): rely solely on peer sync state. This correctly handles full sync on
-    // post-merge networks where reachedTerminalDifficulty is always true, which previously caused
-    // this method to always return false even while the node was actively downloading the chain.
+    // Post-TTD or TTD status unknown (e.g. synchronizer not started when --p2p-enabled=false):
+    // rely on peer sync state. No peers means trivially in sync (isSyncing returns false).
+    // This correctly handles full sync on post-merge networks where reachedTerminalDifficulty is
+    // true, and previously caused this method to always return false while actively downloading.
     return !state.isInSync();
   }
 

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
@@ -334,6 +334,17 @@ public class PostMergeContextTest {
   }
 
   @Test
+  public void isSyncingReturnsFalseWhenP2pDisabledAndFullSyncOnPostMergeNetwork() {
+    // Regression test: when --p2p-enabled=false, the synchronizer is not started so
+    // hasReachedTerminalDifficulty() returns Optional.empty(). With no peers, isInSync() returns
+    // true, so isSyncing() should return false (not syncing).
+    when(mockSyncState.hasReachedTerminalDifficulty()).thenReturn(Optional.empty());
+    when(mockSyncState.isInSync()).thenReturn(Boolean.TRUE);
+
+    assertThat(postMergeContext.isSyncing()).isFalse();
+  }
+
+  @Test
   public void isSyncingReturnsTrueWhenFullSyncingOnPostMergeNetwork() {
     // Regression test for https://github.com/besu-eth/besu/issues/10589
     // On post-merge networks (e.g. Hoodi), reachedTerminalDifficulty is always true.


### PR DESCRIPTION
## PR description
If p2p-enabled=false, only short-circuit to true when TTD is definitively known to be unreached. When TTD status is unknown, delegate to isInSync() - which for a node with no peers returns true, so isSyncing() correctly returns false.

Follow up to #10613 which had an unintended consequence on certain devnet setups, in this case benchmarkoor 

Ref https://github.com/ethpandaops/benchmarkoor/pull/249


Note: with p2p-enabled=false, syncing cannot proceed (no peers are possible). So the synchronizer remains suppressed when p2p is disabled. 

