### PR TITLE
fix(ci): switch reference-tests from OpenJ9 to HotSpot (temurin)

### DIFF
--- a/.github/workflows/reference-tests.yml
+++ b/.github/workflows/reference-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: semeru # IBM Semeru with OpenJ9
+          distribution: temurin
           java-version: 25
       - name: setup gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1


### PR DESCRIPTION
## Summary

- Switches `reference-tests.yml` from `distribution: semeru` (IBM Semeru / OpenJ9) to `distribution: temurin` (HotSpot)
- Removes the OpenJ9-specific comment

## Context

The `reference-tests` workflow was intermittently crashing with a JIT assertion failure in OpenJ9's Testarossa inliner (`Inliner.cpp:4615`) when JIT-compiling `com.sun.source.util.TreeScanner.visitNewArray` on JDK 25. This is an upstream OpenJ9 bug (not a Besu issue).

Switching to temurin is consistent with all other Besu CI workflows. Memory config (`-Xmx6g`, 4 parallel runners on `besu-research-ubuntu-8`) is unchanged.

Closes #10657

## Test plan

- [x] Verify reference-tests CI passes on this PR without the JIT crash

🤖 Generated with [Claude Code](https://claude.ai/code)