### PR TITLE
Add the ability to treat unfunded transactions as invalid

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -81,9 +81,9 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
       names = {TX_POOL_NO_LATE_FUNDING},
       paramLabel = "<Boolean>",
       description =
-          "Set to true to drop transactions from the pool when the sender has insufficient balance "
-              + "at block-selection time, rather than penalising the score and retaining them in "
-              + "the hope that the sender receives funds later (default: ${DEFAULT-VALUE})",
+          "Set to true to penalise (and eventually evict) transactions whose sender has "
+              + "insufficient balance at block-selection time, rather than dropping them immediately "
+              + "(default: ${DEFAULT-VALUE})",
       fallbackValue = "true",
       arity = "0..1")
   private Boolean noLateFunding = TransactionPoolConfiguration.DEFAULT_TX_POOL_NO_LATE_FUNDING;

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -82,9 +82,10 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
       names = {TX_POOL_NO_LATE_FUNDING},
       paramLabel = "<Boolean>",
       description =
-          "Set to true to penalise (and eventually evict) transactions whose sender has "
-              + "insufficient balance at block-selection time, rather than dropping them immediately "
-              + "(default: ${DEFAULT-VALUE})",
+          "When enabled, transactions whose sender has insufficient balance at block-selection time "
+              + "are immediately removed from the pool and tracked to prevent re-admission from peers. "
+              + "When disabled (default), such transactions are retained in the pool and retried in "
+              + "a later block (default: ${DEFAULT-VALUE})",
       fallbackValue = "true",
       arity = "0..1")
   private Boolean noLateFunding = TransactionPoolConfiguration.DEFAULT_TX_POOL_NO_LATE_FUNDING;

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -49,6 +49,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
   private static final String TX_POOL_IMPLEMENTATION = "--tx-pool";
   private static final String TX_POOL_NO_LOCAL_PRIORITY = "--tx-pool-no-local-priority";
   private static final String TX_POOL_NO_LATE_FUNDING = "--tx-pool-no-late-funding";
+  private static final String TX_POOL_FORGET_INVALID_TXN_MINS = "--tx-pool-forget-invalid-txn-mins";
   private static final String TX_POOL_ENABLE_SAVE_RESTORE = "--tx-pool-enable-save-restore";
   private static final String TX_POOL_SAVE_FILE = "--tx-pool-save-file";
   private static final String TX_POOL_PRICE_BUMP = "--tx-pool-price-bump";
@@ -87,6 +88,16 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
       fallbackValue = "true",
       arity = "0..1")
   private Boolean noLateFunding = TransactionPoolConfiguration.DEFAULT_TX_POOL_NO_LATE_FUNDING;
+
+  @CommandLine.Option(
+      names = {TX_POOL_FORGET_INVALID_TXN_MINS},
+      paramLabel = "<INTEGER>",
+      description =
+          "Number of minutes after which a seen-but-invalid transaction is forgotten and can be "
+              + "re-accepted from peers. 0 disables time-based expiry (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private int forgetInvalidTxnMins =
+      TransactionPoolConfiguration.DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS;
 
   @CommandLine.Option(
       names = {TX_POOL_ENABLE_SAVE_RESTORE},
@@ -364,6 +375,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
     options.saveRestoreEnabled = config.getEnableSaveRestore();
     options.noLocalPriority = config.getNoLocalPriority();
     options.noLateFunding = config.getNoLateFunding();
+    options.forgetInvalidTxnMins = config.getForgetInvalidTxnMins();
     options.priceBump = config.getPriceBump();
     options.blobPriceBump = config.getBlobPriceBump();
     options.txFeeCap = config.getTxFeeCap();
@@ -432,6 +444,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         .enableSaveRestore(saveRestoreEnabled)
         .noLocalPriority(noLocalPriority)
         .noLateFunding(noLateFunding)
+        .forgetInvalidTxnMins(forgetInvalidTxnMins)
         .priceBump(priceBump)
         .blobPriceBump(blobPriceBump)
         .txFeeCap(txFeeCap)

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -93,8 +93,11 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
       names = {TX_POOL_FORGET_INVALID_TXN_MINS},
       paramLabel = "<INTEGER>",
       description =
-          "Number of minutes after which a seen-but-invalid transaction is forgotten and can be "
-              + "re-accepted from peers. 0 disables time-based expiry (default: ${DEFAULT-VALUE})",
+          "Controls how long a seen-but-invalid transaction is remembered before being forgotten "
+              + "and potentially re-accepted from peers. "
+              + "-1 disables forgetting (LRU eviction only), "
+              + "0 forgets immediately on drop, "
+              + "N > 0 forgets after N minutes (default: ${DEFAULT-VALUE})",
       arity = "1")
   private int forgetInvalidTxnMins =
       TransactionPoolConfiguration.DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS;

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -99,7 +99,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
               + "0 forgets immediately on drop, "
               + "N > 0 forgets after N minutes (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private int forgetInvalidTxnMins =
+  private Integer forgetInvalidTxnMins =
       TransactionPoolConfiguration.DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS;
 
   @CommandLine.Option(

--- a/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -48,6 +48,7 @@ import picocli.CommandLine;
 public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfiguration> {
   private static final String TX_POOL_IMPLEMENTATION = "--tx-pool";
   private static final String TX_POOL_NO_LOCAL_PRIORITY = "--tx-pool-no-local-priority";
+  private static final String TX_POOL_NO_LATE_FUNDING = "--tx-pool-no-late-funding";
   private static final String TX_POOL_ENABLE_SAVE_RESTORE = "--tx-pool-enable-save-restore";
   private static final String TX_POOL_SAVE_FILE = "--tx-pool-save-file";
   private static final String TX_POOL_PRICE_BUMP = "--tx-pool-price-bump";
@@ -75,6 +76,17 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
       fallbackValue = "true",
       arity = "0..1")
   private Boolean noLocalPriority = TransactionPoolConfiguration.DEFAULT_NO_LOCAL_PRIORITY;
+
+  @CommandLine.Option(
+      names = {TX_POOL_NO_LATE_FUNDING},
+      paramLabel = "<Boolean>",
+      description =
+          "Set to true to drop transactions from the pool when the sender has insufficient balance "
+              + "at block-selection time, rather than penalising the score and retaining them in "
+              + "the hope that the sender receives funds later (default: ${DEFAULT-VALUE})",
+      fallbackValue = "true",
+      arity = "0..1")
+  private Boolean noLateFunding = TransactionPoolConfiguration.DEFAULT_TX_POOL_NO_LATE_FUNDING;
 
   @CommandLine.Option(
       names = {TX_POOL_ENABLE_SAVE_RESTORE},
@@ -351,6 +363,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
     options.txPoolImplementation = config.getTxPoolImplementation();
     options.saveRestoreEnabled = config.getEnableSaveRestore();
     options.noLocalPriority = config.getNoLocalPriority();
+    options.noLateFunding = config.getNoLateFunding();
     options.priceBump = config.getPriceBump();
     options.blobPriceBump = config.getBlobPriceBump();
     options.txFeeCap = config.getTxFeeCap();
@@ -418,6 +431,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         .txPoolImplementation(txPoolImplementation)
         .enableSaveRestore(saveRestoreEnabled)
         .noLocalPriority(noLocalPriority)
+        .noLateFunding(noLateFunding)
         .priceBump(priceBump)
         .blobPriceBump(blobPriceBump)
         .txFeeCap(txFeeCap)

--- a/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -109,6 +109,25 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
+  public void noLateFundingDefaultIsFalse() {
+    internalTestSuccess(config -> assertThat(config.getNoLateFunding()).isFalse());
+  }
+
+  @Test
+  public void noLateFundingCanBeEnabled() {
+    internalTestSuccess(
+        config -> assertThat(config.getNoLateFunding()).isTrue(),
+        "--tx-pool-no-late-funding=true");
+  }
+
+  @Test
+  public void noLateFundingCanBeDisabledExplicitly() {
+    internalTestSuccess(
+        config -> assertThat(config.getNoLateFunding()).isFalse(),
+        "--tx-pool-no-late-funding=false");
+  }
+
+  @Test
   public void saveToFileDisabledByDefault() {
     internalTestSuccess(config -> assertThat(config.getEnableSaveRestore()).isFalse());
   }

--- a/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -128,6 +128,18 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
+  public void forgetInvalidTxnMinsDefaultIsZero() {
+    internalTestSuccess(config -> assertThat(config.getForgetInvalidTxnMins()).isZero());
+  }
+
+  @Test
+  public void forgetInvalidTxnMinsCanBeSet() {
+    internalTestSuccess(
+        config -> assertThat(config.getForgetInvalidTxnMins()).isEqualTo(60),
+        "--tx-pool-forget-invalid-txn-mins=60");
+  }
+
+  @Test
   public void saveToFileDisabledByDefault() {
     internalTestSuccess(config -> assertThat(config.getEnableSaveRestore()).isFalse());
   }

--- a/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -128,12 +128,19 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
-  public void forgetInvalidTxnMinsDefaultIsZero() {
-    internalTestSuccess(config -> assertThat(config.getForgetInvalidTxnMins()).isZero());
+  public void forgetInvalidTxnMinsDefaultIsDisabled() {
+    internalTestSuccess(config -> assertThat(config.getForgetInvalidTxnMins()).isEqualTo(-1));
   }
 
   @Test
-  public void forgetInvalidTxnMinsCanBeSet() {
+  public void forgetInvalidTxnMinsZeroForgetImmediately() {
+    internalTestSuccess(
+        config -> assertThat(config.getForgetInvalidTxnMins()).isZero(),
+        "--tx-pool-forget-invalid-txn-mins=0");
+  }
+
+  @Test
+  public void forgetInvalidTxnMinsCanBeSetToMinutes() {
     internalTestSuccess(
         config -> assertThat(config.getForgetInvalidTxnMins()).isEqualTo(60),
         "--tx-pool-forget-invalid-txn-mins=60");

--- a/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -116,8 +116,7 @@ public class TransactionPoolOptionsTest
   @Test
   public void noLateFundingCanBeEnabled() {
     internalTestSuccess(
-        config -> assertThat(config.getNoLateFunding()).isTrue(),
-        "--tx-pool-no-late-funding=true");
+        config -> assertThat(config.getNoLateFunding()).isTrue(), "--tx-pool-no-late-funding=true");
   }
 
   @Test

--- a/app/src/test/resources/everything_config.toml
+++ b/app/src/test/resources/everything_config.toml
@@ -196,6 +196,8 @@ tx-pool-max-prioritized=9876
 tx-pool-max-prioritized-by-type=["BLOB=10","FRONTIER=100"]
 tx-pool-max-future-by-sender=321
 tx-pool-enable-balance-check=false
+tx-pool-no-late-funding=false
+tx-pool-forget-invalid-txn-mins=-1
 ## Legacy/Sequenced
 tx-pool-retention-hours=999
 tx-pool-max-size=1234

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -101,14 +101,22 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
   }
 
   /**
-   * Checks if the invalid reason is a transient validation error.
+   * Checks if the invalid reason is a transient validation error. When transient, the transaction
+   * is penalised (score reduced) but retained in the pool so it can be retried in a later block.
+   * When not transient, the transaction is dropped from the pool permanently.
+   *
+   * <p>UPFRONT_COST_EXCEEDS_BALANCE is only treated as transient when {@code noLateFunding} is
+   * false (the default). When {@code noLateFunding} is true the sender's insufficient balance is
+   * treated as a permanent failure and the transaction is removed from the pool immediately.
    *
    * @param invalidReason The invalid reason.
    * @return True if the invalid reason is transient, false otherwise.
    */
   private boolean isTransientValidationError(final TransactionInvalidReason invalidReason) {
-    return invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)
-        || invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
+    if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
+      return !context.transactionPool().getConfiguration().getNoLateFunding();
+    }
+    return invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
         || invalidReason.equals(TransactionInvalidReason.NONCE_TOO_HIGH)
         || invalidReason.equals(TransactionInvalidReason.EXECUTION_INTERRUPTED);
   }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -105,16 +105,17 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
    * is penalised (score reduced) but retained in the pool so it can be retried in a later block.
    * When not transient, the transaction is dropped from the pool permanently.
    *
-   * <p>UPFRONT_COST_EXCEEDS_BALANCE is only treated as transient when {@code noLateFunding} is
-   * false (the default). When {@code noLateFunding} is true the sender's insufficient balance is
-   * treated as a permanent failure and the transaction is removed from the pool immediately.
+   * <p>By default, UPFRONT_COST_EXCEEDS_BALANCE is a permanent failure and the transaction is
+   * removed from the pool immediately. When {@code noLateFunding} is true, it is instead treated
+   * as transient: the score is penalised each block until the sender's balance improves or the
+   * score falls below the minimum and the transaction is evicted.
    *
    * @param invalidReason The invalid reason.
    * @return True if the invalid reason is transient, false otherwise.
    */
   private boolean isTransientValidationError(final TransactionInvalidReason invalidReason) {
     if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
-      return !context.transactionPool().getConfiguration().getNoLateFunding();
+      return context.transactionPool().getConfiguration().getNoLateFunding();
     }
     return invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
         || invalidReason.equals(TransactionInvalidReason.NONCE_TOO_HIGH)

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -92,11 +92,20 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
       return TransactionSelectionResult.invalidPenalized(invalidReason.name());
     }
     // If the transaction was invalid for any other reason, delete it, and continue.
-    LOG.atTrace()
-        .setMessage("Delete invalid transaction {}, reason {}")
-        .addArgument(transaction::toTraceLog)
-        .addArgument(invalidReason)
-        .log();
+    if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
+      LOG.atInfo()
+          .setMessage(
+              "Transaction {} removed from pool: sender had insufficient balance at block-selection"
+                  + " time (tx-pool-no-late-funding=true)")
+          .addArgument(transaction::getHash)
+          .log();
+    } else {
+      LOG.atTrace()
+          .setMessage("Removing invalid transaction {}, reason {}")
+          .addArgument(transaction::toTraceLog)
+          .addArgument(invalidReason)
+          .log();
+    }
     return TransactionSelectionResult.invalid(invalidReason.name());
   }
 

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -92,7 +92,8 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
       return TransactionSelectionResult.invalidPenalized(invalidReason.name());
     }
     // If the transaction was invalid for any other reason, delete it, and continue.
-    if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
+    if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)
+        && context.transactionPool().getConfiguration().getNoLateFunding()) {
       LOG.atInfo()
           .setMessage(
               "Transaction {} removed from pool: sender had insufficient balance at block-selection"
@@ -110,27 +111,15 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
   }
 
   /**
-   * Checks if the invalid reason is a transient validation error. When transient, the transaction
-   * is penalised (score reduced) but retained in the pool so it can be retried in a later block.
-   * When not transient, the transaction is dropped from the pool permanently.
-   *
-   * <p>UPFRONT_COST_EXCEEDS_BALANCE behaviour depends on {@code noLateFunding}:
-   *
-   * <ul>
-   *   <li><b>noLateFunding=false</b> (default): treated as transient — the layered pool
-   *       score-penalises the transaction and retains it; the sequenced pool ignores the penalise
-   *       result and leaves the transaction in the pool. Both pools restore the original behaviour.
-   *   <li><b>noLateFunding=true</b>: treated as non-transient — the transaction is dropped
-   *       immediately and tracked in the seen-transaction list so it cannot be re-admitted from
-   *       peers.
-   * </ul>
+   * Checks if the invalid reason is a transient validation error. Some errors have configurable
+   * behaviour to allow for customization of the pool behaviour.
    *
    * @param invalidReason The invalid reason.
    * @return True if the invalid reason is transient, false otherwise.
    */
   private boolean isTransientValidationError(final TransactionInvalidReason invalidReason) {
     if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
-      return !context.transactionPool().getConfiguration().getNoLateFunding();
+      return context.transactionPool().getConfiguration().getNoLateFunding() ? false : true;
     }
     return invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
         || invalidReason.equals(TransactionInvalidReason.NONCE_TOO_HIGH)

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration.Implementation;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
@@ -106,16 +105,15 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
    * is penalised (score reduced) but retained in the pool so it can be retried in a later block.
    * When not transient, the transaction is dropped from the pool permanently.
    *
-   * <p>UPFRONT_COST_EXCEEDS_BALANCE is handled differently per pool type and {@code noLateFunding}:
+   * <p>UPFRONT_COST_EXCEEDS_BALANCE behaviour depends on {@code noLateFunding}:
    *
    * <ul>
-   *   <li><b>Layered, noLateFunding=false</b>: non-transient — dropped immediately.
-   *   <li><b>Layered, noLateFunding=true</b>: transient — score-penalised each block; evicted when
-   *       score falls below the minimum.
-   *   <li><b>Sequenced, noLateFunding=false</b>: transient — the sequenced pool ignores penalise
-   *       results, so the transaction stays in the pool indefinitely (original behaviour).
-   *   <li><b>Sequenced, noLateFunding=true</b>: non-transient — dropped and added to the tracked
-   *       seen-transaction list so it cannot be immediately re-admitted from peers.
+   *   <li><b>noLateFunding=false</b> (default): treated as transient — the layered pool
+   *       score-penalises the transaction and retains it; the sequenced pool ignores the penalise
+   *       result and leaves the transaction in the pool. Both pools restore the original behaviour.
+   *   <li><b>noLateFunding=true</b>: treated as non-transient — the transaction is dropped
+   *       immediately and tracked in the seen-transaction list so it cannot be re-admitted from
+   *       peers.
    * </ul>
    *
    * @param invalidReason The invalid reason.
@@ -123,12 +121,7 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
    */
   private boolean isTransientValidationError(final TransactionInvalidReason invalidReason) {
     if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
-      final var config = context.transactionPool().getConfiguration();
-      final boolean isLayered = config.getTxPoolImplementation() == Implementation.LAYERED;
-      final boolean noLateFunding = config.getNoLateFunding();
-      // Layered:    transient iff noLateFunding=true  (penalise rather than drop immediately)
-      // Sequenced:  transient iff noLateFunding=false (leave in pool; drop+track when true)
-      return isLayered ? noLateFunding : !noLateFunding;
+      return !context.transactionPool().getConfiguration().getNoLateFunding();
     }
     return invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
         || invalidReason.equals(TransactionInvalidReason.NONCE_TOO_HIGH)

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration.Implementation;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
@@ -105,17 +106,29 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
    * is penalised (score reduced) but retained in the pool so it can be retried in a later block.
    * When not transient, the transaction is dropped from the pool permanently.
    *
-   * <p>By default, UPFRONT_COST_EXCEEDS_BALANCE is a permanent failure and the transaction is
-   * removed from the pool immediately. When {@code noLateFunding} is true, it is instead treated
-   * as transient: the score is penalised each block until the sender's balance improves or the
-   * score falls below the minimum and the transaction is evicted.
+   * <p>UPFRONT_COST_EXCEEDS_BALANCE is handled differently per pool type and {@code noLateFunding}:
+   *
+   * <ul>
+   *   <li><b>Layered, noLateFunding=false</b>: non-transient — dropped immediately.
+   *   <li><b>Layered, noLateFunding=true</b>: transient — score-penalised each block; evicted when
+   *       score falls below the minimum.
+   *   <li><b>Sequenced, noLateFunding=false</b>: transient — the sequenced pool ignores penalise
+   *       results, so the transaction stays in the pool indefinitely (original behaviour).
+   *   <li><b>Sequenced, noLateFunding=true</b>: non-transient — dropped and added to the tracked
+   *       seen-transaction list so it cannot be immediately re-admitted from peers.
+   * </ul>
    *
    * @param invalidReason The invalid reason.
    * @return True if the invalid reason is transient, false otherwise.
    */
   private boolean isTransientValidationError(final TransactionInvalidReason invalidReason) {
     if (invalidReason.equals(TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE)) {
-      return context.transactionPool().getConfiguration().getNoLateFunding();
+      final var config = context.transactionPool().getConfiguration();
+      final boolean isLayered = config.getTxPoolImplementation() == Implementation.LAYERED;
+      final boolean noLateFunding = config.getNoLateFunding();
+      // Layered:    transient iff noLateFunding=true  (penalise rather than drop immediately)
+      // Sequenced:  transient iff noLateFunding=false (leave in pool; drop+track when true)
+      return isLayered ? noLateFunding : !noLateFunding;
     }
     return invalidReason.equals(TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE)
         || invalidReason.equals(TransactionInvalidReason.NONCE_TOO_HIGH)

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -244,8 +244,6 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     assertThat(results.getNotSelectedTransactions()).isEmpty();
   }
 
-  // --- noLateFunding tests: sequenced pool (BaseFeePendingTransactionsSorter) ---
-
   @Test
   public void sequencedPool_upfrontCostExceedsBalance_noLateFundingFalse_txRemainsInPool() {
     transactionPool = createSequencedPoolWithNoLateFunding(false);
@@ -297,8 +295,6 @@ public class LondonFeeMarketBlockTransactionSelectorTest
         .containsOnly(
             entry(tx, TransactionSelectionResult.invalid(UPFRONT_COST_EXCEEDS_BALANCE.name())));
   }
-
-  // --- noLateFunding tests: layered pool (LayeredPendingTransactions) ---
 
   @Test
   public void layeredPool_upfrontCostExceedsBalance_noLateFundingFalse_txRemainsInPool() {

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -19,7 +19,10 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER1;
 import static org.hyperledger.besu.ethereum.blockcreation.AbstractBlockTransactionSelectorTest.Sender.SENDER2;
 import static org.hyperledger.besu.ethereum.core.MiningConfiguration.DEFAULT_POS_BLOCK_TXS_SELECTION_MAX_TIME;
+import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.datatypes.Address;
@@ -34,17 +37,26 @@ import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionBroadcaster;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolReplacementHandler;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.BaseFeePrioritizedTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.EndLayer;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredPendingTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.ReadyTransactions;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.SenderBalanceChecker;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.SparseTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.BalConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecAdapters;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
@@ -54,6 +66,7 @@ import org.hyperledger.besu.util.number.Fraction;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -229,6 +242,193 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     assertThat(results.getSelectedTransactions())
         .containsExactly(txFrontier1, txLondon1, txFrontier2, txLondon2);
     assertThat(results.getNotSelectedTransactions()).isEmpty();
+  }
+
+  // --- noLateFunding tests: sequenced pool (BaseFeePendingTransactionsSorter) ---
+
+  @Test
+  public void sequencedPool_upfrontCostExceedsBalance_noLateFundingFalse_txRemainsInPool() {
+    transactionPool = createSequencedPoolWithNoLateFunding(false);
+    final ProcessableBlockHeader blockHeader = createBlock(5_000_000);
+    final BlockTransactionSelector selector =
+        createBlockSelector(
+            defaultTestMiningConfiguration,
+            transactionProcessor,
+            blockHeader,
+            AddressHelpers.ofValue(1),
+            Wei.ZERO,
+            transactionSelectionService);
+
+    final Transaction tx = createTransaction(0, Wei.of(7L), 100_000);
+    transactionPool.addRemoteTransactions(List.of(tx));
+    ensureTransactionIsInvalid(tx, UPFRONT_COST_EXCEEDS_BALANCE);
+
+    final TransactionSelectionResults results = selector.buildTransactionListForBlock();
+
+    assertThat(transactionPool.getTransactionByHash(tx.getHash())).isPresent();
+    assertThat(results.getNotSelectedTransactions())
+        .containsOnly(
+            entry(tx, TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+  }
+
+  @Test
+  public void sequencedPool_upfrontCostExceedsBalance_noLateFundingTrue_txRemovedFromPool() {
+    transactionPool = createSequencedPoolWithNoLateFunding(true);
+    final ProcessableBlockHeader blockHeader = createBlock(5_000_000);
+    final BlockTransactionSelector selector =
+        createBlockSelector(
+            defaultTestMiningConfiguration,
+            transactionProcessor,
+            blockHeader,
+            AddressHelpers.ofValue(1),
+            Wei.ZERO,
+            transactionSelectionService);
+
+    final Transaction tx = createTransaction(0, Wei.of(7L), 100_000);
+    transactionPool.addRemoteTransactions(List.of(tx));
+    ensureTransactionIsInvalid(tx, UPFRONT_COST_EXCEEDS_BALANCE);
+
+    final TransactionSelectionResults results = selector.buildTransactionListForBlock();
+
+    assertThat(transactionPool.getTransactionByHash(tx.getHash())).isNotPresent();
+    assertThat(results.getNotSelectedTransactions())
+        .containsOnly(
+            entry(tx, TransactionSelectionResult.invalid(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+  }
+
+  // --- noLateFunding tests: layered pool (LayeredPendingTransactions) ---
+
+  @Test
+  public void layeredPool_upfrontCostExceedsBalance_noLateFundingFalse_txRemainsInPool() {
+    transactionPool = createLayeredPoolWithNoLateFunding(false);
+    final ProcessableBlockHeader blockHeader = createBlock(5_000_000);
+    final BlockTransactionSelector selector =
+        createBlockSelector(
+            defaultTestMiningConfiguration,
+            transactionProcessor,
+            blockHeader,
+            AddressHelpers.ofValue(1),
+            Wei.ZERO,
+            transactionSelectionService);
+
+    final Transaction tx = createTransaction(0, Wei.of(7L), 100_000);
+    transactionPool.addRemoteTransactions(List.of(tx));
+    ensureTransactionIsInvalid(tx, UPFRONT_COST_EXCEEDS_BALANCE);
+
+    final TransactionSelectionResults results = selector.buildTransactionListForBlock();
+
+    assertThat(transactionPool.getTransactionByHash(tx.getHash())).isPresent();
+    assertThat(results.getNotSelectedTransactions())
+        .containsOnly(
+            entry(tx, TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+  }
+
+  @Test
+  public void layeredPool_upfrontCostExceedsBalance_noLateFundingTrue_txRemovedFromPool() {
+    // The layered pool schedules removal via ethScheduler.scheduleServiceTask(); mock it to run
+    // the removal task inline so the assertion can observe the post-removal pool state.
+    when(ethScheduler.scheduleServiceTask(any(Runnable.class)))
+        .thenAnswer(
+            inv -> {
+              inv.getArgument(0, Runnable.class).run();
+              return null;
+            });
+
+    transactionPool = createLayeredPoolWithNoLateFunding(true);
+    final ProcessableBlockHeader blockHeader = createBlock(5_000_000);
+    final BlockTransactionSelector selector =
+        createBlockSelector(
+            defaultTestMiningConfiguration,
+            transactionProcessor,
+            blockHeader,
+            AddressHelpers.ofValue(1),
+            Wei.ZERO,
+            transactionSelectionService);
+
+    final Transaction tx = createTransaction(0, Wei.of(7L), 100_000);
+    transactionPool.addRemoteTransactions(List.of(tx));
+    ensureTransactionIsInvalid(tx, UPFRONT_COST_EXCEEDS_BALANCE);
+
+    final TransactionSelectionResults results = selector.buildTransactionListForBlock();
+
+    assertThat(transactionPool.getTransactionByHash(tx.getHash())).isNotPresent();
+    assertThat(results.getNotSelectedTransactions())
+        .containsOnly(
+            entry(tx, TransactionSelectionResult.invalid(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+  }
+
+  private TransactionPool createSequencedPoolWithNoLateFunding(final boolean noLateFunding) {
+    final TransactionPoolConfiguration poolConf =
+        ImmutableTransactionPoolConfiguration.builder()
+            .txPoolMaxSize(5)
+            .txPoolLimitByAccountPercentage(Fraction.fromFloat(1f))
+            .minGasPrice(Wei.ONE)
+            .noLateFunding(noLateFunding)
+            .build();
+    final PendingTransactions pending =
+        new BaseFeePendingTransactionsSorter(
+            poolConf,
+            TestClock.system(ZoneId.systemDefault()),
+            metricsSystem,
+            blockchain::getChainHeadHeader);
+    final TransactionPool pool =
+        new TransactionPool(
+            () -> pending,
+            protocolSchedule,
+            protocolContext,
+            mock(TransactionBroadcaster.class),
+            ethContext,
+            new TransactionPoolMetrics(metricsSystem),
+            poolConf,
+            new BlobCache());
+    pool.setEnabled();
+    return pool;
+  }
+
+  private TransactionPool createLayeredPoolWithNoLateFunding(final boolean noLateFunding) {
+    final TransactionPoolConfiguration poolConf =
+        ImmutableTransactionPoolConfiguration.builder()
+            .txPoolMaxSize(5)
+            .txPoolLimitByAccountPercentage(Fraction.fromFloat(1f))
+            .minGasPrice(Wei.ONE)
+            .noLateFunding(noLateFunding)
+            .build();
+    final TransactionPoolMetrics metrics = new TransactionPoolMetrics(metricsSystem);
+    final BiFunction<PendingTransaction, PendingTransaction, Boolean> replacementTester =
+        (t1, t2) ->
+            new TransactionPoolReplacementHandler(poolConf.getPriceBump(), poolConf.getBlobPriceBump())
+                .shouldReplace(t1, t2, blockchain.getChainHeadHeader());
+    final EndLayer evictCollector = new EndLayer(metrics);
+    final SparseTransactions sparse =
+        new SparseTransactions(poolConf, ethScheduler, evictCollector, metrics, replacementTester, new BlobCache());
+    final ReadyTransactions ready =
+        new ReadyTransactions(poolConf, ethScheduler, sparse, metrics, replacementTester, new BlobCache());
+    final BaseFeePrioritizedTransactions prioritized =
+        new BaseFeePrioritizedTransactions(
+            poolConf,
+            blockchain::getChainHeadHeader,
+            ethScheduler,
+            ready,
+            metrics,
+            replacementTester,
+            FeeMarket.london(0L),
+            new BlobCache(),
+            MiningConfiguration.newDefault().setMinTransactionGasPrice(Wei.ONE),
+            new SenderBalanceChecker.NoOpChecker());
+    final PendingTransactions layered =
+        new LayeredPendingTransactions(poolConf, prioritized, ethScheduler);
+    final TransactionPool pool =
+        new TransactionPool(
+            () -> layered,
+            protocolSchedule,
+            protocolContext,
+            mock(TransactionBroadcaster.class),
+            ethContext,
+            metrics,
+            poolConf,
+            new BlobCache());
+    pool.setEnabled();
+    return pool;
   }
 
   @Test

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -268,7 +268,9 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     assertThat(transactionPool.getTransactionByHash(tx.getHash())).isPresent();
     assertThat(results.getNotSelectedTransactions())
         .containsOnly(
-            entry(tx, TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+            entry(
+                tx,
+                TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
   }
 
   @Test
@@ -320,7 +322,9 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     assertThat(transactionPool.getTransactionByHash(tx.getHash())).isPresent();
     assertThat(results.getNotSelectedTransactions())
         .containsOnly(
-            entry(tx, TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
+            entry(
+                tx,
+                TransactionSelectionResult.invalidPenalized(UPFRONT_COST_EXCEEDS_BALANCE.name())));
   }
 
   @Test
@@ -396,13 +400,16 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final TransactionPoolMetrics metrics = new TransactionPoolMetrics(metricsSystem);
     final BiFunction<PendingTransaction, PendingTransaction, Boolean> replacementTester =
         (t1, t2) ->
-            new TransactionPoolReplacementHandler(poolConf.getPriceBump(), poolConf.getBlobPriceBump())
+            new TransactionPoolReplacementHandler(
+                    poolConf.getPriceBump(), poolConf.getBlobPriceBump())
                 .shouldReplace(t1, t2, blockchain.getChainHeadHeader());
     final EndLayer evictCollector = new EndLayer(metrics);
     final SparseTransactions sparse =
-        new SparseTransactions(poolConf, ethScheduler, evictCollector, metrics, replacementTester, new BlobCache());
+        new SparseTransactions(
+            poolConf, ethScheduler, evictCollector, metrics, replacementTester, new BlobCache());
     final ReadyTransactions ready =
-        new ReadyTransactions(poolConf, ethScheduler, sparse, metrics, replacementTester, new BlobCache());
+        new ReadyTransactions(
+            poolConf, ethScheduler, sparse, metrics, replacementTester, new BlobCache());
     final BaseFeePrioritizedTransactions prioritized =
         new BaseFeePrioritizedTransactions(
             poolConf,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.plugin.data.AddedBlockContext;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.concurrent.TimeUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SequencedSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -105,7 +105,10 @@ public class PeerTransactionTracker
     peersSeenStateByHash.entrySet().removeIf(e -> e.getValue().addedAtMillis() < cutoffMillis);
     final int removed = before - peersSeenStateByHash.size();
     if (removed > 0) {
-      LOG.debug("Purged {} expired seen-transaction entries (older than {} min)", removed, forgetInvalidTxnMins);
+      LOG.debug(
+          "Purged {} expired seen-transaction entries (older than {} min)",
+          removed,
+          forgetInvalidTxnMins);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -443,7 +443,7 @@ public class PeerTransactionTracker
       removeAnnouncementsToRequest(droppedHashes);
     }
 
-    if (reason.stopTracking() && forgetEvictedTxsEnabled) {
+    if (forgetInvalidTxnMins == 0 || (reason.stopTracking() && forgetEvictedTxsEnabled)) {
       peersSeenStateByHash.remove(transaction.getHash());
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.plugin.data.AddedBlockContext;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.concurrent.TimeUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +60,7 @@ public class PeerTransactionTracker
   private final EthScheduler ethScheduler;
   private final int maxSendQueueSizePerPeer;
   private final boolean forgetEvictedTxsEnabled;
+  private final int forgetInvalidTxnMins;
   private final FixedCapacityLRUMap<Hash, PeersSeenState> peersSeenStateByHash;
   private final Map<EthPeer, SequencedSet<Transaction>> transactionsToSend = new HashMap<>();
   private final Map<EthPeer, SequencedSet<Transaction>> announcementsToSend = new HashMap<>();
@@ -75,11 +77,16 @@ public class PeerTransactionTracker
     this.ethScheduler = scheduler;
     this.maxSendQueueSizePerPeer = txPoolConfig.getUnstable().getMaxSendQueueSizePerPeer();
     this.forgetEvictedTxsEnabled = txPoolConfig.getUnstable().getPeerTrackerForgetEvictedTxs();
+    this.forgetInvalidTxnMins = txPoolConfig.getForgetInvalidTxnMins();
     this.peersSeenStateByHash =
         new FixedCapacityLRUMap<>(txPoolConfig.getUnstable().getMaxTrackedSeenTxs());
     this.peerToSlotIndexMap = HashBiMap.create(ethPeers.getMaxPeers());
     ethScheduler.scheduleFutureTaskWithFixedDelay(
         this::logStats, Duration.ofMinutes(1), Duration.ofMinutes(1));
+    if (forgetInvalidTxnMins > 0) {
+      ethScheduler.scheduleFutureTaskWithFixedDelay(
+          this::purgeExpiredSeenTransactions, Duration.ofMinutes(1), Duration.ofMinutes(1));
+    }
   }
 
   public synchronized void reset() {
@@ -89,6 +96,17 @@ public class PeerTransactionTracker
     announcementsToSend.clear();
     announcementsToRequestByHash.clear();
     inProgressAnnouncements.clear();
+  }
+
+  private synchronized void purgeExpiredSeenTransactions() {
+    final long cutoffMillis =
+        System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(forgetInvalidTxnMins);
+    final int before = peersSeenStateByHash.size();
+    peersSeenStateByHash.entrySet().removeIf(e -> e.getValue().addedAtMillis() < cutoffMillis);
+    final int removed = before - peersSeenStateByHash.size();
+    if (removed > 0) {
+      LOG.debug("Purged {} expired seen-transaction entries (older than {} min)", removed, forgetInvalidTxnMins);
+    }
   }
 
   private synchronized void logStats() {
@@ -483,9 +501,9 @@ public class PeerTransactionTracker
     }
   }
 
-  private record PeersSeenState(BitSet transactions, BitSet announcements) {
+  private record PeersSeenState(BitSet transactions, BitSet announcements, long addedAtMillis) {
     PeersSeenState(final int maxSlots) {
-      this(new BitSet(maxSlots), new BitSet(maxSlots));
+      this(new BitSet(maxSlots), new BitSet(maxSlots), System.currentTimeMillis());
     }
 
     public void transactionSeenAll() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -599,6 +599,10 @@ public class TransactionPool implements BlockAddedObserver {
     pendingTransactions.selectTransactions(transactionSelector);
   }
 
+  public TransactionPoolConfiguration getConfiguration() {
+    return configuration;
+  }
+
   public String logStats() {
     return pendingTransactions.logStats();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -108,6 +108,7 @@ public interface TransactionPoolConfiguration {
   byte DEFAULT_TX_POOL_MIN_SCORE = -128;
   boolean DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK = true;
   boolean DEFAULT_TX_POOL_NO_LATE_FUNDING = false;
+  int DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS = 0;
 
   TransactionPoolConfiguration DEFAULT = ImmutableTransactionPoolConfiguration.builder().build();
 
@@ -214,6 +215,11 @@ public interface TransactionPoolConfiguration {
   @Value.Default
   default boolean getNoLateFunding() {
     return DEFAULT_TX_POOL_NO_LATE_FUNDING;
+  }
+
+  @Value.Default
+  default int getForgetInvalidTxnMins() {
+    return DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS;
   }
 
   @Value.Default

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -108,7 +108,7 @@ public interface TransactionPoolConfiguration {
   byte DEFAULT_TX_POOL_MIN_SCORE = -128;
   boolean DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK = true;
   boolean DEFAULT_TX_POOL_NO_LATE_FUNDING = false;
-  int DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS = 0;
+  int DEFAULT_TX_POOL_FORGET_INVALID_TXN_MINS = -1;
 
   TransactionPoolConfiguration DEFAULT = ImmutableTransactionPoolConfiguration.builder().build();
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -107,6 +107,7 @@ public interface TransactionPoolConfiguration {
   Wei DEFAULT_TX_POOL_MIN_GAS_PRICE = Wei.of(1000);
   byte DEFAULT_TX_POOL_MIN_SCORE = -128;
   boolean DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK = true;
+  boolean DEFAULT_TX_POOL_NO_LATE_FUNDING = false;
 
   TransactionPoolConfiguration DEFAULT = ImmutableTransactionPoolConfiguration.builder().build();
 
@@ -208,6 +209,11 @@ public interface TransactionPoolConfiguration {
   @Value.Default
   default boolean getEnableBalanceCheck() {
     return DEFAULT_TX_POOL_ENABLE_BALANCE_CHECK;
+  }
+
+  @Value.Default
+  default boolean getNoLateFunding() {
+    return DEFAULT_TX_POOL_NO_LATE_FUNDING;
   }
 
   @Value.Default

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
@@ -221,6 +221,8 @@ public class LayeredPendingTransactions implements PendingTransactions {
   private void logInvalidTransaction(
       final PendingTransaction pendingTransaction, final TransactionSelectionResult result) {
     LOG.atInfo()
+        .setMessage("Transaction removed during block selection: {}")
+        .addArgument(pendingTransaction::getHash)
         .addMarker(INVALID_TX_REMOVED)
         .addKeyValue("txhash", pendingTransaction::getHash)
         .addKeyValue("txlog", pendingTransaction::toTraceLog)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -274,6 +274,8 @@ public abstract class AbstractPendingTransactionsSorter implements PendingTransa
   private void logDiscardedTransaction(
       final PendingTransaction pendingTransaction, final TransactionSelectionResult result) {
     LOG.atInfo()
+        .setMessage("Transaction removed during block selection: {}")
+        .addArgument(pendingTransaction::getHash)
         .addMarker(INVALID_TX_REMOVED)
         .addKeyValue("txhash", pendingTransaction::getHash)
         .addKeyValue("txlog", pendingTransaction::toTraceLog)


### PR DESCRIPTION
## PR description
There are cases where it is useful in an enterprise, permissioned chain with no gas price/token (often the case when `--min-gas-price = 0` but being a min gas price it doesn't prevent transactions with > 0 price getting into the pool) to prevent transactions getting into the transaction pool which can never be mined. If the chain has no addresses that are funded, a stuck TX can't be prevented from taking up a nonce for a sender indefinitely (or until the tx pool timeout - minimum 1 hour - or a restart).

There are several changes that can contribute to providing more control of nodes & their pools in this way:

1. https://github.com/besu-eth/besu/pull/10640 was merged recently which announces a future change where `--rpc-tx-feecap` can be set to `0`. Today it treats `0` as "do not cap based on tx fees".
   - A small future PR will then make that change to allow a node to prevent transactions with fees > 0 from being accepted
   - This doesn't address P2P sharing of such transactions from other nodes however 
2. https://github.com/besu-eth/besu/pull/10642 also merged recently which helps applications to avoid submitting transactions with gas price set > 0. If an application uses `eth_maxPriorityFeePerGas` to determine the fees to set on a transaction, there are cases where `eth_maxPriorityFeePerGas` can return a priority fee > 0 even if almost all transactions in the chain use zero gas price. 

This PR is an additional enhancement in this space. Should a node not use the above options correctly to prevent transactions with > 0 gas fees/price, another node could receive such a transaction into its pool over P2P and hit the issue of  a sender nonce being locked up in a TX pool entry that can never be mined.

The PR adds the following enhancements:

1. A new option `--tx-pool-no-late-funding` (default `false`). If set to true, any transaction that is considered during transaction selection but rejected for reason `UPFRONT_COST_EXCEEDS_BALANCE` is immediately rejected as invalid
   - The transaction will be put into the tracked invalid transactions list to prevent it being re-admitted to the pool over P2P
2. A new option `--tx-pool-forget-invalid-txn-mins` (default `-1` = off).
   - If left as `-1` the list of tracked invalid transactions behaves as today, which is a 300k LRU approach
   - If set to a non-negative number the LRU evicted transaction list forgets the transaction after the number of minutes. For `0` this means it forgets them immediately.

I looked at adding metrics for this case but we already have general case eviction metrics and I don't think we need a specific one just for this scenario.

## Fixed Issue(s)
N/A


