### PR TITLE
Tune RocksDB options per column family for point-lookup-heavy state access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Upgrade netty dependencies to 4.2.15.Final [#10693](https://github.com/besu-eth/besu/pull/10693) 
 - Besu now falls back to Proof of Stake when the genesis file declares no consensus mechanism (e.g. an empty `"config": {}`). [#10266](https://github.com/besu-eth/besu/pull/10266)
 - Add `HealthCheckService` plugin API enabling custom health check implementations. The plugin-based `/readiness` response body is simplified to `{"status":"UP"|"DOWN"}` and no longer includes the previous `{peers, sync}` detail. [#10167](https://github.com/besu-eth/besu/pull/10167)
-- Tune RocksDB options per column family for point-lookup-heavy state access: smaller data blocks, in-block hash index, non-partitioned index/filters and stronger bloom filters on flat state segments, plus a flatter LSM shape for state segments
+- Tune RocksDB options per column family for point-lookup-heavy state access: smaller data blocks, in-block hash index, non-partitioned index/filters, stronger bloom filters and flush-time block cache prepopulation on flat state segments, plus a flatter LSM shape for state segments
 
 ## 26.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Upgrade netty dependencies to 4.2.15.Final [#10693](https://github.com/besu-eth/besu/pull/10693) 
 - Besu now falls back to Proof of Stake when the genesis file declares no consensus mechanism (e.g. an empty `"config": {}`). [#10266](https://github.com/besu-eth/besu/pull/10266)
 - Add `HealthCheckService` plugin API enabling custom health check implementations. The plugin-based `/readiness` response body is simplified to `{"status":"UP"|"DOWN"}` and no longer includes the previous `{peers, sync}` detail. [#10167](https://github.com/besu-eth/besu/pull/10167)
-- Tune RocksDB options per column family for point-lookup-heavy state access: smaller data blocks, in-block hash index, non-partitioned index/filters, stronger bloom filters and flush-time block cache prepopulation on flat state segments, plus a flatter LSM shape for state segments
+- Tune RocksDB options per column family for point-lookup-heavy state access: smaller data blocks, in-block hash index, non-partitioned index/filters, stronger bloom filters and flush-time block cache prepopulation on flat state segments, a flatter LSM shape for state segments, and 4x larger SST files (256 MiB) for the data-heavy column families to reduce table-cache thrashing
 
 ## 26.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Upgrade netty dependencies to 4.2.15.Final [#10693](https://github.com/besu-eth/besu/pull/10693) 
 - Besu now falls back to Proof of Stake when the genesis file declares no consensus mechanism (e.g. an empty `"config": {}`). [#10266](https://github.com/besu-eth/besu/pull/10266)
 - Add `HealthCheckService` plugin API enabling custom health check implementations. The plugin-based `/readiness` response body is simplified to `{"status":"UP"|"DOWN"}` and no longer includes the previous `{peers, sync}` detail. [#10167](https://github.com/besu-eth/besu/pull/10167)
+- Tune RocksDB options per column family for point-lookup-heavy state access: smaller data blocks, in-block hash index, non-partitioned index/filters and stronger bloom filters on flat state segments, plus a flatter LSM shape for state segments
 
 ## 26.6.1
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -108,10 +108,20 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   private static final int DEFAULT_BLOOM_FILTER_BITS_PER_KEY = 10;
 
   /**
-   * Target size of L1 for state segments (~350 MB). Together with a larger level multiplier this
-   * flattens the LSM tree, so point reads have fewer levels to probe.
+   * Target SST file size for the data-heavy column families (blockchain, flat state, trie nodes).
+   * These column families can grow beyond 100 GiB, which with the RocksDB default target file size
+   * of 64 MiB produces thousands of SST files. That many files thrash the table cache (frequent,
+   * expensive re-opens in TableCache::FindTable on the read path) and multiply per-file metadata
+   * overhead. Larger 256 MiB files keep the file count manageable.
    */
-  private static final long STATE_MAX_BYTES_FOR_LEVEL_BASE = 350 * 1_048_576L;
+  private static final long LARGE_SEGMENT_SST_TARGET_FILE_SIZE = 268_435_456L;
+
+  /**
+   * Target size of L1 for the data-heavy column families: 4x the RocksDB default, scaled with the
+   * 4x target file size so L1 still holds ~4 target-size files.
+   */
+  private static final long LARGE_SEGMENT_MAX_BYTES_FOR_LEVEL_BASE =
+      4 * LARGE_SEGMENT_SST_TARGET_FILE_SIZE;
 
   /** Level size multiplier for state segments, keeping the LSM shallow (fewer levels to probe). */
   private static final double STATE_MAX_BYTES_FOR_LEVEL_MULTIPLIER = 30;
@@ -277,12 +287,17 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
             .setTtl(0)
             .setCompressionType(CompressionType.LZ4_COMPRESSION)
             .setLevelCompactionDynamicLevelBytes(dynamicLevelBytes);
-    if (isStateSegment(segment)) {
-      // Flatten the LSM for state column families: a larger level base and multiplier mean
-      // fewer levels, so each point lookup has fewer levels to probe.
+    if (segment.isEligibleToHighSpecFlag()) {
+      // Data-heavy column families (blockchain + state) get 4x the RocksDB default SST file
+      // size and L1 size, to keep the SST file count (and table-cache pressure) manageable.
       cfOptions
-          .setMaxBytesForLevelBase(STATE_MAX_BYTES_FOR_LEVEL_BASE)
-          .setMaxBytesForLevelMultiplier(STATE_MAX_BYTES_FOR_LEVEL_MULTIPLIER);
+          .setTargetFileSizeBase(LARGE_SEGMENT_SST_TARGET_FILE_SIZE)
+          .setMaxBytesForLevelBase(LARGE_SEGMENT_MAX_BYTES_FOR_LEVEL_BASE);
+    }
+    if (isStateSegment(segment)) {
+      // Flatten the LSM for state column families: a larger level multiplier means fewer
+      // levels, so each point lookup has fewer levels to probe.
+      cfOptions.setMaxBytesForLevelMultiplier(STATE_MAX_BYTES_FOR_LEVEL_MULTIPLIER);
     }
     columnFamilyOptionsList.add(cfOptions);
     if (segment.containsStaticData()) {

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -57,9 +58,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompressionType;
 import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
-import org.rocksdb.DataBlockIndexType;
 import org.rocksdb.Env;
-import org.rocksdb.IndexType;
 import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.OptionsUtil;
@@ -267,13 +266,16 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     } catch (RocksDBException ex) {
       // Options file is not found in the database
     }
-    BlockBasedTableConfig basedTableConfig = createBlockBasedTableConfig(segment, configuration);
-
-    final var cfOptions =
-        new ColumnFamilyOptions()
+    // Flat state segments need table options that have no RocksJava setter (e.g.
+    // prepopulate_block_cache), so their whole table factory is built from an options string;
+    // the other segments keep the programmatic BlockBasedTableConfig.
+    final ColumnFamilyOptions cfOptions =
+        (isFlatStateSegment(segment)
+                ? createFlatStateColumnFamilyOptions(segment, configuration)
+                : new ColumnFamilyOptions()
+                    .setTableFormatConfig(createBlockBasedTableConfig(segment, configuration)))
             .setTtl(0)
             .setCompressionType(CompressionType.LZ4_COMPRESSION)
-            .setTableFormatConfig(basedTableConfig)
             .setLevelCompactionDynamicLevelBytes(dynamicLevelBytes);
     if (isStateSegment(segment)) {
       // Flatten the LSM for state column families: a larger level base and multiplier mean
@@ -288,6 +290,67 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     }
 
     return new ColumnFamilyDescriptor(segment.getId(), cfOptions);
+  }
+
+  /**
+   * Create the column family options for a flat state segment. The block-based table options are
+   * built from a RocksDB options string instead of {@link BlockBasedTableConfig} because {@code
+   * prepopulate_block_cache} has no RocksJava setter; the other values mirror what would otherwise
+   * be set programmatically.
+   *
+   * @param segment the flat state segment
+   * @param config RocksDB configuration
+   * @return column family options with point-lookup-oriented table options applied
+   */
+  private ColumnFamilyOptions createFlatStateColumnFamilyOptions(
+      final SegmentIdentifier segment, final RocksDBConfiguration config) {
+    final long blockSize =
+        ACCOUNT_INFO_STATE.getName().equals(segment.getName())
+            ? FLAT_ACCOUNT_BLOCK_SIZE
+            : FLAT_STORAGE_BLOCK_SIZE;
+    final long cacheCapacity =
+        config.isHighSpec() && segment.isEligibleToHighSpecFlag()
+            ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
+            : config.getCacheCapacity();
+    final Properties props = new Properties();
+    props.setProperty(
+        "block_based_table_factory",
+        "{format_version="
+            + ROCKSDB_FORMAT_VERSION
+            // block_cache=<capacity> makes RocksDB create an LRU cache of that size for this
+            // column family, matching the per-segment LRUCache used for the other segments.
+            + ";block_cache="
+            + cacheCapacity
+            + ";block_size="
+            + blockSize
+            + ";cache_index_and_filter_blocks="
+            + segment.isCacheIndexAndFilterBlocks()
+            + ";filter_policy=bloomfilter:"
+            + FLAT_STATE_BLOOM_FILTER_BITS_PER_KEY
+            + ":false"
+            // A single binary-search index with whole (non-partitioned) filters keeps a point
+            // lookup to one index probe and one filter probe, instead of the extra top-level
+            // index hop that partitioned indexes/filters add on every read.
+            + ";index_type=kBinarySearch"
+            + ";partition_filters=false"
+            // In-block hash index resolves a key inside a data block in O(1) instead of a
+            // binary search over restart points, which pays off for random point lookups.
+            + ";data_block_index_type=kDataBlockBinaryAndHash"
+            + ";data_block_hash_table_util_ratio="
+            + DATA_BLOCK_HASH_TABLE_UTIL_RATIO
+            + ";pin_l0_filter_and_index_blocks_in_cache=true"
+            // Freshly flushed blocks go straight into the block cache, so recently written
+            // state is served from memory without waiting for a read to warm the cache.
+            + ";prepopulate_block_cache=kFlushOnly}");
+    try (ConfigOptions configOptions = new ConfigOptions().setIgnoreUnknownOptions(false)) {
+      final ColumnFamilyOptions cfOptions =
+          ColumnFamilyOptions.getColumnFamilyOptionsFromProps(configOptions, props);
+      if (cfOptions == null) {
+        throw new StorageException(
+            "Invalid RocksDB options string for segment " + segment.getName());
+      }
+      return cfOptions;
+    }
   }
 
   /**
@@ -369,34 +432,14 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
         new BlockBasedTableConfig()
             .setFormatVersion(ROCKSDB_FORMAT_VERSION)
             .setBlockCache(cache)
-            .setCacheIndexAndFilterBlocks(segment.isCacheIndexAndFilterBlocks());
-    if (isFlatStateSegment(segment)) {
-      tableConfig
-          .setBlockSize(
-              ACCOUNT_INFO_STATE.getName().equals(segment.getName())
-                  ? FLAT_ACCOUNT_BLOCK_SIZE
-                  : FLAT_STORAGE_BLOCK_SIZE)
-          .setFilterPolicy(new BloomFilter(FLAT_STATE_BLOOM_FILTER_BITS_PER_KEY, false))
-          // A single binary-search index with whole (non-partitioned) filters keeps a point
-          // lookup to one index probe and one filter probe, instead of the extra top-level
-          // index hop that partitioned indexes/filters add on every read.
-          .setIndexType(IndexType.kBinarySearch)
-          .setPartitionFilters(false)
-          // In-block hash index resolves a key inside a data block in O(1) instead of a
-          // binary search over restart points, which pays off for random point lookups.
-          .setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash)
-          .setDataBlockHashTableUtilRatio(DATA_BLOCK_HASH_TABLE_UTIL_RATIO)
-          .setPinL0FilterAndIndexBlocksInCache(true);
-    } else {
-      tableConfig
-          .setBlockSize(ROCKSDB_BLOCK_SIZE)
-          .setFilterPolicy(new BloomFilter(DEFAULT_BLOOM_FILTER_BITS_PER_KEY, false))
-          // Partitioned filters/indexes are kept for the remaining (large or scan-oriented)
-          // segments to bound the memory held per SST file.
-          .setPartitionFilters(true);
-      if (TRIE_BRANCH_STORAGE.getName().equals(segment.getName())) {
-        tableConfig.setPinL0FilterAndIndexBlocksInCache(true);
-      }
+            .setCacheIndexAndFilterBlocks(segment.isCacheIndexAndFilterBlocks())
+            .setBlockSize(ROCKSDB_BLOCK_SIZE)
+            .setFilterPolicy(new BloomFilter(DEFAULT_BLOOM_FILTER_BITS_PER_KEY, false))
+            // Partitioned filters/indexes are kept for the remaining (large or scan-oriented)
+            // segments to bound the memory held per SST file.
+            .setPartitionFilters(true);
+    if (TRIE_BRANCH_STORAGE.getName().equals(segment.getName())) {
+      tableConfig.setPinL0FilterAndIndexBlocksInCache(true);
     }
     return tableConfig;
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -15,7 +15,10 @@
 package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
@@ -54,7 +57,9 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompressionType;
 import org.rocksdb.ConfigOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.DataBlockIndexType;
 import org.rocksdb.Env;
+import org.rocksdb.IndexType;
 import org.rocksdb.LRUCache;
 import org.rocksdb.Options;
 import org.rocksdb.OptionsUtil;
@@ -75,6 +80,42 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBColumnarKeyValueStorage.class);
   private static final int ROCKSDB_FORMAT_VERSION = 5;
   private static final long ROCKSDB_BLOCK_SIZE = 32768;
+
+  /**
+   * Block size for the flat account state segment. Values are small (~70-150 bytes) and accessed by
+   * random point lookups on hashed keys, so small data blocks reduce read amplification and make
+   * better use of the block cache (less unrelated data pulled in per lookup).
+   */
+  private static final long FLAT_ACCOUNT_BLOCK_SIZE = 4096;
+
+  /** Block size for the flat account storage segment, tuned like the flat account state one. */
+  private static final long FLAT_STORAGE_BLOCK_SIZE = 8192;
+
+  /**
+   * Fraction of in-block hash table slots to use for the hash-based data block index. 0.75 is the
+   * RocksDB recommended starting point: dense enough to keep the index small, sparse enough to keep
+   * collisions (and the resulting binary-search fallback) rare.
+   */
+  private static final double DATA_BLOCK_HASH_TABLE_UTIL_RATIO = 0.75;
+
+  /**
+   * Bloom filter bits per key for flat state segments. Point-lookup-heavy workloads with many
+   * negative lookups benefit from a lower false positive rate (~0.05% at 15 bits vs ~1% at 10
+   * bits), avoiding useless data block reads.
+   */
+  private static final int FLAT_STATE_BLOOM_FILTER_BITS_PER_KEY = 15;
+
+  /** Bloom filter bits per key for the remaining segments (RocksDB's common default of 10). */
+  private static final int DEFAULT_BLOOM_FILTER_BITS_PER_KEY = 10;
+
+  /**
+   * Target size of L1 for state segments (~350 MB). Together with a larger level multiplier this
+   * flattens the LSM tree, so point reads have fewer levels to probe.
+   */
+  private static final long STATE_MAX_BYTES_FOR_LEVEL_BASE = 350 * 1_048_576L;
+
+  /** Level size multiplier for state segments, keeping the LSM shallow (fewer levels to probe). */
+  private static final double STATE_MAX_BYTES_FOR_LEVEL_MULTIPLIER = 30;
 
   /** RocksDb blockcache size when using the high spec option */
   protected static final long ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC = 1_073_741_824L;
@@ -234,12 +275,42 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
             .setCompressionType(CompressionType.LZ4_COMPRESSION)
             .setTableFormatConfig(basedTableConfig)
             .setLevelCompactionDynamicLevelBytes(dynamicLevelBytes);
+    if (isStateSegment(segment)) {
+      // Flatten the LSM for state column families: a larger level base and multiplier mean
+      // fewer levels, so each point lookup has fewer levels to probe.
+      cfOptions
+          .setMaxBytesForLevelBase(STATE_MAX_BYTES_FOR_LEVEL_BASE)
+          .setMaxBytesForLevelMultiplier(STATE_MAX_BYTES_FOR_LEVEL_MULTIPLIER);
+    }
     columnFamilyOptionsList.add(cfOptions);
     if (segment.containsStaticData()) {
       configureBlobDBForSegment(segment, configuration, cfOptions);
     }
 
     return new ColumnFamilyDescriptor(segment.getId(), cfOptions);
+  }
+
+  /**
+   * Flat state segments hold small values (~70-150 bytes) read almost exclusively through random
+   * point lookups on hashed keys, so they get point-lookup-oriented table options.
+   *
+   * @param segment the segment identifier
+   * @return true if the segment stores flat state data
+   */
+  private static boolean isFlatStateSegment(final SegmentIdentifier segment) {
+    return ACCOUNT_INFO_STATE.getName().equals(segment.getName())
+        || ACCOUNT_STORAGE_STORAGE.getName().equals(segment.getName());
+  }
+
+  /**
+   * State segments (flat state and trie nodes) are the read-hot column families during block
+   * processing and benefit from a shallower LSM shape.
+   *
+   * @param segment the segment identifier
+   * @return true if the segment stores world state data
+   */
+  private static boolean isStateSegment(final SegmentIdentifier segment) {
+    return isFlatStateSegment(segment) || TRIE_BRANCH_STORAGE.getName().equals(segment.getName());
   }
 
   private static void configureBlobDBForSegment(
@@ -294,13 +365,40 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
                 ? ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC
                 : config.getCacheCapacity());
     blockCaches.add(cache);
-    return new BlockBasedTableConfig()
-        .setFormatVersion(ROCKSDB_FORMAT_VERSION)
-        .setBlockCache(cache)
-        .setFilterPolicy(new BloomFilter(10, false))
-        .setPartitionFilters(true)
-        .setCacheIndexAndFilterBlocks(segment.isCacheIndexAndFilterBlocks())
-        .setBlockSize(ROCKSDB_BLOCK_SIZE);
+    final BlockBasedTableConfig tableConfig =
+        new BlockBasedTableConfig()
+            .setFormatVersion(ROCKSDB_FORMAT_VERSION)
+            .setBlockCache(cache)
+            .setCacheIndexAndFilterBlocks(segment.isCacheIndexAndFilterBlocks());
+    if (isFlatStateSegment(segment)) {
+      tableConfig
+          .setBlockSize(
+              ACCOUNT_INFO_STATE.getName().equals(segment.getName())
+                  ? FLAT_ACCOUNT_BLOCK_SIZE
+                  : FLAT_STORAGE_BLOCK_SIZE)
+          .setFilterPolicy(new BloomFilter(FLAT_STATE_BLOOM_FILTER_BITS_PER_KEY, false))
+          // A single binary-search index with whole (non-partitioned) filters keeps a point
+          // lookup to one index probe and one filter probe, instead of the extra top-level
+          // index hop that partitioned indexes/filters add on every read.
+          .setIndexType(IndexType.kBinarySearch)
+          .setPartitionFilters(false)
+          // In-block hash index resolves a key inside a data block in O(1) instead of a
+          // binary search over restart points, which pays off for random point lookups.
+          .setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash)
+          .setDataBlockHashTableUtilRatio(DATA_BLOCK_HASH_TABLE_UTIL_RATIO)
+          .setPinL0FilterAndIndexBlocksInCache(true);
+    } else {
+      tableConfig
+          .setBlockSize(ROCKSDB_BLOCK_SIZE)
+          .setFilterPolicy(new BloomFilter(DEFAULT_BLOOM_FILTER_BITS_PER_KEY, false))
+          // Partitioned filters/indexes are kept for the remaining (large or scan-oriented)
+          // segments to bound the memory held per SST file.
+          .setPartitionFilters(true);
+      if (TRIE_BRANCH_STORAGE.getName().equals(segment.getName())) {
+        tableConfig.setPinL0FilterAndIndexBlocksInCache(true);
+      }
+    }
+    return tableConfig;
   }
 
   /***

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
@@ -24,9 +24,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.kvstore.AbstractKeyValueStorageTest;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
@@ -39,6 +41,7 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTran
 import org.hyperledger.besu.services.kvstore.SegmentedKeyValueStorageAdapter;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +55,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.rocksdb.Env;
+import org.rocksdb.OptionsUtil;
 
 public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValueStorageTest {
 
@@ -285,6 +290,79 @@ public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValu
     } catch (StorageException e) {
       assertThat(e.getMessage()).contains("Unhandled column families");
     }
+  }
+
+  @Test
+  public void flatStateSegmentsUsePointLookupTableOptions(@TempDir final Path testPath)
+      throws Exception {
+    final SegmentedKeyValueStorage store =
+        createSegmentedStore(
+            testPath,
+            new NoOpMetricsSystem(),
+            Arrays.asList(
+                KeyValueSegmentIdentifier.DEFAULT,
+                KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE,
+                KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE,
+                KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE),
+            List.of());
+
+    // sanity check the tuned column families are usable
+    final SegmentedKeyValueStorageTransaction tx = store.startTransaction();
+    tx.put(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE, bytesOf(1), bytesOf(2));
+    tx.put(KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE, bytesOf(3), bytesOf(4));
+    tx.commit();
+    assertThat(store.get(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE, bytesOf(1)))
+        .contains(bytesOf(2));
+    assertThat(store.get(KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE, bytesOf(3)))
+        .contains(bytesOf(4));
+    store.close();
+
+    // verify the effective options RocksDB persisted for each column family, including the
+    // ones only settable through the options string mechanism (no RocksJava setter)
+    final String accountInfoOptions =
+        tableOptionsSection(testPath, KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE);
+    assertThat(accountInfoOptions)
+        .contains("block_size=4096")
+        .contains("prepopulate_block_cache=kFlushOnly")
+        .contains("data_block_index_type=kDataBlockBinaryAndHash")
+        .contains("index_type=kBinarySearch")
+        .contains("partition_filters=false")
+        .contains("pin_l0_filter_and_index_blocks_in_cache=true")
+        .contains("bloomfilter:15");
+
+    final String accountStorageOptions =
+        tableOptionsSection(testPath, KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE);
+    assertThat(accountStorageOptions)
+        .contains("block_size=8192")
+        .contains("prepopulate_block_cache=kFlushOnly");
+
+    // control: a non flat-state segment keeps the generic configuration
+    final String trieBranchOptions =
+        tableOptionsSection(testPath, KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE);
+    assertThat(trieBranchOptions)
+        .contains("block_size=32768")
+        .contains("prepopulate_block_cache=kDisable")
+        .contains("data_block_index_type=kDataBlockBinarySearch")
+        .contains("bloomfilter:10");
+  }
+
+  private static String tableOptionsSection(final Path dbPath, final SegmentIdentifier segment)
+      throws Exception {
+    final String optionsFileName =
+        OptionsUtil.getLatestOptionsFileName(dbPath.toString(), Env.getDefault());
+    // ISO-8859-1 keeps the raw column family name bytes intact
+    final String content =
+        Files.readString(dbPath.resolve(optionsFileName), StandardCharsets.ISO_8859_1);
+    final String header =
+        "[TableOptions/BlockBasedTable \""
+            + new String(segment.getId(), StandardCharsets.ISO_8859_1)
+            + "\"]";
+    final int start = content.indexOf(header);
+    assertThat(start)
+        .as("table options section for segment %s", segment.getName())
+        .isGreaterThanOrEqualTo(0);
+    final int end = content.indexOf('[', start + header.length());
+    return end == -1 ? content.substring(start) : content.substring(start, end);
   }
 
   @Test

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
@@ -301,6 +301,7 @@ public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValu
             new NoOpMetricsSystem(),
             Arrays.asList(
                 KeyValueSegmentIdentifier.DEFAULT,
+                KeyValueSegmentIdentifier.BLOCKCHAIN,
                 KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE,
                 KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE,
                 KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE),
@@ -344,9 +345,39 @@ public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValu
         .contains("prepopulate_block_cache=kDisable")
         .contains("data_block_index_type=kDataBlockBinarySearch")
         .contains("bloomfilter:10");
+
+    // data-heavy segments get larger SST files and L1; state segments a larger multiplier
+    for (final SegmentIdentifier segment :
+        List.of(
+            KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE,
+            KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE,
+            KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE)) {
+      assertThat(cfOptionsSection(testPath, segment))
+          .contains("target_file_size_base=268435456")
+          .contains("max_bytes_for_level_base=1073741824")
+          .contains("max_bytes_for_level_multiplier=30.000000");
+    }
+    // blockchain is data-heavy but not a state segment: bigger files, default multiplier
+    assertThat(cfOptionsSection(testPath, KeyValueSegmentIdentifier.BLOCKCHAIN))
+        .contains("target_file_size_base=268435456")
+        .contains("max_bytes_for_level_base=1073741824")
+        .contains("max_bytes_for_level_multiplier=10.000000");
+    assertThat(cfOptionsSection(testPath, KeyValueSegmentIdentifier.DEFAULT))
+        .contains("target_file_size_base=67108864");
   }
 
   private static String tableOptionsSection(final Path dbPath, final SegmentIdentifier segment)
+      throws Exception {
+    return optionsSection(dbPath, "TableOptions/BlockBasedTable", segment);
+  }
+
+  private static String cfOptionsSection(final Path dbPath, final SegmentIdentifier segment)
+      throws Exception {
+    return optionsSection(dbPath, "CFOptions", segment);
+  }
+
+  private static String optionsSection(
+      final Path dbPath, final String sectionType, final SegmentIdentifier segment)
       throws Exception {
     final String optionsFileName =
         OptionsUtil.getLatestOptionsFileName(dbPath.toString(), Env.getDefault());
@@ -354,12 +385,14 @@ public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValu
     final String content =
         Files.readString(dbPath.resolve(optionsFileName), StandardCharsets.ISO_8859_1);
     final String header =
-        "[TableOptions/BlockBasedTable \""
+        "["
+            + sectionType
+            + " \""
             + new String(segment.getId(), StandardCharsets.ISO_8859_1)
             + "\"]";
     final int start = content.indexOf(header);
     assertThat(start)
-        .as("table options section for segment %s", segment.getName())
+        .as("%s section for segment %s", sectionType, segment.getName())
         .isGreaterThanOrEqualTo(0);
     final int end = content.indexOf('[', start + header.length());
     return end == -1 ? content.substring(start) : content.substring(start, end);


### PR DESCRIPTION
## PR description

State access during block processing is dominated by random point lookups on hashed keys over small values (~70-150 bytes for flat account/storage entries). The current RocksDB table configuration is identical for every column family (32 KiB blocks, partitioned filters, 10-bit bloom filters, default LSM shape and file sizing), which is oriented towards scans and memory frugality rather than point reads. This PR differentiates the options per segment, following RocksDB tuning guidance for point-lookup-heavy workloads.

### Flat state segments (`ACCOUNT_INFO_STATE`, `ACCOUNT_STORAGE_STORAGE`)

- **Small data blocks** (4 KiB for account info, 8 KiB for account storage): each point lookup reads and caches less unrelated data, reducing read amplification and making the block cache effectively larger.
- **In-block hash index** (`kDataBlockBinaryAndHash`, util ratio 0.75): resolves a key inside a data block in O(1) instead of a binary search over restart points.
- **Non-partitioned binary-search index + whole filters** (`index_type=kBinarySearch`, `partition_filters=false`): one index probe and one filter probe per read, removing the extra top-level index hop that partitioned indexes/filters add.
- **Stronger bloom filters** (15 bits/key vs 10): ~0.05% false positive rate vs ~1%, avoiding useless data block reads on the many negative lookups these segments see.
- **`pin_l0_filter_and_index_blocks_in_cache=true`**: L0 metadata for the hottest files cannot be evicted.
- **`prepopulate_block_cache=kFlushOnly`**: freshly flushed blocks go straight into the block cache, so recently written state is served from memory without waiting for a read to warm the cache.

Because `prepopulate_block_cache` has no RocksJava setter (verified against rocksdbjni 10.6.2), the table factory of these two column families is built through RocksDB's options-string mechanism (`ColumnFamilyOptions.getColumnFamilyOptionsFromProps` with `block_based_table_factory={...}`) instead of `BlockBasedTableConfig`; the remaining CF-level options (compression, dynamic level bytes, file/level sizing) are chained programmatically on the returned object. Unknown options are rejected (`setIgnoreUnknownOptions(false)`), so a typo fails fast at startup instead of being silently dropped.

### SST file and level sizing for data-heavy segments (`BLOCKCHAIN`, `ACCOUNT_INFO_STATE`, `ACCOUNT_STORAGE_STORAGE`, `TRIE_BRANCH_STORAGE`)

These column families can grow beyond 100 GiB; with the RocksDB default `target_file_size_base` of 64 MiB that produces thousands of SST files, far more than the table cache can keep open with typical `max_open_files` settings. Profiling of a mainnet node showed a large share of native read time spent in `TableCache::FindTable` re-opening evicted SST files on the block-import critical path. Final sizing per segment (reusing the existing high-spec-eligible predicate):

- `BLOCKCHAIN`: `target_file_size_base=256 MiB`, `max_bytes_for_level_base=1 GiB` (4x the defaults, preserving the level shape), default multiplier (10).
- `ACCOUNT_INFO_STATE`, `ACCOUNT_STORAGE_STORAGE`, `TRIE_BRANCH_STORAGE`: `target_file_size_base=256 MiB`, `max_bytes_for_level_base=1 GiB` (L1 holds ~4 target-size files), `max_bytes_for_level_multiplier=30` so the LSM stays shallow and point reads probe fewer levels.
- All other segments: RocksDB defaults, unchanged.

`max_open_files` is deliberately left unchanged.

### Other trie segment tuning

- `TRIE_BRANCH_STORAGE` also pins L0 filter/index blocks, but keeps partitioned filters and 32 KiB blocks since it is much larger and its index/filter memory footprint matters.

### Unchanged

- All other segments (e.g. `CODE_STORAGE`, `TRIE_LOG_STORAGE`) keep the previous configuration exactly.
- High-spec block cache sizing (1 GiB for eligible segments) behaves as before, including for the string-configured flat state segments (`block_cache=<capacity>`).
- Compression stays LZ4 everywhere; disabling it for `ACCOUNT_INFO_STATE` (mostly incompressible hashed values) is left as future work pending benchmarking.

All changes only affect options applied at DB open time; no data format change, existing databases are unaffected and the change is fully reversible.

## Test plan

- `./gradlew :plugins:rocksdb:spotlessApply :plugins:rocksdb:compileJava :plugins:rocksdb:test` passes locally.
- New test `flatStateSegmentsUsePointLookupTableOptions` opens a store with the real state segments and asserts the effective per-column-family options RocksDB persists in its OPTIONS file — including `prepopulate_block_cache=kFlushOnly`, `data_block_index_type=kDataBlockBinaryAndHash`, `block_size`, `partition_filters=false` and the 15-bit bloom filter on flat state, `target_file_size_base` / `max_bytes_for_level_base` / multiplier on the data-heavy segments, and the unchanged generic configuration on control segments. This proves the option string is accepted by the native parser and every option is applied to the right column families.