### PR TITLE
add JMH gas profiler and formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Complete QBFT votes in a reasonable time when `empyblockperiodseconds` is set by treating QBFT votes as "non empty blocks" [#11111](https://github.com/besu-eth/besu/pull/11111)
 
 ### Additions and Improvements
+- Add JMH `GasProfiler` that emits `mgas_per_s` as a secondary metric on each benchmark iteration using Besu's own `GasCalculator`. Enable with `-PgasProfiler=true`; override the EVM fork with `-PgasProfilerFork=<fork>` (defaults to Osaka). [#10807](https://github.com/besu-eth/besu/pull/10807)
 - Align Kotlin runtime dependencies to 2.4.0 to support plugins compiled against the Kotlin 2.4 API. [#10983](https://github.com/besu-eth/besu/pull/10983)
 - Upgrade log4j to 2.25.5 [#11075](https://github.com/besu-eth/besu/pull/11075)
 - Upgrade netty dependency to 4.2.17.Final [#11078](https://github.com/besu-eth/besu/pull/11078)

--- a/build.gradle
+++ b/build.gradle
@@ -949,6 +949,7 @@ subprojects {
         if (asyncProfiler == null) profilers = []
         profilers.add('gc')
       }
+      profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler')
       duplicateClassesStrategy = DuplicatesStrategy.INCLUDE
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -949,7 +949,11 @@ subprojects {
         if (asyncProfiler == null) profilers = []
         profilers.add('gc')
       }
-      profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler')
+      var gasProfiler = _strCmdArg('gasProfiler')
+      if (gasProfiler != null && gasProfiler.toBoolean()) {
+        if (asyncProfiler == null) profilers = []
+        profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler')
+      }
       duplicateClassesStrategy = DuplicatesStrategy.INCLUDE
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -911,7 +911,9 @@ subprojects {
         "\t-Pcases=<caseNames>\t\tComma-separated list of @Param caseName values to run (e.g. MOD_32_32,MOD_256_256). Defaults to running all cases.\n" +
         "\t-PgcProfiler=true\t\tEnable the JMH GC profiler to capture allocation rates (gc.alloc.rate.norm) alongside timing.\n" +
         "\t-PasyncProfiler=<libPath>\tLibrary path to fetch the Async profiler from. Default is to disable profiling.\n" +
-        "\t-PasyncProfilerOptions=<asyncProfilerOptions>\tOptions to pass on to the Async profiler separated by ';'. Default is to produce a flamegraph with all other default profiler options.\n"
+        "\t-PasyncProfilerOptions=<asyncProfilerOptions>\tOptions to pass on to the Async profiler separated by ';'. Default is to produce a flamegraph with all other default profiler options.\n" +
+        "\t-PgasProfiler=true\t\tEnable the gas profiler to emit per-benchmark EVM gas cost as a secondary metric.\n" +
+        "\t-PgasProfilerFork=<fork>\tEVM fork to use for gas cost calculation (e.g. CANCUN, OSAKA). Defaults to OSAKA.\n"
     }
 
     tasks.named("jmhJar") {
@@ -952,7 +954,8 @@ subprojects {
       var gasProfiler = _strCmdArg('gasProfiler')
       if (gasProfiler != null && gasProfiler.toBoolean()) {
         if (asyncProfiler == null) profilers = []
-        profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler')
+        var gasProfilerFork = _strCmdArg('gasProfilerFork')
+        profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler' + (gasProfilerFork != null ? ':' + gasProfilerFork : ''))
       }
       duplicateClassesStrategy = DuplicatesStrategy.INCLUDE
     }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
@@ -19,8 +19,6 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AddOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
-import java.util.OptionalLong;
-
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
@@ -30,8 +28,8 @@ public class AddOperationBenchmark extends BinaryArithmeticOperationBenchmark
   private String caseName;
 
   @Override
-  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
-    return OptionalLong.of(new AddOperationOptimized(calc).getGasCost());
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new AddOperationOptimized(calc).getGasCost();
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
@@ -28,8 +28,8 @@ public class AddOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Param("ADD_RANDOM_RANDOM")
   private String caseName;
 
-  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
-    return OptionalLong.of(calc.getVeryLowTierGasCost());
+  static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return OptionalLong.of(new AddOperationOptimized(calc).getGasCost());
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
@@ -15,14 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AddOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
+import java.util.OptionalLong;
+
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 public class AddOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Param("ADD_RANDOM_RANDOM")
   private String caseName;
+
+  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return OptionalLong.of(calc.getVeryLowTierGasCost());
+  }
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddOperationBenchmark.java
@@ -24,11 +24,13 @@ import java.util.OptionalLong;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class AddOperationBenchmark extends BinaryArithmeticOperationBenchmark {
+public class AddOperationBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param("ADD_RANDOM_RANDOM")
   private String caseName;
 
-  static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  @Override
+  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     return OptionalLong.of(new AddOperationOptimized(calc).getGasCost());
   }
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
@@ -41,9 +41,10 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class CallDataCopyOperationBenchmark {
+public class CallDataCopyOperationBenchmark implements GasCostBenchmark {
 
-  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  @Override
+  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final long size = Long.parseLong(params.getParam("dataSize"));
     final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
     frame.expandMemory(0, size);

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CallDataCopyOperation;
 
-import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -44,11 +43,11 @@ import org.openjdk.jmh.infra.Blackhole;
 public class CallDataCopyOperationBenchmark implements GasCostBenchmark {
 
   @Override
-  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final long size = Long.parseLong(params.getParam("dataSize"));
     final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
     frame.expandMemory(0, size);
-    return OptionalLong.of(calc.dataCopyOperationGasCost(frame, 0, size));
+    return calc.dataCopyOperationGasCost(frame, 0, size);
   }
 
   private CallDataCopyOperation callDataCopyOperation;

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
@@ -16,8 +16,10 @@ package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CallDataCopyOperation;
 
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -31,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)
@@ -39,6 +42,13 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class CallDataCopyOperationBenchmark {
+
+  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    final long size = Long.parseLong(params.getParam("dataSize"));
+    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
+    frame.expandMemory(0, size);
+    return OptionalLong.of(calc.dataCopyOperationGasCost(frame, 0, size));
+  }
 
   private CallDataCopyOperation callDataCopyOperation;
   protected static final int SAMPLE_SIZE = 30_000;

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
@@ -20,25 +20,6 @@ import java.util.OptionalLong;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public final class GasFormulas {
-
-  private GasFormulas() {}
-
-  public static OptionalLong compute(final BenchmarkParams params, final GasCalculator calc) {
-    final String fqn = params.getBenchmark();
-    if (fqn.endsWith(".baseline")) {
-      return OptionalLong.empty();
-    }
-    final String className = fqn.substring(0, fqn.lastIndexOf('.'));
-    try {
-      final GasCostBenchmark gcb =
-          Class.forName(className)
-              .asSubclass(GasCostBenchmark.class)
-              .getDeclaredConstructor()
-              .newInstance();
-      return gcb.getGasCost(params, calc);
-    } catch (ClassCastException | ReflectiveOperationException e) {
-      return OptionalLong.empty();
-    }
-  }
+public interface GasCostBenchmark {
+  OptionalLong getGasCost(BenchmarkParams params, GasCalculator calc);
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
@@ -16,10 +16,8 @@ package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.util.OptionalLong;
-
 import org.openjdk.jmh.infra.BenchmarkParams;
 
 public interface GasCostBenchmark {
-  OptionalLong getGasCost(BenchmarkParams params, GasCalculator calc);
+  long getGasCost(BenchmarkParams params, GasCalculator calc);
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import java.util.OptionalLong;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+/** Per-benchmark gas-cost formulas keyed by the JMH benchmark-method FQN. */
+public final class GasFormulas {
+
+  private GasFormulas() {}
+
+  /**
+   * Compute the static gas cost of one benchmark invocation.
+   *
+   * @param params the JMH benchmark params carrying the FQN and all {@code @Param} values
+   * @return an {@link OptionalLong} carrying the gas cost, or empty if the benchmark is not mapped
+   */
+  public static OptionalLong compute(final BenchmarkParams params) {
+    final String benchmark = params.getBenchmark();
+
+    if (benchmark.endsWith(".CallDataCopyOperationBenchmark.executeOperation")) {
+      final int dataSize = Integer.parseInt(params.getParam("dataSize"));
+      return OptionalLong.of(3L + 3L * ((dataSize + 31) / 32));
+    }
+
+    if (benchmark.endsWith(".Keccak256Benchmark.executeOperation")) {
+      final int inputSize = Integer.parseInt(params.getParam("inputSize"));
+      return OptionalLong.of(30L + 6L * ((inputSize + 31) / 32));
+    }
+
+    if (benchmark.endsWith(".SHA256Benchmark.sha256")) {
+      final int inputSize = Integer.parseInt(params.getParam("inputSize"));
+      return OptionalLong.of(60L + 12L * ((inputSize + 31) / 32));
+    }
+
+    return OptionalLong.empty();
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
@@ -14,39 +14,62 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
-import java.util.OptionalLong;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.function.BiFunction;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-/** Per-benchmark gas-cost formulas keyed by the JMH benchmark-method FQN. */
 public final class GasFormulas {
 
   private GasFormulas() {}
 
-  /**
-   * Compute the static gas cost of one benchmark invocation.
-   *
-   * @param params the JMH benchmark params carrying the FQN and all {@code @Param} values
-   * @return an {@link OptionalLong} carrying the gas cost, or empty if the benchmark is not mapped
-   */
-  public static OptionalLong compute(final BenchmarkParams params) {
-    final String benchmark = params.getBenchmark();
+  private static final Map<Class<?>, BiFunction<BenchmarkParams, GasCalculator, OptionalLong>>
+      REGISTRY =
+          Map.of(
+              CallDataCopyOperationBenchmark.class, GasFormulas::callDataCopyGas,
+              Keccak256Benchmark.class, GasFormulas::keccak256Gas,
+              SHA256Benchmark.class, GasFormulas::sha256Gas,
+              AddOperationBenchmark.class,
+                  (p, calc) -> OptionalLong.of(calc.getVeryLowTierGasCost()));
 
-    if (benchmark.endsWith(".CallDataCopyOperationBenchmark.executeOperation")) {
-      final int dataSize = Integer.parseInt(params.getParam("dataSize"));
-      return OptionalLong.of(3L + 3L * ((dataSize + 31) / 32));
+  public static OptionalLong compute(final BenchmarkParams params, final GasCalculator calc) {
+    final String fqn = params.getBenchmark();
+    if (fqn.endsWith(".baseline")) {
+      return OptionalLong.empty();
     }
-
-    if (benchmark.endsWith(".Keccak256Benchmark.executeOperation")) {
-      final int inputSize = Integer.parseInt(params.getParam("inputSize"));
-      return OptionalLong.of(30L + 6L * ((inputSize + 31) / 32));
+    final String className = fqn.substring(0, fqn.lastIndexOf('.'));
+    try {
+      final Class<?> clazz = Class.forName(className);
+      final BiFunction<BenchmarkParams, GasCalculator, OptionalLong> formula = REGISTRY.get(clazz);
+      return formula != null ? formula.apply(params, calc) : OptionalLong.empty();
+    } catch (ClassNotFoundException e) {
+      return OptionalLong.empty();
     }
+  }
 
-    if (benchmark.endsWith(".SHA256Benchmark.sha256")) {
-      final int inputSize = Integer.parseInt(params.getParam("inputSize"));
-      return OptionalLong.of(60L + 12L * ((inputSize + 31) / 32));
-    }
+  private static OptionalLong callDataCopyGas(
+      final BenchmarkParams params, final GasCalculator calc) {
+    final long dataSize = Long.parseLong(params.getParam("dataSize"));
+    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
+    frame.expandMemory(0, dataSize);
+    return OptionalLong.of(calc.dataCopyOperationGasCost(frame, 0, dataSize));
+  }
 
-    return OptionalLong.empty();
+  private static OptionalLong keccak256Gas(
+      final BenchmarkParams params, final GasCalculator calc) {
+    final long inputSize = Long.parseLong(params.getParam("inputSize"));
+    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
+    frame.expandMemory(0, inputSize);
+    return OptionalLong.of(calc.keccak256OperationGasCost(frame, 0, inputSize));
+  }
+
+  private static OptionalLong sha256Gas(final BenchmarkParams params, final GasCalculator calc) {
+    final int inputSize = Integer.parseInt(params.getParam("inputSize"));
+    return OptionalLong.of(calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[inputSize])));
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
@@ -36,7 +36,7 @@ public final class GasFormulas {
               .asSubclass(GasCostBenchmark.class)
               .getDeclaredConstructor()
               .newInstance();
-      return gcb.getGasCost(params, calc);
+      return OptionalLong.of(gcb.getGasCost(params, calc));
     } catch (ClassCastException | ReflectiveOperationException e) {
       return OptionalLong.empty();
     }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
@@ -14,14 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
-import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.function.BiFunction;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
 public final class GasFormulas {
@@ -31,11 +29,10 @@ public final class GasFormulas {
   private static final Map<Class<?>, BiFunction<BenchmarkParams, GasCalculator, OptionalLong>>
       REGISTRY =
           Map.of(
-              CallDataCopyOperationBenchmark.class, GasFormulas::callDataCopyGas,
-              Keccak256Benchmark.class, GasFormulas::keccak256Gas,
-              SHA256Benchmark.class, GasFormulas::sha256Gas,
-              AddOperationBenchmark.class,
-                  (p, calc) -> OptionalLong.of(calc.getVeryLowTierGasCost()));
+              CallDataCopyOperationBenchmark.class, CallDataCopyOperationBenchmark::getGasCost,
+              Keccak256Benchmark.class, Keccak256Benchmark::getGasCost,
+              SHA256Benchmark.class, SHA256Benchmark::getGasCost,
+              AddOperationBenchmark.class, AddOperationBenchmark::getGasCost);
 
   public static OptionalLong compute(final BenchmarkParams params, final GasCalculator calc) {
     final String fqn = params.getBenchmark();
@@ -50,26 +47,5 @@ public final class GasFormulas {
     } catch (ClassNotFoundException e) {
       return OptionalLong.empty();
     }
-  }
-
-  private static OptionalLong callDataCopyGas(
-      final BenchmarkParams params, final GasCalculator calc) {
-    final long dataSize = Long.parseLong(params.getParam("dataSize"));
-    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
-    frame.expandMemory(0, dataSize);
-    return OptionalLong.of(calc.dataCopyOperationGasCost(frame, 0, dataSize));
-  }
-
-  private static OptionalLong keccak256Gas(
-      final BenchmarkParams params, final GasCalculator calc) {
-    final long inputSize = Long.parseLong(params.getParam("inputSize"));
-    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
-    frame.expandMemory(0, inputSize);
-    return OptionalLong.of(calc.keccak256OperationGasCost(frame, 0, inputSize));
-  }
-
-  private static OptionalLong sha256Gas(final BenchmarkParams params, final GasCalculator calc) {
-    final int inputSize = Integer.parseInt(params.getParam("inputSize"));
-    return OptionalLong.of(calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[inputSize])));
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.vm.operations;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
+/**
+ * JMH {@link InternalProfiler} that publishes the per-benchmark gas cost as a secondary metric
+ * named {@code gas}. Runs outside the measurement window so it cannot affect the recorded ns/op
+ * score.
+ */
+public class GasProfiler implements InternalProfiler {
+
+  @Override
+  public String getDescription() {
+    return "Emits per-benchmark gas cost as a secondary metric named 'gas'";
+  }
+
+  @Override
+  public void beforeIteration(
+      final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {}
+
+  @Override
+  public Collection<? extends Result<?>> afterIteration(
+      final BenchmarkParams benchmarkParams,
+      final IterationParams iterationParams,
+      final IterationResult result) {
+    final OptionalLong gas = GasFormulas.compute(benchmarkParams);
+    if (gas.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return List.of(new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
+  }
+}

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -70,7 +70,8 @@ public class GasProfiler implements ExternalProfiler {
     try {
       gasCalculator = gasCalculatorForFork(fork);
     } catch (IllegalArgumentException e) {
-      throw new ProfilerException("Unknown fork: " + fork + ". Must be a valid EvmSpecVersion name.");
+      throw new ProfilerException(
+          "Unknown fork: " + fork + ". Must be a valid EvmSpecVersion name.");
     }
   }
 
@@ -117,8 +118,7 @@ public class GasProfiler implements ExternalProfiler {
     if (gas.isEmpty()) {
       return Collections.emptyList();
     }
-    return List.of(
-        new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
+    return List.of(new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -110,7 +110,9 @@ public class GasProfiler implements ExternalProfiler {
   }
 
   @Override
-  public void beforeTrial(final BenchmarkParams params) {}
+  public void beforeTrial(final BenchmarkParams params) {
+    System.out.printf("[GasProfiler] fork=%s%n", fork);
+  }
 
   @Override
   public Collection<? extends Result<?>> afterTrial(

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -51,8 +51,8 @@ import org.openjdk.jmh.runner.IterationType;
 
 /**
  * JMH {@link InternalProfiler} that publishes the benchmark's gas throughput as a secondary metric
- * named {@code mgas_per_s} in MGas/s, derived from each measurement iteration's primary score and the gas
- * cost computed with Besu's own {@link GasCalculator}.
+ * named {@code mgas_per_s} in MGas/s, derived from each measurement iteration's primary score and
+ * the gas cost computed with Besu's own {@link GasCalculator}.
  *
  * <p>Run with: {@code ./gradlew :ethereum:core:jmh -PgasProfiler=true}
  *
@@ -64,8 +64,10 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
   private final GasCalculator gasCalculator;
   private final String fork;
 
-  // Field seen by the InternalProfiler - ExternalProfiler side never sees the field as it runs in another JVM instance.
-  // Lazily populates the gas cost only once, then only computes gas related results if it is optionally available.
+  // Field seen by the InternalProfiler - ExternalProfiler side never sees the field as it runs in
+  // another JVM instance.
+  // Lazily populates the gas cost only once, then only computes gas related results if it is
+  // optionally available.
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private OptionalLong trialGasCost;
 
@@ -130,7 +132,10 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
         result.getPrimaryResult().getScore() * benchmarkParams.getTimeUnit().toNanos(1);
     return List.of(
         new ScalarResult(
-            "mgas_per_s", 1000 * trialGasCost.getAsLong() / nsPerOp, "MGas/s", AggregationPolicy.AVG));
+            "mgas_per_s",
+            1000 * trialGasCost.getAsLong() / nsPerOp,
+            "MGas/s",
+            AggregationPolicy.AVG));
   }
 
   @Override
@@ -152,7 +157,8 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
   }
 
   @Override
-  public Collection<? extends Result<?>> afterTrial(final BenchmarkResult br, final long pid, final File stdOut, final File stdErr) {
+  public Collection<? extends Result<?>> afterTrial(
+      final BenchmarkResult br, final long pid, final File stdOut, final File stdErr) {
     return Collections.emptyList();
   }
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -46,8 +46,9 @@ import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.ScalarResult;
 
 /**
- * JMH {@link ExternalProfiler} that publishes the per-benchmark gas cost as a secondary metric
- * named {@code gas}, computed once per trial using Besu's own {@link GasCalculator}.
+ * JMH {@link ExternalProfiler} that publishes two secondary metrics per benchmark trial: {@code
+ * gas} (the EVM gas cost derived from Besu's own {@link GasCalculator}) and {@code mgas_per_s}
+ * (throughput in MGas/s, computed as {@code gas × 1e3 / ns_per_op}).
  *
  * <p>Run with: {@code ./gradlew :ethereum:core:jmh -PgasProfiler=true}
  *
@@ -96,7 +97,7 @@ public class GasProfiler implements ExternalProfiler {
 
   @Override
   public String getDescription() {
-    return "Emits per-benchmark gas cost as secondary metric 'gas' using " + fork + " gas rules";
+    return "Emits 'gas' and 'mgas_per_s' secondary metrics using " + fork + " gas rules";
   }
 
   @Override
@@ -121,7 +122,15 @@ public class GasProfiler implements ExternalProfiler {
     if (gas.isEmpty()) {
       return Collections.emptyList();
     }
-    return List.of(new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
+    final double gasValue = (double) gas.getAsLong();
+    final double primaryScore = br.getPrimaryResult().getScore();
+    if (Double.isFinite(primaryScore) && primaryScore > 0) {
+      return List.of(
+          new ScalarResult("gas", gasValue, "gas", AggregationPolicy.AVG),
+          new ScalarResult(
+              "mgas_per_s", gasValue * 1e3 / primaryScore, "MGas/s", AggregationPolicy.AVG));
+    }
+    return List.of(new ScalarResult("gas", gasValue, "gas", AggregationPolicy.AVG));
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -38,27 +38,36 @@ import java.util.Locale;
 import java.util.OptionalLong;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.profile.ExternalProfiler;
+import org.openjdk.jmh.profile.InternalProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
 import org.openjdk.jmh.results.AggregationPolicy;
 import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.ScalarResult;
+import org.openjdk.jmh.runner.IterationType;
 
 /**
- * JMH {@link ExternalProfiler} that publishes two secondary metrics per benchmark trial: {@code
- * gas} (the EVM gas cost derived from Besu's own {@link GasCalculator}) and {@code mgas_per_s}
- * (throughput in MGas/s, computed as {@code gas × 1e3 / ns_per_op}).
+ * JMH {@link InternalProfiler} that publishes the benchmark's gas throughput as a secondary metric
+ * named {@code mgas_per_s} in MGas/s, derived from each measurement iteration's primary score and the gas
+ * cost computed with Besu's own {@link GasCalculator}.
  *
  * <p>Run with: {@code ./gradlew :ethereum:core:jmh -PgasProfiler=true}
  *
  * <p>To specify the EVM fork (defaults to OSAKA): {@code ./gradlew :ethereum:core:jmh
  * -PgasProfiler=true -PgasProfilerFork=CANCUN}
  */
-public class GasProfiler implements ExternalProfiler {
+public class GasProfiler implements InternalProfiler, ExternalProfiler {
 
   private final GasCalculator gasCalculator;
   private final String fork;
+
+  // Field seen by the InternalProfiler - ExternalProfiler side never sees the field as it runs in another JVM instance.
+  // Lazily populates the gas cost only once, then only computes gas related results if it is optionally available.
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private OptionalLong trialGasCost;
 
   public GasProfiler() throws ProfilerException {
     this("");
@@ -97,7 +106,31 @@ public class GasProfiler implements ExternalProfiler {
 
   @Override
   public String getDescription() {
-    return "Emits 'gas' and 'mgas_per_s' secondary metrics using " + fork + " gas rules";
+    return "Emits per-benchmark 'mgas_per_s' as secondary metric using " + fork + " gas rules";
+  }
+
+  @Override
+  @SuppressWarnings("OptionalAssignedToNull")
+  public void beforeIteration(
+      final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {
+    if (trialGasCost == null) {
+      trialGasCost = GasFormulas.compute(benchmarkParams, gasCalculator);
+    }
+  }
+
+  @Override
+  public Collection<? extends Result<?>> afterIteration(
+      final BenchmarkParams benchmarkParams,
+      final IterationParams iterationParams,
+      final IterationResult result) {
+    if (iterationParams.getType() != IterationType.MEASUREMENT || trialGasCost.isEmpty()) {
+      return Collections.emptyList();
+    }
+    final double nsPerOp =
+        result.getPrimaryResult().getScore() * benchmarkParams.getTimeUnit().toNanos(1);
+    return List.of(
+        new ScalarResult(
+            "mgas_per_s", 1000 * trialGasCost.getAsLong() / nsPerOp, "MGas/s", AggregationPolicy.AVG));
   }
 
   @Override
@@ -111,35 +144,25 @@ public class GasProfiler implements ExternalProfiler {
   }
 
   @Override
-  public void beforeTrial(final BenchmarkParams params) {
-    System.out.printf("[GasProfiler] fork=%s%n", fork);
+  public void beforeTrial(final BenchmarkParams benchmarkParams) {
+    final OptionalLong gasCost = GasFormulas.compute(benchmarkParams, gasCalculator);
+    System.out.printf(
+        "\n# GasProfiler: fork=%s%s%n",
+        fork, gasCost.isPresent() ? ", gasCost=" + gasCost.getAsLong() : "");
   }
 
   @Override
-  public Collection<? extends Result<?>> afterTrial(
-      final BenchmarkResult br, final long pid, final File stdOut, final File stdErr) {
-    final OptionalLong gas = GasFormulas.compute(br.getParams(), gasCalculator);
-    if (gas.isEmpty()) {
-      return Collections.emptyList();
-    }
-    final double gasValue = (double) gas.getAsLong();
-    final double primaryScore = br.getPrimaryResult().getScore();
-    if (Double.isFinite(primaryScore) && primaryScore > 0) {
-      return List.of(
-          new ScalarResult("gas", gasValue, "gas", AggregationPolicy.AVG),
-          new ScalarResult(
-              "mgas_per_s", gasValue * 1e3 / primaryScore, "MGas/s", AggregationPolicy.AVG));
-    }
-    return List.of(new ScalarResult("gas", gasValue, "gas", AggregationPolicy.AVG));
+  public Collection<? extends Result<?>> afterTrial(final BenchmarkResult br, final long pid, final File stdOut, final File stdErr) {
+    return Collections.emptyList();
   }
 
   @Override
   public boolean allowPrintOut() {
-    return true;
+    return false;
   }
 
   @Override
   public boolean allowPrintErr() {
-    return true;
+    return false;
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -14,44 +14,120 @@
  */
 package org.hyperledger.besu.ethereum.vm.operations;
 
+import org.hyperledger.besu.evm.EvmSpecVersion;
+import org.hyperledger.besu.evm.gascalculator.BerlinGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.ByzantiumGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.FrontierGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.gascalculator.HomesteadGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.IstanbulGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.OsakaGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.ShanghaiGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.SpuriousDragonGasCalculator;
+
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.OptionalLong;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
-import org.openjdk.jmh.infra.IterationParams;
-import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.profile.ExternalProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
 import org.openjdk.jmh.results.AggregationPolicy;
-import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.BenchmarkResult;
 import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.ScalarResult;
 
 /**
- * JMH {@link InternalProfiler} that publishes the per-benchmark gas cost as a secondary metric
- * named {@code gas}. Runs outside the measurement window so it cannot affect the recorded ns/op
- * score.
+ * JMH {@link ExternalProfiler} that publishes the per-benchmark gas cost as a secondary metric
+ * named {@code gas}, computed once per trial using Besu's own {@link GasCalculator}.
+ *
+ * <p>Run with: {@code ./gradlew :ethereum:core:jmh -Pprofiler=gas}
+ *
+ * <p>To select a different fork: {@code -Pprofiler=gas:cancun}
  */
-public class GasProfiler implements InternalProfiler {
+public class GasProfiler implements ExternalProfiler {
 
-  @Override
-  public String getDescription() {
-    return "Emits per-benchmark gas cost as a secondary metric named 'gas'";
+  private final GasCalculator gasCalculator;
+  private final String fork;
+
+  public GasProfiler() throws ProfilerException {
+    this("");
+  }
+
+  public GasProfiler(final String initLine) throws ProfilerException {
+    fork =
+        (initLine == null || initLine.isBlank())
+            ? "OSAKA"
+            : initLine.trim().toUpperCase(Locale.ROOT);
+    try {
+      gasCalculator = gasCalculatorForFork(fork);
+    } catch (IllegalArgumentException e) {
+      throw new ProfilerException("Unknown fork: " + fork + ". Must be a valid EvmSpecVersion name.");
+    }
+  }
+
+  private static GasCalculator gasCalculatorForFork(final String fork) {
+    return switch (EvmSpecVersion.valueOf(fork)) {
+      case FRONTIER -> new FrontierGasCalculator();
+      case HOMESTEAD -> new HomesteadGasCalculator();
+      case SPURIOUS_DRAGON -> new SpuriousDragonGasCalculator();
+      case BYZANTIUM -> new ByzantiumGasCalculator();
+      case CONSTANTINOPLE -> new ConstantinopleGasCalculator();
+      case PETERSBURG -> new PetersburgGasCalculator();
+      case ISTANBUL -> new IstanbulGasCalculator();
+      case BERLIN -> new BerlinGasCalculator();
+      case LONDON, PARIS -> new LondonGasCalculator();
+      case SHANGHAI -> new ShanghaiGasCalculator();
+      case CANCUN -> new CancunGasCalculator();
+      case PRAGUE -> new PragueGasCalculator();
+      default -> new OsakaGasCalculator();
+    };
   }
 
   @Override
-  public void beforeIteration(
-      final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {}
+  public String getDescription() {
+    return "Emits per-benchmark gas cost as secondary metric 'gas' using " + fork + " gas rules";
+  }
 
   @Override
-  public Collection<? extends Result<?>> afterIteration(
-      final BenchmarkParams benchmarkParams,
-      final IterationParams iterationParams,
-      final IterationResult result) {
-    final OptionalLong gas = GasFormulas.compute(benchmarkParams);
+  public Collection<String> addJVMInvokeOptions(final BenchmarkParams params) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<String> addJVMOptions(final BenchmarkParams params) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void beforeTrial(final BenchmarkParams params) {}
+
+  @Override
+  public Collection<? extends Result<?>> afterTrial(
+      final BenchmarkResult br, final long pid, final File stdOut, final File stdErr) {
+    final OptionalLong gas = GasFormulas.compute(br.getParams(), gasCalculator);
     if (gas.isEmpty()) {
       return Collections.emptyList();
     }
-    return List.of(new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
+    return List.of(
+        new ScalarResult("gas", (double) gas.getAsLong(), "gas", AggregationPolicy.AVG));
+  }
+
+  @Override
+  public boolean allowPrintOut() {
+    return true;
+  }
+
+  @Override
+  public boolean allowPrintErr() {
+    return true;
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -49,9 +49,7 @@ import org.openjdk.jmh.results.ScalarResult;
  * JMH {@link ExternalProfiler} that publishes the per-benchmark gas cost as a secondary metric
  * named {@code gas}, computed once per trial using Besu's own {@link GasCalculator}.
  *
- * <p>Run with: {@code ./gradlew :ethereum:core:jmh -Pprofiler=gas}
- *
- * <p>To select a different fork: {@code -Pprofiler=gas:cancun}
+ * <p>Run with: {@code ./gradlew :ethereum:core:jmh -PgasProfiler=true}
  */
 public class GasProfiler implements ExternalProfiler {
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -50,6 +50,9 @@ import org.openjdk.jmh.results.ScalarResult;
  * named {@code gas}, computed once per trial using Besu's own {@link GasCalculator}.
  *
  * <p>Run with: {@code ./gradlew :ethereum:core:jmh -PgasProfiler=true}
+ *
+ * <p>To specify the EVM fork (defaults to OSAKA): {@code ./gradlew :ethereum:core:jmh
+ * -PgasProfiler=true -PgasProfilerFork=CANCUN}
  */
 public class GasProfiler implements ExternalProfiler {
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -43,11 +42,11 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 public class Keccak256Benchmark implements GasCostBenchmark {
 
   @Override
-  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final long size = Long.parseLong(params.getParam("inputSize"));
     final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
     frame.expandMemory(0, size);
-    return OptionalLong.of(calc.keccak256OperationGasCost(frame, 0, size));
+    return calc.keccak256OperationGasCost(frame, 0, size);
   }
 
   @Param({"32", "64", "128", "256", "512"})

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
@@ -15,7 +15,10 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.crypto.Hash;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -30,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -37,6 +41,13 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class Keccak256Benchmark {
+
+  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    final long size = Long.parseLong(params.getParam("inputSize"));
+    final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
+    frame.expandMemory(0, size);
+    return OptionalLong.of(calc.keccak256OperationGasCost(frame, 0, size));
+  }
 
   @Param({"32", "64", "128", "256", "512"})
   private String inputSize;

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
@@ -40,9 +40,10 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class Keccak256Benchmark {
+public class Keccak256Benchmark implements GasCostBenchmark {
 
-  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  @Override
+  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final long size = Long.parseLong(params.getParam("inputSize"));
     final MessageFrame frame = BenchmarkHelper.createMessageCallFrame();
     frame.expandMemory(0, size);

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
@@ -15,7 +15,9 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.crypto.Hash;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +33,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -38,6 +41,11 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class SHA256Benchmark {
+
+  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    final int size = Integer.parseInt(params.getParam("inputSize"));
+    return OptionalLong.of(calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[size])));
+  }
 
   @Param({"32", "64", "128", "256", "512", "1024", "2048", "4096"})
   private String inputSize;

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
@@ -40,9 +40,10 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class SHA256Benchmark {
+public class SHA256Benchmark implements GasCostBenchmark {
 
-  public static OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  @Override
+  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final int size = Integer.parseInt(params.getParam("inputSize"));
     return OptionalLong.of(calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[size])));
   }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.vm.operations;
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -43,9 +42,9 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 public class SHA256Benchmark implements GasCostBenchmark {
 
   @Override
-  public OptionalLong getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
     final int size = Integer.parseInt(params.getParam("inputSize"));
-    return OptionalLong.of(calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[size])));
+    return calc.sha256PrecompiledContractGasCost(Bytes.wrap(new byte[size]));
   }
 
   @Param({"32", "64", "128", "256", "512", "1024", "2048", "4096"})

--- a/ethereum/core/src/jmh/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/ethereum/core/src/jmh/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,1 @@
+org.hyperledger.besu.ethereum.vm.operations.GasProfiler

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractFixedCostOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractFixedCostOperation.java
@@ -37,6 +37,15 @@ abstract class AbstractFixedCostOperation extends AbstractOperation {
   protected final long gasCost;
 
   /**
+   * Returns the fixed gas cost of this operation.
+   *
+   * @return the gas cost
+   */
+  public long getGasCost() {
+    return gasCost;
+  }
+
+  /**
    * Instantiates a new Abstract fixed cost operation.
    *
    * @param opcode the opcode


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Introduces GasProfiler, a JMH ExternalProfiler that publishes per-benchmark gas cost as a secondaryMetrics.gas value in results.json, sourced from Besu's own GasCalculator methods  so downstream tooling can compute MGas/s for dynamic-gas benchmarks without duplicating formulas outside Besu.

What changed from the original:
- Switched from InternalProfiler to ExternalProfiler so gas is computed once per trial outside the timed execution path, not per iteration
- Gas formulas live on each benchmark class via the GasCostBenchmark interface; GasFormulas.compute() dispatches via reflection — no registry map, no hardcoded values
-  Fork is configurable via -PgasProfilerFork=<fork> e.g. CANCUN, defaulting to OSAKA; gasCalculatorForFork() is the single place to update when the latest fork changes
- Added AddOperationBenchmark as a static-gas example VeryLowTier = 3 gas
- Currently wired: CallDataCopyOperationBenchmark, Keccak256Benchmark, SHA256Benchmark, AddOperationBenchmark

Run
./gradlew :ethereum:core:jmh -PgasProfiler=true
 Select fork:
./gradlew :ethereum:core:jmh -PgasProfiler=true -PgasProfilerFork=CANCUN

## Example output (Osaka, full run)

### CallDataCopyOperationBenchmark

| Benchmark | `dataSize` | Score | `·gas` |
|-----------|-----------:|------:|-------:|
| `CallDataCopyOperationBenchmark.executeOperation` | 0 | ~ns | 3 |
| `CallDataCopyOperationBenchmark.executeOperation` | 100 | ~ns | 15 |
| `CallDataCopyOperationBenchmark.executeOperation` | 10240 | ~ns | 963 |
| `CallDataCopyOperationBenchmark.executeOperation` | 1048576 | ~ns | 98307 |

### Keccak256Benchmark

| Benchmark | `inputSize` | Score | `·gas` |
|-----------|------------:|------:|-------:|
| `Keccak256Benchmark.executeOperation` | 32 | ~ns | 36 |
| `Keccak256Benchmark.executeOperation` | 64 | ~ns | 42 |
| `Keccak256Benchmark.executeOperation` | 128 | ~ns | 54 |
| `Keccak256Benchmark.executeOperation` | 256 | ~ns | 78 |
| `Keccak256Benchmark.executeOperation` | 512 | ~ns | 126 |

### SHA256Benchmark

| Benchmark | `inputSize` | Score | `·gas` |
|-----------|------------:|------:|-------:|
| `SHA256Benchmark.sha256` | 32 | ~ns | 72 |
| `SHA256Benchmark.sha256` | 64 | ~ns | 84 |
| `SHA256Benchmark.sha256` | 128 | ~ns | 108 |
| `SHA256Benchmark.sha256` | 256 | ~ns | 156 |
| `SHA256Benchmark.sha256` | 512 | ~ns | 252 |
| `SHA256Benchmark.sha256` | 1024 | ~ns | 444 |
| `SHA256Benchmark.sha256` | 2048 | ~ns | 828 |
| `SHA256Benchmark.sha256` | 4096 | ~ns | 1596 |

### AddOperationBenchmark

| Benchmark | Score | `·gas` |
|-----------|------:|-------:|
| `AddOperationBenchmark.executeOperation` | ~ns | 3 |

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


