### PR TITLE
Check that code delegation authorization list is not empty when using EIP-7702

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Skip DNS discovery records that fail enode conversion (e.g. out-of-range port) instead of dropping the rest of the batch [#10752](https://github.com/besu-eth/besu/pull/10752)
 - Raise the default DiscV5 discovery round timeout (`--Xv5-discovery-timeout-seconds`) from 30 to 60 seconds to avoid spurious round failures on networks with many unreachable candidates [#10800](https://github.com/besu-eth/besu/pull/10800)
 - Fix QBFT/IBFT mining continuing to seal blocks after the merge terminal total difficulty (TTD) is reached [#10733](https://github.com/besu-eth/besu/pull/10733)
+- Reject EIP-7702 code-delegation (type 0x04) transactions with an empty `authorization_list`, which is invalid per the spec. Such transactions are now rejected at build/decode time, and peers that send them (in a transactions broadcast or in a block-bodies response) are disconnected with `BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED`. [#10853](https://github.com/besu-eth/besu/pull/10853)
 
 ### Additions and Improvements
 - Add `--logging-format` CLI option to select structured JSON console logging (`ECS`, `GCP`, `LOGSTASH`, `GELF`) in addition to the default `PLAIN` pattern output, without requiring a custom `LOG4J_CONFIGURATION_FILE`. Each format is a bundled Log4j2 configuration file selected at startup. [#9626](https://github.com/besu-eth/besu/issues/9626)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix `admin_nodeInfo` reporting wrong RLPx/discovery ephemeral ports under `--nat-method=DOCKER`, due to a swapped NAT port mapping and a stale pre-bind snapshot. [#10860](https://github.com/besu-eth/besu/pull/10860)
 - `eth_simulateV1` no longer applies EIP-7825's transaction gas limit cap to simulation gas, fixing incorrect block/transaction hashes on Osaka [#10885](https://github.com/besu-eth/besu/pull/10885)
 - Recover from restart during flatDB heal sync step [#10883](https://github.com/besu-eth/besu/pull/10883)
+- Reject EIP-7702 code-delegation (type 0x04) transactions with an empty `authorization_list`, which is invalid per the spec. Such transactions are now rejected at build/decode time, and peers that send them (in a transactions broadcast or in a block-bodies response) are disconnected with `BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED`. [#10853](https://github.com/besu-eth/besu/pull/10853)
 
 ### Additions and Improvements
 - Align Kotlin runtime dependencies to 2.4.0 to support plugins compiled against the Kotlin 2.4 API. [#10983](https://github.com/besu-eth/besu/pull/10983)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -249,6 +249,9 @@ public class Transaction
         checkArgument(
             maybeCodeDelegationList.isPresent(),
             "Must specify code delegation authorizations for code delegation transaction");
+        checkArgument(
+            !maybeCodeDelegationList.get().isEmpty(),
+            "Code delegation transaction must have at least one authorization");
       }
     }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
@@ -110,6 +110,25 @@ class TransactionBuilderTest {
   }
 
   @Test
+  void zeroCodeDelegationAuthorizationIsInvalid() {
+    TransactionTestFixture ttf =
+        new TransactionTestFixture()
+            .type(TransactionType.DELEGATE_CODE)
+            .chainId(Optional.of(BigInteger.ONE))
+            .codeDelegations(List.of())
+            .maxFeePerGas(Optional.of(Wei.of(5)))
+            .maxPriorityFeePerGas(Optional.of(Wei.of(5)))
+            .maxFeePerBlobGas(Optional.of(Wei.of(5)));
+    try {
+      ttf.createTransaction(senderKeys);
+      fail();
+    } catch (IllegalArgumentException iea) {
+      assertThat(iea)
+          .hasMessage("Code delegation transaction must have at least one authorization");
+    }
+  }
+
+  @Test
   @SuppressWarnings("ReferenceEquality")
   void copyFromIsIdentical() {
     final TransactionTestFixture fixture = new TransactionTestFixture();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
@@ -110,14 +110,15 @@ class TransactionBuilderTest {
   }
 
   @Test
-  void emptyCodeDelegationListIsInvalid() {
+  void zeroCodeDelegationAuthorizationIsInvalid() {
     TransactionTestFixture ttf =
         new TransactionTestFixture()
             .type(TransactionType.DELEGATE_CODE)
             .chainId(Optional.of(BigInteger.ONE))
+            .codeDelegations(List.of())
             .maxFeePerGas(Optional.of(Wei.of(5)))
             .maxPriorityFeePerGas(Optional.of(Wei.of(5)))
-            .codeDelegations(List.of());
+            .maxFeePerBlobGas(Optional.of(Wei.of(5)));
     try {
       ttf.createTransaction(senderKeys);
       fail();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
@@ -123,7 +123,7 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
           .log();
       peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
       promise.completeExceptionally(new PeerBreachedProtocolException());
-    } catch (final RLPException e) {
+    } catch (final RLPException | IllegalArgumentException e) {
       // Peer sent us malformed data - disconnect
       LOG.debug(
           "Disconnecting with BREACH_OF_PROTOCOL due to malformed message: {}",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
@@ -104,7 +104,7 @@ class TransactionsMessageProcessor {
 
       transactionPool.addRemoteTransactions(freshTransactions);
 
-    } catch (final RLPException ex) {
+    } catch (final RLPException | IllegalArgumentException ex) {
       if (peer != null) {
         LOG.debug(
             "Malformed transaction message received (BREACH_OF_PROTOCOL), disconnecting: {}",

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/GetBodiesFromPeerTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/GetBodiesFromPeerTaskTest.java
@@ -23,17 +23,26 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.ethtaskutils.PeerMessageTaskTest;
+import org.hyperledger.besu.ethereum.eth.messages.BlockBodiesMessage;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.Test;
 
 public class GetBodiesFromPeerTaskTest extends PeerMessageTaskTest<List<Block>> {
+
+  private static final Bytes MALFORMED_BODIES_RLP =
+      Bytes.fromHexString(
+          "0xf871b86f04f86c83301824800285012a05f2008307a1209471562b71999873db5b286df957af199ec94617f78080c0c080a0df13441160d9e36a96c4f27f7be42f0a67de1b27345d32e562d7a7e80cc61332a04160c3339755fd0f41d852dff56da6b71a975eda6fefdf1d00ba6d8b3ce3e0d2");
 
   @Override
   protected List<Block> generateDataToBeRequested() {
@@ -79,5 +88,22 @@ public class GetBodiesFromPeerTaskTest extends PeerMessageTaskTest<List<Block>> 
     assertThat(
             new BodyIdentifier(emptyBodyBlock).equals(new BodyIdentifier(bodyBlockWithWithdrawal)))
         .isFalse();
+  }
+
+  @Test
+  public void disconnectsPeerWhenBodyContainsEmptyAuthorizationListCodeDelegationTx() {
+    final RespondingEthPeer respondingPeer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 32);
+
+    final List<Block> requestedData = generateDataToBeRequested();
+    final EthTask<AbstractPeerTask.PeerTaskResult<List<Block>>> task = createTask(requestedData);
+    final CompletableFuture<?> future = task.run();
+
+    final RespondingEthPeer.Responder malformed =
+        (cap, peer, msg) -> Optional.of(BlockBodiesMessage.createUnsafe(MALFORMED_BODIES_RLP));
+    respondingPeer.respondWhile(malformed, () -> !future.isDone());
+
+    assertThat(respondingPeer.getPeerConnection().isDisconnected()).isTrue();
+    assertThat(future).isCompletedExceptionally();
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
@@ -59,6 +59,9 @@ public class TransactionsMessageProcessorTest {
   private static final Bytes TRANSACTIONS_MESSAGE_WITH_AUTHORIZATION_CHAIN_ID_OVERFLOW =
       Bytes.fromHexString(
           "0xf9014db9014a04f9014683301824800285012a05f2008307a1209471562b71999873db5b286df957af199ec94617f78080c0f8d9f87ba101000000000000000000000000000000000000000000000000000000000000000094000000000000000000000000000000000000aaaa0101a0f7e3e597fc097e71ed6c26b14b25e5395bc8510d58b9136af439e12715f2d721a06cf7c3d7939bfdb784373effc0ebb0bd7549691a513f395e3cdabf8602724987f85a8094000000000000000000000000000000000000bbbb8001a05011890f198f0356a887b0779bde5afa1ed04e6acb1e3f37f8f18c7b6f521b98a056c3fa3456b103f3ef4a0acb4b647b9cab9ec4bc68fbcdf1e10b49fb2bcbcf6180a0df13441160d9e36a96c4f27f7be42f0a67de1b27345d32e562d7a7e80cc61332a04160c3339755fd0f41d852dff56da6b71a975eda6fefdf1d00ba6d8b3ce3e0d2");
+  private static final Bytes TRANSACTIONS_MESSAGE_WITH_EMPTY_AUTHORIZATION_LIST =
+      Bytes.fromHexString(
+          "0xf871b86f04f86c83301824800285012a05f2008307a1209471562b71999873db5b286df957af199ec94617f78080c0c080a0df13441160d9e36a96c4f27f7be42f0a67de1b27345d32e562d7a7e80cc61332a04160c3339755fd0f41d852dff56da6b71a975eda6fefdf1d00ba6d8b3ce3e0d2");
 
   private TransactionsMessageProcessor messageHandler;
   private StubMetricsSystem metricsSystem;
@@ -169,6 +172,21 @@ public class TransactionsMessageProcessorTest {
             new RawMessage(
                 EthProtocolMessages.TRANSACTIONS,
                 TRANSACTIONS_MESSAGE_WITH_AUTHORIZATION_CHAIN_ID_OVERFLOW));
+
+    messageHandler.processTransactionsMessage(peer1, transactionsMessage, now(), ofMinutes(1));
+
+    verify(peer1).disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
+    verifyNoInteractions(transactionPool);
+    verifyNoInteractions(transactionTracker);
+  }
+
+  @Test
+  public void shouldDisconnectPeerWhenCodeDelegationAuthorizationListIsEmpty() {
+    final TransactionsMessage transactionsMessage =
+        TransactionsMessage.readFrom(
+            new RawMessage(
+                EthProtocolMessages.TRANSACTIONS,
+                TRANSACTIONS_MESSAGE_WITH_EMPTY_AUTHORIZATION_LIST));
 
     messageHandler.processTransactionsMessage(peer1, transactionsMessage, now(), ofMinutes(1));
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
@@ -61,6 +61,9 @@ public class TransactionsMessageProcessorTest {
   private static final Bytes TRANSACTIONS_MESSAGE_WITH_AUTHORIZATION_CHAIN_ID_OVERFLOW =
       Bytes.fromHexString(
           "0xf9014db9014a04f9014683301824800285012a05f2008307a1209471562b71999873db5b286df957af199ec94617f78080c0f8d9f87ba101000000000000000000000000000000000000000000000000000000000000000094000000000000000000000000000000000000aaaa0101a0f7e3e597fc097e71ed6c26b14b25e5395bc8510d58b9136af439e12715f2d721a06cf7c3d7939bfdb784373effc0ebb0bd7549691a513f395e3cdabf8602724987f85a8094000000000000000000000000000000000000bbbb8001a05011890f198f0356a887b0779bde5afa1ed04e6acb1e3f37f8f18c7b6f521b98a056c3fa3456b103f3ef4a0acb4b647b9cab9ec4bc68fbcdf1e10b49fb2bcbcf6180a0df13441160d9e36a96c4f27f7be42f0a67de1b27345d32e562d7a7e80cc61332a04160c3339755fd0f41d852dff56da6b71a975eda6fefdf1d00ba6d8b3ce3e0d2");
+  private static final Bytes TRANSACTIONS_MESSAGE_WITH_EMPTY_AUTHORIZATION_LIST =
+      Bytes.fromHexString(
+          "0xf871b86f04f86c83301824800285012a05f2008307a1209471562b71999873db5b286df957af199ec94617f78080c0c080a0df13441160d9e36a96c4f27f7be42f0a67de1b27345d32e562d7a7e80cc61332a04160c3339755fd0f41d852dff56da6b71a975eda6fefdf1d00ba6d8b3ce3e0d2");
 
   private TransactionsMessageProcessor messageHandler;
   private StubMetricsSystem metricsSystem;
@@ -185,6 +188,21 @@ public class TransactionsMessageProcessorTest {
             new RawMessage(
                 EthProtocolMessages.TRANSACTIONS,
                 TRANSACTIONS_MESSAGE_WITH_AUTHORIZATION_CHAIN_ID_OVERFLOW));
+
+    messageHandler.processTransactionsMessage(peer1, transactionsMessage, now(), ofMinutes(1));
+
+    verify(peer1).disconnect(DisconnectReason.BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED);
+    verifyNoInteractions(transactionPool);
+    verifyNoInteractions(transactionTracker);
+  }
+
+  @Test
+  public void shouldDisconnectPeerWhenCodeDelegationAuthorizationListIsEmpty() {
+    final TransactionsMessage transactionsMessage =
+        TransactionsMessage.readFrom(
+            new RawMessage(
+                EthProtocolMessages.TRANSACTIONS,
+                TRANSACTIONS_MESSAGE_WITH_EMPTY_AUTHORIZATION_LIST));
 
     messageHandler.processTransactionsMessage(peer1, transactionsMessage, now(), ofMinutes(1));
 


### PR DESCRIPTION
## PR description

EIP-7702 (set-code / code-delegation transactions, type 0x04) requires the authorization list to contain at least one authorization tuple — an empty list is invalid per the spec. Previously Besu only checked that the authorization list was present, but not that it was non-empty, when building a DELEGATE_CODE transaction. This PR adds that validation and ensures peers sending such malformed transactions are disconnected.                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  **Changes**                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  _Core validation (Transaction.java)_                                                                                                                                                                             
  - Added a check in the transaction builder so that a code-delegation transaction with an empty authorization list is rejected with IllegalArgumentException: "Code delegation transaction must have at least one authorization". This complements the existing "must be present" check.                                                                                                                                     
                                                                                                                                                                                                                 
  _Networking / malformed-message handling_                                                                                                                                                                        
  - TransactionsMessageProcessor: extended the catch to also handle IllegalArgumentException (in addition to RLPException), so a peer sending a code-delegation tx with an empty authorization list triggers a   BREACH_OF_PROTOCOL_MALFORMED_MESSAGE_RECEIVED disconnect instead of propagating an error.                                                                                                                      
  - AbstractPeerRequestTask: same treatment — an IllegalArgumentException raised while decoding a peer response (e.g. block bodies containing such a tx) now results in a protocol-breach disconnect.            
                                                                                                                                                                                                                 
  **Tests**                                                                                                                                                                                                          
  - TransactionBuilderTest.zeroCodeDelegationAuthorizationIsInvalid — verifies the builder rejects an empty authorization list.                                                                                  
  - TransactionsMessageProcessorTest.shouldDisconnectPeerWhenCodeDelegationAuthorizationListIsEmpty — verifies a peer is disconnected when it broadcasts a transactions message containing a code-delegation tx with an empty authorization list.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


