### PR TITLE
feat(core): support explicit operation tracer in block processing

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 
 import java.util.List;
 import java.util.Optional;
@@ -86,6 +87,31 @@ public interface BlockValidator {
       final Optional<BlockAccessList> blockAccessList,
       final boolean shouldPersist,
       final boolean shouldRecordBadBlock);
+
+  /**
+   * Validates and processes a block with an explicit operation tracer, bypassing the plugin-based
+   * import tracer. Used by debug tooling (e.g. {@code debug_executionWitness}) that needs to
+   * observe EVM execution without running the normal import tracer.
+   *
+   * @param context the protocol context
+   * @param block the block to validate and process
+   * @param headerValidationMode the header validation mode
+   * @param ommerValidationMode the ommer validation mode
+   * @param blockAccessList optional block access list for validation and processing
+   * @param shouldPersist flag indicating whether the block should be persisted
+   * @param shouldRecordBadBlock flag indicating whether bad blocks should be recorded
+   * @param tracer the tracer to use during block execution
+   * @return the result of the block processing
+   */
+  BlockProcessingResult validateAndProcessBlock(
+      final ProtocolContext context,
+      final Block block,
+      final HeaderValidationMode headerValidationMode,
+      final HeaderValidationMode ommerValidationMode,
+      final Optional<BlockAccessList> blockAccessList,
+      final boolean shouldPersist,
+      final boolean shouldRecordBadBlock,
+      final BlockAwareOperationTracer tracer);
 
   /**
    * Performs fast block validation appropriate for use during syncing skipping transaction receipt

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -353,6 +353,7 @@ public class MainnetBlockValidator implements BlockValidator {
    * @param worldState the world state for the parent block state root hash
    * @param block the block to be processed
    * @param blockAccessList optional block access list
+   * @param maybeTracer optional BlockAwareOperationTracer
    * @return the result of processing the block
    */
   protected BlockProcessingResult processBlock(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -165,7 +165,7 @@ public class MainnetBlockValidator implements BlockValidator {
         blockAccessList,
         shouldPersist,
         shouldRecordBadBlock,
-        Optional.of(tracer));
+        Optional.ofNullable(tracer));
   }
 
   private BlockProcessingResult validateAndProcessBlock(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.util.ArrayList;
@@ -135,6 +136,47 @@ public class MainnetBlockValidator implements BlockValidator {
       final Optional<BlockAccessList> blockAccessList,
       final boolean shouldUpdateHead,
       final boolean shouldRecordBadBlock) {
+    return validateAndProcessBlock(
+        context,
+        block,
+        headerValidationMode,
+        ommerValidationMode,
+        blockAccessList,
+        shouldUpdateHead,
+        shouldRecordBadBlock,
+        Optional.empty());
+  }
+
+  @Override
+  public BlockProcessingResult validateAndProcessBlock(
+      final ProtocolContext context,
+      final Block block,
+      final HeaderValidationMode headerValidationMode,
+      final HeaderValidationMode ommerValidationMode,
+      final Optional<BlockAccessList> blockAccessList,
+      final boolean shouldPersist,
+      final boolean shouldRecordBadBlock,
+      final BlockAwareOperationTracer tracer) {
+    return validateAndProcessBlock(
+        context,
+        block,
+        headerValidationMode,
+        ommerValidationMode,
+        blockAccessList,
+        shouldPersist,
+        shouldRecordBadBlock,
+        Optional.of(tracer));
+  }
+
+  private BlockProcessingResult validateAndProcessBlock(
+      final ProtocolContext context,
+      final Block block,
+      final HeaderValidationMode headerValidationMode,
+      final HeaderValidationMode ommerValidationMode,
+      final Optional<BlockAccessList> blockAccessList,
+      final boolean shouldUpdateHead,
+      final boolean shouldRecordBadBlock,
+      final Optional<BlockAwareOperationTracer> maybeTracer) {
 
     final int blockSize = block.getSize();
     if (blockSize > maxRlpBlockSize) {
@@ -206,7 +248,7 @@ public class MainnetBlockValidator implements BlockValidator {
         return result;
       }
 
-      var result = processBlock(context, worldState, block, blockAccessList);
+      var result = processBlock(context, worldState, block, blockAccessList, maybeTracer);
       if (result.isFailed()) {
         handleFailedBlockProcessing(block, blockAccessList, result, shouldRecordBadBlock, context);
         return result;
@@ -317,10 +359,11 @@ public class MainnetBlockValidator implements BlockValidator {
       final ProtocolContext context,
       final MutableWorldState worldState,
       final Block block,
-      final Optional<BlockAccessList> blockAccessList) {
+      final Optional<BlockAccessList> blockAccessList,
+      final Optional<BlockAwareOperationTracer> maybeTracer) {
 
     return blockProcessor.processBlock(
-        context, context.getBlockchain(), worldState, block, blockAccessList);
+        context, context.getBlockchain(), worldState, block, blockAccessList, maybeTracer);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -210,6 +210,43 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final Block block,
       final Optional<BlockAccessList> blockAccessList,
       final PreprocessingFunction preprocessingBlockFunction) {
+    return processBlock(
+        protocolContext,
+        blockchain,
+        worldState,
+        block,
+        blockAccessList,
+        preprocessingBlockFunction,
+        Optional.empty());
+  }
+
+  @Override
+  public BlockProcessingResult processBlock(
+      final ProtocolContext protocolContext,
+      final Blockchain blockchain,
+      final MutableWorldState worldState,
+      final Block block,
+      final Optional<BlockAccessList> blockAccessList,
+      final Optional<BlockAwareOperationTracer> maybeTracer) {
+    return processBlock(
+        protocolContext,
+        blockchain,
+        worldState,
+        block,
+        blockAccessList,
+        new NoPreprocessing(),
+        maybeTracer);
+  }
+
+  @Override
+  public BlockProcessingResult processBlock(
+      final ProtocolContext protocolContext,
+      final Blockchain blockchain,
+      final MutableWorldState worldState,
+      final Block block,
+      final Optional<BlockAccessList> blockAccessList,
+      final PreprocessingFunction preprocessingBlockFunction,
+      final Optional<BlockAwareOperationTracer> maybeTracer) {
     final List<TransactionReceipt> receipts = new ArrayList<>();
     // EIP-7778: Track two separate cumulative gas values
     // cumulativeRegularGasUsed: For block gas limit enforcement (uses protocol-specific strategy)
@@ -231,8 +268,9 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final BlockHashLookup blockHashLookup =
         protocolSpec.getPreExecutionProcessor().createBlockHashLookup(blockchain, blockHeader);
 
+    // Use the provided tracer if present, otherwise get one from the protocol context
     final BlockAwareOperationTracer blockTracer =
-        getBlockImportTracer(protocolContext, blockHeader);
+        maybeTracer.orElseGet(() -> getBlockImportTracer(protocolContext, block.getHeader()));
 
     final Address miningBeneficiary = miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.util.List;
@@ -119,6 +120,51 @@ public interface BlockProcessor {
       final Block block,
       final Optional<BlockAccessList> blockAccessList,
       final AbstractBlockProcessor.PreprocessingFunction preprocessingBlockFunction);
+
+  /**
+   * Processes the block with an explicit operation tracer, bypassing the plugin-based import
+   * tracer. Used by debug tooling (e.g. {@code debug_executionWitness}) that needs to observe EVM
+   * execution without interfering with the normal import tracer.
+   *
+   * @param protocolContext the current context of the protocol
+   * @param blockchain the blockchain to append the block to
+   * @param worldState the world state to apply changes to
+   * @param block the block to process
+   * @param blockAccessList the optional block access list
+   * @param maybeTracer the tracer to use for this execution, replacing the plugin-based import
+   *     tracer; when empty the plugin-based import tracer is resolved as usual
+   * @return the block processing result
+   */
+  BlockProcessingResult processBlock(
+      final ProtocolContext protocolContext,
+      final Blockchain blockchain,
+      final MutableWorldState worldState,
+      final Block block,
+      final Optional<BlockAccessList> blockAccessList,
+      final Optional<BlockAwareOperationTracer> maybeTracer);
+
+  /**
+   * Processes the block with both a preprocessing function and an optional explicit operation
+   * tracer. This is the canonical overload — all other {@code processBlock} variants delegate here.
+   *
+   * @param protocolContext the current context of the protocol
+   * @param blockchain the blockchain to append the block to
+   * @param worldState the world state to apply changes to
+   * @param block the block to process
+   * @param blockAccessList the optional block access list
+   * @param preprocessingBlockFunction a preprocessing function for block execution
+   * @param maybeTracer the tracer to use for this execution; when empty the plugin-based import
+   *     tracer is resolved as usual
+   * @return the block processing result
+   */
+  BlockProcessingResult processBlock(
+      final ProtocolContext protocolContext,
+      final Blockchain blockchain,
+      final MutableWorldState worldState,
+      final Block block,
+      final Optional<BlockAccessList> blockAccessList,
+      final AbstractBlockProcessor.PreprocessingFunction preprocessingBlockFunction,
+      final Optional<BlockAwareOperationTracer> maybeTracer);
 
   /**
    * Get ommer reward in ${@link Wei}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -106,6 +106,7 @@ import org.hyperledger.besu.evm.worldstate.CodeDelegationService;
 import org.hyperledger.besu.evm.worldstate.WorldState;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.io.IOException;
@@ -1492,6 +1493,39 @@ public abstract class MainnetProtocolSpecs {
           block,
           blockAccessList,
           preprocessingBlockFunction);
+    }
+
+    @Override
+    public BlockProcessingResult processBlock(
+        final ProtocolContext protocolContext,
+        final Blockchain blockchain,
+        final MutableWorldState worldState,
+        final Block block,
+        final Optional<BlockAccessList> blockAccessList,
+        final Optional<BlockAwareOperationTracer> maybeTracer) {
+      updateWorldStateForDao(worldState);
+      return wrapped.processBlock(
+          protocolContext, blockchain, worldState, block, blockAccessList, maybeTracer);
+    }
+
+    @Override
+    public BlockProcessingResult processBlock(
+        final ProtocolContext protocolContext,
+        final Blockchain blockchain,
+        final MutableWorldState worldState,
+        final Block block,
+        final Optional<BlockAccessList> blockAccessList,
+        final AbstractBlockProcessor.PreprocessingFunction preprocessingBlockFunction,
+        final Optional<BlockAwareOperationTracer> maybeTracer) {
+      updateWorldStateForDao(worldState);
+      return wrapped.processBlock(
+          protocolContext,
+          blockchain,
+          worldState,
+          block,
+          blockAccessList,
+          preprocessingBlockFunction,
+          maybeTracer);
     }
 
     private static final Address DAO_REFUND_CONTRACT_ADDRESS =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
@@ -118,10 +118,10 @@ public class MainnetBlockValidatorTest {
     when(blockBodyValidator.validateBodyLight(any(), any(), any(), any(), any())).thenReturn(true);
     when(blockAccessListValidator.validate(any(), any(), anyInt())).thenReturn(true);
     when(blockProcessor.processBlock(
-            eq(protocolContext), any(), any(), any(), eq(Optional.empty())))
+            eq(protocolContext), any(), any(), any(), eq(Optional.empty()), eq(Optional.empty())))
         .thenReturn(successfulProcessingResult);
     when(blockProcessor.processBlock(
-            eq(protocolContext), any(), any(), any(), eq(Optional.empty())))
+            eq(protocolContext), any(), any(), any(), eq(Optional.empty()), eq(Optional.empty())))
         .thenReturn(successfulProcessingResult);
 
     assertNoBadBlocks();
@@ -208,7 +208,8 @@ public class MainnetBlockValidatorTest {
                     List.of())));
     final Optional<BlockAccessList> optionalBal = Optional.of(bal);
     when(blockAccessListValidator.validate(eq(optionalBal), any(), anyInt())).thenReturn(true);
-    when(blockProcessor.processBlock(eq(protocolContext), any(), any(), any(), eq(optionalBal)))
+    when(blockProcessor.processBlock(
+            eq(protocolContext), any(), any(), any(), eq(optionalBal), eq(Optional.empty())))
         .thenReturn(new BlockProcessingResult(Optional.empty(), false));
 
     BlockProcessingResult result =
@@ -315,6 +316,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty())))
         .thenReturn(BlockProcessingResult.FAILED);
 
@@ -358,6 +360,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty()));
 
     BlockProcessingResult result =
@@ -402,6 +405,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty())))
         .thenReturn(exceptionalResult);
 
@@ -423,6 +427,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty())))
         .thenReturn(BlockProcessingResult.FAILED);
 
@@ -447,6 +452,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty())))
         .thenReturn(BlockProcessingResult.FAILED);
 
@@ -471,6 +477,7 @@ public class MainnetBlockValidatorTest {
             eq(blockchain),
             any(MutableWorldState.class),
             eq(block),
+            eq(Optional.empty()),
             eq(Optional.empty())))
         .thenReturn(BlockProcessingResult.FAILED);
 
@@ -623,7 +630,7 @@ public class MainnetBlockValidatorTest {
     when(blockHeaderValidator.validateHeader(any(), any(), any())).thenReturn(true);
     when(blockHeaderValidator.validateHeader(any(), any(), any(), any())).thenReturn(true);
     when(blockProcessor.processBlock(
-            eq(protocolContext), any(), any(), any(), eq(Optional.empty())))
+            eq(protocolContext), any(), any(), any(), eq(Optional.empty()), eq(Optional.empty())))
         .thenReturn(successfulProcessingResult);
     when(blockBodyValidator.validateBody(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(true);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
@@ -43,6 +43,9 @@ import org.hyperledger.besu.ethereum.referencetests.ReferenceTestBlockchain;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.gascalculator.StateGasCostCalculator;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.BlockImportTracerProvider;
+import org.hyperledger.besu.plugin.services.tracer.BlockAwareOperationTracer;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.util.List;
@@ -124,6 +127,45 @@ abstract class AbstractBlockProcessorTest {
     blockProcessor.processBlock(
         protocolContext, blockchain, worldState, testBlockBuilder(withdrawals));
     verify(withdrawalsProcessor, never()).processWithdrawals(any(), any(), any(), any());
+  }
+
+  @Test
+  void whenExplicitTracerProvided_itIsUsedForBlockProcessing() {
+    // An explicit tracer passed to processBlock must be the one driving execution, in preference
+    // to the plugin-based import tracer.
+    final BlockAwareOperationTracer explicitTracer = mock(BlockAwareOperationTracer.class);
+
+    blockProcessor.processBlock(
+        protocolContext,
+        blockchain,
+        worldState,
+        testBlockBuilder(emptyList()),
+        Optional.empty(),
+        Optional.of(explicitTracer));
+
+    verify(explicitTracer).traceStartBlock(any(), any(BlockHeader.class), any(Address.class));
+  }
+
+  @Test
+  void whenNoTracerProvided_pluginImportTracerIsResolvedAndUsed() {
+    // With no explicit tracer, the plugin-based BlockImportTracerProvider must be consulted and its
+    // tracer used to drive execution.
+    final BlockAwareOperationTracer defaultTracer = mock(BlockAwareOperationTracer.class);
+    final ServiceManager serviceManager = mock(ServiceManager.class);
+    final BlockImportTracerProvider provider = header -> defaultTracer;
+    when(protocolContext.getPluginServiceManager()).thenReturn(serviceManager);
+    when(serviceManager.getService(BlockImportTracerProvider.class))
+        .thenReturn(Optional.of(provider));
+
+    blockProcessor.processBlock(
+        protocolContext,
+        blockchain,
+        worldState,
+        testBlockBuilder(emptyList()),
+        Optional.empty(),
+        Optional.empty());
+
+    verify(defaultTracer).traceStartBlock(any(), any(BlockHeader.class), any(Address.class));
   }
 
   @Test


### PR DESCRIPTION
Preparatory refactor for the upcoming execution witness generation PR (EIP-8025).

Witness generation executes block processing with a specialised `WitnessOperationTracer` that records accessed code and ancestor headers during EVM execution. To support this cleanly, block processing needs a way to accept an explicit, caller-supplied tracer instead of always resolving the plugin-based import tracer. This PR introduces that plumbing only; there is no witness-generation logic and no behavioural change.