### PR TITLE
Empty round fix

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
@@ -91,4 +91,38 @@ public class RoundTimer {
 
     currentTimerTask = Optional.of(newTimerTask);
   }
+
+  /**
+   * Starts a timer for the supplied round that expires after an explicit delay, cancelling any
+   * previously active round timer. This is used to defer the round-0 expiry until the empty-block
+   * period has elapsed, so that validators do not treat a proposer that is legitimately waiting
+   * out the empty-block window as having failed and trigger an unnecessary round change.
+   *
+   * @param round The round identifier which this timer is tracking
+   * @param delayMillis The delay, in milliseconds, before the round expires. Negative values are
+   *     treated as zero (expire immediately).
+   */
+  public synchronized void startTimer(
+      final ConsensusRoundIdentifier round, final long delayMillis) {
+    cancelTimer();
+
+    final long safeDelayMillis = Math.max(0, delayMillis);
+
+    final Runnable newTimerRunnable = () -> queue.add(new RoundExpiry(round));
+
+    final ScheduledFuture<?> newTimerTask =
+        bftExecutors.scheduleTask(newTimerRunnable, safeDelayMillis, TimeUnit.MILLISECONDS);
+
+    currentTimerTask = Optional.of(newTimerTask);
+  }
+
+  /**
+   * Returns the configured expiry period, in milliseconds, for the supplied round.
+   *
+   * @param round the round identifier
+   * @return the round expiry period in milliseconds
+   */
+  public long getRoundExpiry(final ConsensusRoundIdentifier round) {
+    return roundExpiryTimeCalculator.calculateRoundExpiry(round).toMillis();
+  }
 }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
@@ -95,8 +95,8 @@ public class RoundTimer {
   /**
    * Starts a timer for the supplied round that expires after an explicit delay, cancelling any
    * previously active round timer. This is used to defer the round-0 expiry until the empty-block
-   * period has elapsed, so that validators do not treat a proposer that is legitimately waiting
-   * out the empty-block window as having failed and trigger an unnecessary round change.
+   * period has elapsed, so that validators do not treat a proposer that is legitimately waiting out
+   * the empty-block window as having failed and trigger an unnecessary round change.
    *
    * @param round The round identifier which this timer is tracking
    * @param delayMillis The delay, in milliseconds, before the round expires. Negative values are

--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManager.java
@@ -288,7 +288,66 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
       return;
     }
 
+    // While the chain is idle the round-0 proposer intentionally stays silent until the
+    // emptyBlockPeriodSeconds window elapses (see buildBlockAndMaybePropose). Non-proposers cannot
+    // tell that deliberate silence apart from a failed proposer, so a naive requestTimeout expiry
+    // would trigger a round change on every empty-block height. To avoid that, defer the round-0
+    // expiry until the empty-block window has elapsed (plus the normal requestTimeout grace) so a
+    // genuine proposer failure is still detected.
+    if (qbftRound.getRoundIdentifier().getRoundNumber() == 0 && shouldWaitForEmptyBlockPeriod()) {
+      final long now = clock.millis();
+      final long emptyBlockPeriodExpiryMillis =
+          (parentHeader.getTimestamp() + finalState.getBlockTimer().getEmptyBlockPeriodSeconds())
+              * 1000L;
+      final long graceMillis =
+          finalState.getRoundTimer().getRoundExpiry(qbftRound.getRoundIdentifier());
+      final long deferMillis = (emptyBlockPeriodExpiryMillis - now) + graceMillis;
+      LOG.debug(
+          "Round 0 expired inside the empty-block window; deferring round change by {}ms until the "
+              + "empty-block period elapses. round={}",
+          deferMillis,
+          qbftRound.getRoundIdentifier());
+      finalState.getRoundTimer().startTimer(qbftRound.getRoundIdentifier(), deferMillis);
+      return;
+    }
+
     doRoundChange(qbftRound.getRoundIdentifier().getRoundNumber() + 1);
+  }
+
+  /**
+   * Determines whether the current round-0 timer expiry should be ignored because the proposer is
+   * legitimately waiting out the empty-block period rather than having failed.
+   *
+   * <p>Returns true only when the empty-block period has not yet elapsed AND the block this node
+   * would produce right now would be empty. If transactions are pending a real block is due and a
+   * genuine proposer failure must still be detected on the normal requestTimeout schedule, so this
+   * returns false. It also returns false (allowing the round change to proceed) if the emptiness of
+   * the candidate block cannot be determined, favouring liveness over suppressing a round change.
+   *
+   * @return true if the round change should be deferred, false if it should proceed
+   */
+  private boolean shouldWaitForEmptyBlockPeriod() {
+    if (currentRound.isEmpty()) {
+      return false;
+    }
+    if (finalState.getBlockTimer().getEmptyBlockPeriodSeconds() <= 0) {
+      // The empty-block-period feature is not configured, so behave exactly as before.
+      return false;
+    }
+    final long now = clock.millis();
+    if (finalState.getBlockTimer().checkEmptyBlockExpired(parentHeader::getTimestamp, now)) {
+      // The empty-block period has elapsed - a block is due, so a stalled round is a genuine fault.
+      return false;
+    }
+    try {
+      final long headerTimeStampSeconds = Math.round(now / 1000D);
+      final QbftBlock candidateBlock =
+          currentRound.get().createBlock(headerTimeStampSeconds).block();
+      return candidateBlock.isEmpty();
+    } catch (final RuntimeException e) {
+      LOG.debug("Failed to evaluate empty-block wait condition; allowing round change.", e);
+      return false;
+    }
   }
 
   private synchronized void doRoundChange(final int newRoundNumber) {

--- a/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft-core/src/test/java/org/hyperledger/besu/consensus/qbft/core/statemachine/QbftBlockHeightManagerTest.java
@@ -492,6 +492,63 @@ public class QbftBlockHeightManagerTest {
   }
 
   @Test
+  public void roundZeroExpiryIsDeferredWhileWaitingOutTheEmptyBlockPeriod() {
+    // emptyBlockPeriodSeconds is configured and has not yet elapsed, and the block that would be
+    // produced now is empty. The round-0 proposer is therefore legitimately silent, so the round
+    // change must be deferred rather than triggered - otherwise every idle height round-changes.
+    when(blockTimer.getEmptyBlockPeriodSeconds()).thenReturn(60L);
+    when(blockTimer.checkEmptyBlockExpired(any(), anyLong())).thenReturn(false);
+    // createdBlock is empty by default (QbftBlockTestFixture)
+
+    final QbftBlockHeightManager manager =
+        new QbftBlockHeightManager(
+            headerTestFixture.buildHeader(),
+            finalState,
+            roundChangeManager,
+            roundFactory,
+            clock,
+            messageValidatorFactory,
+            messageFactory,
+            validatorProvider);
+    manager.handleBlockTimerExpiry(roundIdentifier);
+    verify(roundFactory).createNewRound(any(), eq(0));
+
+    manager.roundExpired(new RoundExpiry(roundIdentifier));
+
+    // No round change: round 1 must not be created...
+    verify(roundFactory, never()).createNewRound(any(), eq(1));
+    // ...instead the round-0 timer is re-armed to fire once the empty-block period has elapsed.
+    verify(roundTimer).startTimer(eq(roundIdentifier), anyLong());
+  }
+
+  @Test
+  public void roundZeroExpiryTriggersRoundChangeWhenTransactionsArePendingDuringEmptyBlockPeriod() {
+    // Even inside the empty-block window, if the pending block would be non-empty a real block is
+    // due, so a stalled round must still be treated as a genuine proposer failure.
+    when(blockTimer.getEmptyBlockPeriodSeconds()).thenReturn(60L);
+    when(blockTimer.checkEmptyBlockExpired(any(), anyLong())).thenReturn(false);
+    final QbftBlock nonEmptyBlock = new QbftBlockTestFixture().isEmpty(false).build();
+    when(blockCreator.createBlock(anyLong(), any()))
+        .thenReturn(new QbftBlockCreator.BlockCreationResult(nonEmptyBlock, Optional.empty()));
+
+    final QbftBlockHeightManager manager =
+        new QbftBlockHeightManager(
+            headerTestFixture.buildHeader(),
+            finalState,
+            roundChangeManager,
+            roundFactory,
+            clock,
+            messageValidatorFactory,
+            messageFactory,
+            validatorProvider);
+    manager.handleBlockTimerExpiry(roundIdentifier);
+
+    manager.roundExpired(new RoundExpiry(roundIdentifier));
+
+    verify(roundFactory).createNewRound(any(), eq(1));
+  }
+
+  @Test
   public void whenSufficientRoundChangesAreReceivedAProposalMessageIsTransmitted() {
     final ConsensusRoundIdentifier futureRoundIdentifier = createFrom(roundIdentifier, 0, +2);
     final RoundChange roundChange =


### PR DESCRIPTION
## PR description
Prevents non-block proposers from moving on to the next round before `emptyblockperiodseconds` has expired

## Fixed Issue(s)
Fixes https://github.com/besu-eth/besu/issues/10917

