### PR TITLE
Enable NullAway for Ethereum permissioning

### DIFF
--- a/ethereum/permissioning/build.gradle
+++ b/ethereum/permissioning/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.ethereum.permissioning')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -30,6 +43,8 @@ jar {
 
 dependencies {
   api 'org.slf4j:slf4j-api'
+
+  errorprone 'com.uber.nullaway:nullaway'
 
   implementation project(':crypto:algorithms')
   implementation project(':datatypes')
@@ -47,6 +62,8 @@ dependencies {
   implementation 'io.consensys.tuweni:tuweni-units'
   implementation 'javax.inject:javax.inject'
   implementation 'org.web3j:abi'
+
+  compileOnlyApi 'org.jspecify:jspecify'
 
   testImplementation project(':config')
   testImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningController.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -55,7 +55,11 @@ public class AccountLocalConfigPermissioningController implements TransactionPer
     this(
         configuration,
         new AllowlistPersistor(
-            Objects.requireNonNull(configuration.getAccountPermissioningConfigFilePath())),
+            Optional.ofNullable(configuration.getAccountPermissioningConfigFilePath())
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "Account permissioning config file path is required when account permissioning is enabled"))),
         metricsSystem);
   }
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningController.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -53,7 +54,8 @@ public class AccountLocalConfigPermissioningController implements TransactionPer
       final LocalPermissioningConfiguration configuration, final MetricsSystem metricsSystem) {
     this(
         configuration,
-        new AllowlistPersistor(configuration.getAccountPermissioningConfigFilePath()),
+        new AllowlistPersistor(
+            Objects.requireNonNull(configuration.getAccountPermissioningConfigFilePath())),
         metricsSystem);
   }
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfiguration.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfiguration.java
@@ -21,31 +21,30 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 public class LocalPermissioningConfiguration {
-  private List<EnodeURLImpl> nodeAllowlist;
-  private List<String> accountAllowlist;
+  private final List<EnodeURLImpl> nodeAllowlist = new ArrayList<>();
+  private final List<String> accountAllowlist = new ArrayList<>();
   private boolean nodeAllowlistEnabled;
   private EnodeDnsConfiguration enodeDnsConfiguration = EnodeDnsConfiguration.dnsDisabled();
-  private String nodePermissioningConfigFilePath;
+  private @Nullable String nodePermissioningConfigFilePath;
   private boolean accountAllowlistEnabled;
-  private String accountPermissioningConfigFilePath;
+  private @Nullable String accountPermissioningConfigFilePath;
 
   public List<EnodeURLImpl> getNodeAllowlist() {
     return nodeAllowlist;
   }
 
   public static LocalPermissioningConfiguration createDefault() {
-    final LocalPermissioningConfiguration config = new LocalPermissioningConfiguration();
-    config.nodeAllowlist = new ArrayList<>();
-    config.accountAllowlist = new ArrayList<>();
-    return config;
+    return new LocalPermissioningConfiguration();
   }
 
   public void setEnodeDnsConfiguration(final EnodeDnsConfiguration enodeDnsConfiguration) {
     this.enodeDnsConfiguration = enodeDnsConfiguration;
   }
 
-  public void setNodeAllowlist(final Collection<EnodeURLImpl> nodeAllowlist) {
+  public void setNodeAllowlist(final @Nullable Collection<EnodeURLImpl> nodeAllowlist) {
     if (nodeAllowlist != null) {
       this.nodeAllowlist.addAll(nodeAllowlist);
       this.nodeAllowlistEnabled = true;
@@ -64,7 +63,7 @@ public class LocalPermissioningConfiguration {
     return accountAllowlist;
   }
 
-  public void setAccountAllowlist(final Collection<String> accountAllowlist) {
+  public void setAccountAllowlist(final @Nullable Collection<String> accountAllowlist) {
     if (accountAllowlist != null) {
       this.accountAllowlist.addAll(accountAllowlist);
       this.accountAllowlistEnabled = true;
@@ -75,20 +74,21 @@ public class LocalPermissioningConfiguration {
     return accountAllowlistEnabled;
   }
 
-  public String getNodePermissioningConfigFilePath() {
+  public @Nullable String getNodePermissioningConfigFilePath() {
     return nodePermissioningConfigFilePath;
   }
 
-  public void setNodePermissioningConfigFilePath(final String nodePermissioningConfigFilePath) {
+  public void setNodePermissioningConfigFilePath(
+      final @Nullable String nodePermissioningConfigFilePath) {
     this.nodePermissioningConfigFilePath = nodePermissioningConfigFilePath;
   }
 
-  public String getAccountPermissioningConfigFilePath() {
+  public @Nullable String getAccountPermissioningConfigFilePath() {
     return accountPermissioningConfigFilePath;
   }
 
   public void setAccountPermissioningConfigFilePath(
-      final String accountPermissioningConfigFilePath) {
+      final @Nullable String accountPermissioningConfigFilePath) {
     this.accountPermissioningConfigFilePath = accountPermissioningConfigFilePath;
   }
 }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
@@ -69,8 +69,11 @@ public class NodeLocalConfigPermissioningController implements NodeConnectionPer
         fixedNodes,
         localNodeId,
         new AllowlistPersistor(
-            Objects.requireNonNull(
-                permissioningConfiguration.getNodePermissioningConfigFilePath())),
+            Optional.ofNullable(permissioningConfiguration.getNodePermissioningConfigFilePath())
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "Node permissioning config file path is required when node permissioning is enabled"))),
         metricsSystem);
   }
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
@@ -68,7 +68,9 @@ public class NodeLocalConfigPermissioningController implements NodeConnectionPer
         permissioningConfiguration,
         fixedNodes,
         localNodeId,
-        new AllowlistPersistor(permissioningConfiguration.getNodePermissioningConfigFilePath()),
+        new AllowlistPersistor(
+            Objects.requireNonNull(
+                permissioningConfiguration.getNodePermissioningConfigFilePath())),
         metricsSystem);
   }
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
@@ -18,10 +18,12 @@ import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.toml.TomlArray;
 import org.apache.tuweni.toml.TomlParseResult;
+import org.jspecify.annotations.Nullable;
 
 public class PermissioningConfigurationBuilder {
 
@@ -31,9 +33,9 @@ public class PermissioningConfigurationBuilder {
   public static LocalPermissioningConfiguration permissioningConfiguration(
       final boolean nodePermissioningEnabled,
       final EnodeDnsConfiguration enodeDnsConfiguration,
-      final String nodePermissioningConfigFilepath,
+      final @Nullable String nodePermissioningConfigFilepath,
       final boolean accountPermissioningEnabled,
-      final String accountPermissioningConfigFilepath)
+      final @Nullable String accountPermissioningConfigFilepath)
       throws Exception {
 
     final LocalPermissioningConfiguration permissioningConfiguration =
@@ -52,15 +54,15 @@ public class PermissioningConfigurationBuilder {
   private static LocalPermissioningConfiguration loadNodePermissioning(
       final LocalPermissioningConfiguration permissioningConfiguration,
       final boolean localConfigNodePermissioningEnabled,
-      final String nodePermissioningConfigFilepath)
+      final @Nullable String nodePermissioningConfigFilepath)
       throws Exception {
 
     if (localConfigNodePermissioningEnabled) {
-      final TomlParseResult nodePermissioningToml = readToml(nodePermissioningConfigFilepath);
+      final String configFilepath = Objects.requireNonNull(nodePermissioningConfigFilepath);
+      final TomlParseResult nodePermissioningToml = readToml(configFilepath);
       final TomlArray nodeAllowlistTomlArray = getArray(nodePermissioningToml, NODES_ALLOWLIST_KEY);
 
-      permissioningConfiguration.setNodePermissioningConfigFilePath(
-          nodePermissioningConfigFilepath);
+      permissioningConfiguration.setNodePermissioningConfigFilePath(configFilepath);
 
       if (nodeAllowlistTomlArray != null) {
         List<EnodeURLImpl> nodesAllowlistToml =
@@ -74,9 +76,7 @@ public class PermissioningConfigurationBuilder {
         permissioningConfiguration.setNodeAllowlist(nodesAllowlistToml);
       } else {
         throw new Exception(
-            NODES_ALLOWLIST_KEY
-                + " config option missing in TOML config file "
-                + nodePermissioningConfigFilepath);
+            NODES_ALLOWLIST_KEY + " config option missing in TOML config file " + configFilepath);
       }
     }
     return permissioningConfiguration;
@@ -85,16 +85,16 @@ public class PermissioningConfigurationBuilder {
   private static LocalPermissioningConfiguration loadAccountPermissioning(
       final LocalPermissioningConfiguration permissioningConfiguration,
       final boolean localConfigAccountPermissioningEnabled,
-      final String accountPermissioningConfigFilepath)
+      final @Nullable String accountPermissioningConfigFilepath)
       throws Exception {
 
     if (localConfigAccountPermissioningEnabled) {
-      final TomlParseResult accountPermissioningToml = readToml(accountPermissioningConfigFilepath);
+      final String configFilepath = Objects.requireNonNull(accountPermissioningConfigFilepath);
+      final TomlParseResult accountPermissioningToml = readToml(configFilepath);
       final TomlArray accountAllowlistTomlArray =
           getArray(accountPermissioningToml, ACCOUNTS_ALLOWLIST_KEY);
 
-      permissioningConfiguration.setAccountPermissioningConfigFilePath(
-          accountPermissioningConfigFilepath);
+      permissioningConfiguration.setAccountPermissioningConfigFilePath(configFilepath);
 
       if (accountAllowlistTomlArray != null) {
         List<String> accountsAllowlistToml =
@@ -115,7 +115,7 @@ public class PermissioningConfigurationBuilder {
         throw new Exception(
             ACCOUNTS_ALLOWLIST_KEY
                 + " config option missing in TOML config file "
-                + accountPermissioningConfigFilepath);
+                + configFilepath);
       }
     }
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
@@ -58,7 +58,10 @@ public class PermissioningConfigurationBuilder {
       throws Exception {
 
     if (localConfigNodePermissioningEnabled) {
-      final String configFilepath = Objects.requireNonNull(nodePermissioningConfigFilepath);
+      final String configFilepath =
+          Objects.requireNonNull(
+              nodePermissioningConfigFilepath,
+              "Node permissioning config file path is required when node permissioning is enabled");
       final TomlParseResult nodePermissioningToml = readToml(configFilepath);
       final TomlArray nodeAllowlistTomlArray = getArray(nodePermissioningToml, NODES_ALLOWLIST_KEY);
 
@@ -89,7 +92,10 @@ public class PermissioningConfigurationBuilder {
       throws Exception {
 
     if (localConfigAccountPermissioningEnabled) {
-      final String configFilepath = Objects.requireNonNull(accountPermissioningConfigFilepath);
+      final String configFilepath =
+          Objects.requireNonNull(
+              accountPermissioningConfigFilepath,
+              "Account permissioning config file path is required when account permissioning is enabled");
       final TomlParseResult accountPermissioningToml = readToml(configFilepath);
       final TomlArray accountAllowlistTomlArray =
           getArray(accountPermissioningToml, ACCOUNTS_ALLOWLIST_KEY);

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningControllerTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.permissioning;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -94,6 +95,15 @@ public class AccountLocalConfigPermissioningControllerTest {
 
     assertThat(controller.getAccountAllowlist())
         .contains("0xfe3b557e8fb62b89f4916b721be55ceb828dbd73");
+  }
+
+  @Test
+  public void missingAccountPermissioningFileIsInvalidConfigurationState() {
+    assertThatThrownBy(
+            () -> new AccountLocalConfigPermissioningController(permissioningConfig, metricsSystem))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Account permissioning config file path is required when account permissioning is enabled");
   }
 
   @Test

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
@@ -157,6 +157,28 @@ public class LocalPermissioningConfigurationBuilderTest {
   }
 
   @Test
+  public void enabledNodePermissioningRequiresAConfigFilePath() {
+    assertThatThrownBy(
+            () ->
+                PermissioningConfigurationBuilder.permissioningConfiguration(
+                    true, dnsDisabled(), null, false, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(
+            "Node permissioning config file path is required when node permissioning is enabled");
+  }
+
+  @Test
+  public void enabledAccountPermissioningRequiresAConfigFilePath() {
+    assertThatThrownBy(
+            () ->
+                PermissioningConfigurationBuilder.permissioningConfiguration(
+                    false, dnsDisabled(), null, true, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(
+            "Account permissioning config file path is required when account permissioning is enabled");
+  }
+
+  @Test
   public void permissioningConfigWithInvalidAccount() throws Exception {
     final URL configFile = this.getClass().getResource(PERMISSIONING_CONFIG_INVALID_ACCOUNT);
     final Path toml = createTempFile("toml", Resources.toByteArray(configFile));

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.permissioning;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -119,6 +120,23 @@ public class NodeLocalConfigPermissioningControllerTest {
         .comparingOnlyFields("result")
         .isEqualTo(expected);
     assertThat(controller.getNodesAllowlist()).containsExactly(enode1);
+  }
+
+  @Test
+  public void missingNodePermissioningFileIsInvalidConfigurationState() {
+    final LocalPermissioningConfiguration permissioningConfiguration =
+        LocalPermissioningConfiguration.createDefault();
+
+    assertThatThrownBy(
+            () ->
+                new NodeLocalConfigPermissioningController(
+                    permissioningConfiguration,
+                    bootnodesList,
+                    selfEnode.getNodeId(),
+                    metricsSystem))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Node permissioning config file path is required when node permissioning is enabled");
   }
 
   @Test


### PR DESCRIPTION
## PR description

Enable NullAway for the `ethereum/permissioning` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.ethereum.permissioning`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and exposes JSpecify annotations to downstream consumers with `compileOnlyApi`
- initializes local allowlists eagerly and records their existing nullable setter contract
- makes optional permissioning configuration paths explicit and validates that a path is present when its corresponding permissioning mode is enabled

Valid permissioning configurations behave as before, while missing paths now fail at the point where an enabled permissioning mode requires them.

## Fixed Issue(s)

Part of #10442 (`ethereum/permissioning`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :ethereum:permissioning:spotlessApply` and `./gradlew --no-daemon :ethereum:permissioning:build :ethereum:permissioning:spotlessCheck --rerun-tasks`
- [x] unit tests: `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense`.
