### PR TITLE
Enable NullAway for services pipeline

### DIFF
--- a/services/pipeline/build.gradle
+++ b/services/pipeline/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.services.pipeline')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -29,6 +42,8 @@ jar {
 }
 
 dependencies {
+  errorprone 'com.uber.nullaway:nullaway'
+
   api project(':util')
   api 'org.slf4j:slf4j-api'
 
@@ -37,6 +52,8 @@ dependencies {
 
   implementation 'io.opentelemetry:opentelemetry-api'
   implementation 'com.google.guava:guava'
+
+  compileOnlyApi 'org.jspecify:jspecify'
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/AggregatingReadPipe.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/AggregatingReadPipe.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A read pipe that aggregates all incoming batches into a single batch.
  *
@@ -55,13 +57,13 @@ public class AggregatingReadPipe<T> implements ReadPipe<List<T>> {
   }
 
   @Override
-  public List<T> get() {
+  public @Nullable List<T> get() {
     drainInputToPendingByGet();
     return emitPendingUpTo(Integer.MAX_VALUE);
   }
 
   @Override
-  public List<T> poll() {
+  public @Nullable List<T> poll() {
     drainInputToPendingByPoll();
 
     if (input.hasMore()) {
@@ -87,7 +89,7 @@ public class AggregatingReadPipe<T> implements ReadPipe<List<T>> {
     return 0;
   }
 
-  private List<T> emitPendingUpTo(final int maximumSize) {
+  private @Nullable List<T> emitPendingUpTo(final int maximumSize) {
     if (pendingItems.isEmpty()) {
       return null;
     }

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/BatchingReadPipe.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/BatchingReadPipe.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The Batching read pipe.
  *
@@ -75,7 +77,7 @@ public class BatchingReadPipe<T> implements ReadPipe<List<T>> {
   }
 
   @Override
-  public List<T> get() {
+  public @Nullable List<T> get() {
     final T firstItem = input.get();
     if (firstItem == null) {
       // Contract of get is to explicitly return null when no more items are available.
@@ -98,7 +100,7 @@ public class BatchingReadPipe<T> implements ReadPipe<List<T>> {
   }
 
   @Override
-  public List<T> poll() {
+  public @Nullable List<T> poll() {
     final List<T> batch = new ArrayList<>();
     Integer remainingData = stopBatchCondition.apply(batch);
     while (remainingData > 0

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipe.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipe.java
@@ -22,6 +22,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +114,7 @@ public class Pipe<T> implements ReadPipe<T>, WritePipe<T> {
   }
 
   @Override
-  public T get() {
+  public @Nullable T get() {
     try {
       while (hasMore()) {
         final T value = queue.poll(1, TimeUnit.SECONDS);
@@ -129,7 +130,7 @@ public class Pipe<T> implements ReadPipe<T>, WritePipe<T> {
   }
 
   @Override
-  public T poll() {
+  public @Nullable T poll() {
     final T item = queue.poll();
     if (item != null) {
       outputCounter.inc();

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.util.log.LogUtil;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -160,6 +159,8 @@ public class Pipeline<I> {
    * <p>A best effort is made to halt all processing by the pipeline immediately by interrupting
    * each execution thread and pipes connecting each stage will no longer accept or provide further
    * items.
+   *
+   * @throws IllegalStateException if the pipeline has not been started
    */
   public void abort() {
     final CancellationException exception = new CancellationException("Pipeline aborted");
@@ -214,10 +215,14 @@ public class Pipeline<I> {
   }
 
   private synchronized void abort(final Throwable error) {
+    final List<Future<?>> runningFutures = futures;
+    if (runningFutures == null) {
+      throw new IllegalStateException("Pipeline must be started before it can be aborted");
+    }
     if (completing.compareAndSet(false, true)) {
       inputPipe.abort();
       pipes.forEach(Pipe::abort);
-      Objects.requireNonNull(futures).forEach(future -> future.cancel(true));
+      runningFutures.forEach(future -> future.cancel(true));
       overallFuture.completeExceptionally(error);
     }
   }

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/Pipeline.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.util.log.LogUtil;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -35,6 +36,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +66,7 @@ public class Pipeline<I> {
   private final CompletableFuture<Void> overallFuture = new CompletableFuture<>();
   private final String name;
   private final boolean tracingEnabled;
-  private volatile List<Future<?>> futures;
+  private volatile @Nullable List<Future<?>> futures;
 
   /**
    * Instantiates a new Pipeline.
@@ -167,22 +169,21 @@ public class Pipeline<I> {
   private Future<?> runWithErrorHandling(final ExecutorService executorService, final Stage task) {
     return executorService.submit(
         () -> {
-          Span taskSpan = null;
-          if (tracingEnabled) {
-            taskSpan =
-                tracer
-                    .spanBuilder(task.getName())
-                    .setAttribute("pipeline", name)
-                    .setSpanKind(SpanKind.INTERNAL)
-                    .startSpan();
-          }
+          final @Nullable Span taskSpan =
+              tracingEnabled
+                  ? tracer
+                      .spanBuilder(task.getName())
+                      .setAttribute("pipeline", name)
+                      .setSpanKind(SpanKind.INTERNAL)
+                      .startSpan()
+                  : null;
           final Thread thread = Thread.currentThread();
           final String originalName = thread.getName();
           try {
             thread.setName(originalName + " (" + task.getName() + ")");
             task.run();
           } catch (final Throwable t) {
-            if (tracingEnabled) {
+            if (taskSpan != null) {
               taskSpan.setStatus(StatusCode.ERROR);
             }
             if (t instanceof CompletionException
@@ -204,7 +205,7 @@ public class Pipeline<I> {
               LOG.error("Failed to abort pipeline after error", t2);
             }
           } finally {
-            if (tracingEnabled) {
+            if (taskSpan != null) {
               taskSpan.end();
             }
             thread.setName(originalName);
@@ -216,7 +217,7 @@ public class Pipeline<I> {
     if (completing.compareAndSet(false, true)) {
       inputPipe.abort();
       pipes.forEach(Pipe::abort);
-      futures.forEach(future -> future.cancel(true));
+      Objects.requireNonNull(futures).forEach(future -> future.cancel(true));
       overallFuture.completeExceptionally(error);
     }
   }

--- a/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/ReadPipe.java
+++ b/services/pipeline/src/main/java/org/hyperledger/besu/services/pipeline/ReadPipe.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.services.pipeline;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The interface used to read items from a pipe.
  *
@@ -46,14 +48,14 @@ public interface ReadPipe<T> {
    *
    * @return the next item or <code>null</code> if the pipe is closed or the thread interrupted.
    */
-  T get();
+  @Nullable T get();
 
   /**
    * Get and remove the next item from this pipe without blocking if it is available.
    *
    * @return the next item or <code>null</code> if the pipe is empty.
    */
-  T poll();
+  @Nullable T poll();
 
   /**
    * Removes at most the given number of available elements from the pipe and adds them to the given

--- a/services/pipeline/src/test/java/org/hyperledger/besu/services/pipeline/PipelineBuilderTest.java
+++ b/services/pipeline/src/test/java/org/hyperledger/besu/services/pipeline/PipelineBuilderTest.java
@@ -392,6 +392,22 @@ public class PipelineBuilderTest {
   }
 
   @Test
+  public void shouldRejectAbortBeforePipelineStarts() throws Exception {
+    final List<Integer> output = new ArrayList<>();
+    final Pipeline<Integer> pipeline =
+        PipelineBuilder.createPipelineFrom(
+                "input", tasks, 10, NO_OP_LABELLED_2_COUNTER, false, "test")
+            .andFinishWith("end", output::add);
+
+    assertThatThrownBy(pipeline::abort)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Pipeline must be started before it can be aborted");
+
+    pipeline.start(executorService).get(10, SECONDS);
+    assertThat(output).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+  }
+
+  @Test
   public void shouldAbortPipelineWhenFutureIsCancelled() throws Exception {
     final int allowProcessingUpTo = 5;
     final AtomicBoolean processorInterrupted = new AtomicBoolean(false);


### PR DESCRIPTION
## PR description

Enable NullAway for the `services/pipeline` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.services.pipeline`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and exposes JSpecify annotations with `compileOnlyApi`
- records the documented nullable results of `ReadPipe.get()` and `ReadPipe.poll()` across their implementations
- models the task list before pipeline startup and the optional tracing span as explicitly nullable
- keeps the existing pipeline-start lifecycle invariant explicit when cancelling running tasks

Pipeline scheduling, cancellation, queue handling, and tracing behavior are unchanged for valid execution paths.

## Fixed Issue(s)

Part of #10442 (`services/pipeline`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :services:pipeline:spotlessApply` and `./gradlew --no-daemon :services:pipeline:build :services:pipeline:spotlessCheck --rerun-tasks`
- [x] unit tests: focused `PipeTest`, `BatchingReadPipeTest`, `AggregatingReadPipeTest`, and `PipelineBuilderTest`, plus `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense`.