### PR TITLE
Enable NullAway for services key-value storage

### DIFF
--- a/services/kvstore/build.gradle
+++ b/services/kvstore/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.services.kvstore')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -29,9 +42,13 @@ jar {
 }
 
 dependencies {
+  errorprone 'com.uber.nullaway:nullaway'
+
   api project(':plugin-api')
   api 'org.slf4j:slf4j-api'
   implementation 'com.google.guava:guava'
+
+  compileOnly 'org.jspecify:jspecify'
 
   testImplementation project(':testutil')
   testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -80,7 +79,12 @@ public class InMemoryStoragePlugin implements BesuPlugin {
   }
 
   private void createFactoriesAndRegisterWithStorageService() {
-    Objects.requireNonNull(context)
+    final ServiceManager serviceManager = context;
+    if (serviceManager == null) {
+      throw new IllegalStateException(
+          "In-memory storage plugin must be registered before it can be started");
+    }
+    serviceManager
         .getService(StorageService.class)
         .ifPresentOrElse(
             this::createAndRegister,

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
@@ -28,7 +28,9 @@ import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorage;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +38,8 @@ import org.slf4j.LoggerFactory;
 public class InMemoryStoragePlugin implements BesuPlugin {
 
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryStoragePlugin.class);
-  private ServiceManager context;
-  private InMemoryKeyValueStorageFactory factory;
+  private @Nullable ServiceManager context;
+  private @Nullable InMemoryKeyValueStorageFactory factory;
 
   /** Default constructor */
   public InMemoryStoragePlugin() {}
@@ -78,7 +80,7 @@ public class InMemoryStoragePlugin implements BesuPlugin {
   }
 
   private void createFactoriesAndRegisterWithStorageService() {
-    context
+    Objects.requireNonNull(context)
         .getService(StorageService.class)
         .ifPresentOrElse(
             this::createAndRegister,

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +42,7 @@ import java.util.stream.StreamSupport;
 import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -390,14 +392,14 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
   private static class PeekingIterator<E> implements Iterator<E> {
     private final Iterator<E> iterator;
-    private E next;
+    private @Nullable E next;
 
     public PeekingIterator(final Iterator<E> iterator) {
       this.iterator = iterator;
       this.next = iterator.hasNext() ? iterator.next() : null;
     }
 
-    public E peek() {
+    public @Nullable E peek() {
       return next;
     }
 
@@ -408,7 +410,7 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
     @Override
     public E next() {
-      E oldNext = next;
+      E oldNext = Objects.requireNonNull(next);
       next = iterator.hasNext() ? iterator.next() : null;
       return oldNext;
     }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Objects;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
@@ -410,7 +410,10 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
     @Override
     public E next() {
-      E oldNext = Objects.requireNonNull(next);
+      final E oldNext = next;
+      if (oldNext == null) {
+        throw new NoSuchElementException();
+      }
       next = iterator.hasNext() ? iterator.next() : null;
       return oldNext;
     }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -36,6 +37,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This KeyValueStorage will keep data in memory up to some maximum number of elements. Elements are
@@ -164,19 +166,19 @@ public class LimitedInMemoryKeyValueStorage implements KeyValueStorage {
 
   private class MemoryTransaction implements KeyValueStorageTransaction {
 
-    private Map<Bytes, byte[]> updatedValues = new HashMap<>();
-    private Set<Bytes> removedKeys = new HashSet<>();
+    private @Nullable Map<Bytes, byte[]> updatedValues = new HashMap<>();
+    private @Nullable Set<Bytes> removedKeys = new HashSet<>();
 
     @Override
     public void put(final byte[] key, final byte[] value) {
-      updatedValues.put(Bytes.wrap(key), value);
-      removedKeys.remove(Bytes.wrap(key));
+      Objects.requireNonNull(updatedValues).put(Bytes.wrap(key), value);
+      Objects.requireNonNull(removedKeys).remove(Bytes.wrap(key));
     }
 
     @Override
     public void remove(final byte[] key) {
-      removedKeys.add(Bytes.wrap(key));
-      updatedValues.remove(Bytes.wrap(key));
+      Objects.requireNonNull(removedKeys).add(Bytes.wrap(key));
+      Objects.requireNonNull(updatedValues).remove(Bytes.wrap(key));
     }
 
     @Override
@@ -184,8 +186,8 @@ public class LimitedInMemoryKeyValueStorage implements KeyValueStorage {
       final Lock lock = rwLock.writeLock();
       lock.lock();
       try {
-        storage.putAll(updatedValues);
-        storage.invalidateAll(removedKeys);
+        storage.putAll(Objects.requireNonNull(updatedValues));
+        storage.invalidateAll(Objects.requireNonNull(removedKeys));
         updatedValues = null;
         removedKeys = null;
       } finally {
@@ -200,8 +202,8 @@ public class LimitedInMemoryKeyValueStorage implements KeyValueStorage {
 
     @Override
     public void close() {
-      updatedValues.clear();
-      removedKeys.clear();
+      Objects.requireNonNull(updatedValues).clear();
+      Objects.requireNonNull(removedKeys).clear();
     }
   }
 }

--- a/services/kvstore/src/test/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePluginTest.java
+++ b/services/kvstore/src/test/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePluginTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.services.kvstore;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class InMemoryStoragePluginTest {
+
+  @Test
+  void shouldFailToStartBeforeRegistration() {
+    final InMemoryStoragePlugin plugin = new InMemoryStoragePlugin();
+
+    assertThatThrownBy(plugin::start)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("In-memory storage plugin must be registered before it can be started");
+  }
+}


### PR DESCRIPTION
## PR description

Enable NullAway for the `services/kvstore` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.services.kvstore`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and JSpecify annotations with `compileOnly`
- models the in-memory storage plugin context and factory lifecycle as explicitly nullable
- models the layered peeking iterator lookahead as nullable while preserving its existing `hasNext()` contract
- models in-memory transaction state as unavailable after commit

Storage behavior, locking, commit and invalidation ordering, and on-disk formats are unchanged for valid execution paths.

## Fixed Issue(s)

Part of #10442 (`services/kvstore`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats or durable state.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :services:kvstore:spotlessApply` and `./gradlew --no-daemon :services:kvstore:build :services:kvstore:spotlessCheck --rerun-tasks`
- [x] unit tests: `./gradlew --no-daemon :services:kvstore:test --rerun-tasks`, focused `LayeredKeyValueStorageTest` and `NearestKeyValueStorageTest` from `plugins/rocksdb`, plus `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense`.