### PR TITLE
Enable NullAway for crypto algorithms

### DIFF
--- a/crypto/algorithms/build.gradle
+++ b/crypto/algorithms/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.crypto')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -32,6 +45,9 @@ jar {
 dependencies {
   api 'org.bouncycastle:bcprov-jdk18on'
   api 'org.slf4j:slf4j-api'
+
+  errorprone 'com.uber.nullaway:nullaway'
+  compileOnlyApi 'org.jspecify:jspecify'
 
   implementation 'net.java.dev.jna:jna'
   implementation 'io.consensys.tuweni:tuweni-bytes'

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/AbstractSECP256.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/AbstractSECP256.java
@@ -40,6 +40,7 @@ import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
+import org.jspecify.annotations.Nullable;
 
 /** The Abstract secp256. */
 public abstract class AbstractSECP256 implements SignatureAlgorithm {
@@ -293,7 +294,7 @@ public abstract class AbstractSECP256 implements SignatureAlgorithm {
    * @param dataHash Hash of the data that was signed.
    * @return An ECKey containing only the public part, or null if recovery wasn't possible.
    */
-  protected BigInteger recoverFromSignature(
+  protected @Nullable BigInteger recoverFromSignature(
       final int recId, final BigInteger r, final BigInteger s, final Bytes32 dataHash) {
     assert (recId >= 0);
     assert (r.signum() >= 0);

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
@@ -33,6 +33,7 @@ import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.signers.DSAKCalculator;
 import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,7 +207,7 @@ public class SECP256K1 extends AbstractSECP256 {
   }
 
   @Override
-  protected BigInteger recoverFromSignature(
+  protected @Nullable BigInteger recoverFromSignature(
       final int recId, final BigInteger r, final BigInteger s, final Bytes32 dataHash) {
     if (useNative) {
       return recoverFromSignatureNative(dataHash, new SECPSignature(r, s, (byte) recId))

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256R1.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECP256R1.java
@@ -26,6 +26,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.bouncycastle.crypto.signers.DSAKCalculator;
 import org.bouncycastle.crypto.signers.RandomDSAKCalculator;
 import org.bouncycastle.math.ec.custom.sec.SecP256R1Curve;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,7 +158,7 @@ public class SECP256R1 extends AbstractSECP256 {
   }
 
   @Override
-  protected BigInteger recoverFromSignature(
+  protected @Nullable BigInteger recoverFromSignature(
       final int recId, final BigInteger r, final BigInteger s, final Bytes32 dataHash) {
     if (useNative) {
       return recoverPublicKeyFromSignatureNative(dataHash, new SECPSignature(r, s, (byte) recId))

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECPPrivateKey.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECPPrivateKey.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 
 /** The Secp private key. */
 public class SECPPrivateKey implements java.security.PrivateKey {
@@ -98,7 +99,7 @@ public class SECPPrivateKey implements java.security.PrivateKey {
   }
 
   @Override
-  public String getFormat() {
+  public @Nullable String getFormat() {
     return null;
   }
 

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
@@ -25,6 +25,7 @@ import org.apache.tuweni.bytes.MutableBytes;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
+import org.jspecify.annotations.Nullable;
 
 /** The Secp public key. */
 public class SECPPublicKey implements java.security.PublicKey {
@@ -152,7 +153,7 @@ public class SECPPublicKey implements java.security.PublicKey {
   }
 
   @Override
-  public String getFormat() {
+  public @Nullable String getFormat() {
     return null;
   }
 

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/altbn128/AbstractFieldPoint.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/altbn128/AbstractFieldPoint.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Adapted from the pc_ecc (Apache 2 License) implementation:
@@ -98,7 +99,7 @@ public abstract class AbstractFieldPoint<U extends AbstractFieldPoint> implement
 
   @SuppressWarnings("unchecked")
   @Override
-  public U multiply(final U other) {
+  public @Nullable U multiply(final U other) {
     return null;
   }
 

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/altbn128/FieldPoint.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/altbn128/FieldPoint.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.crypto.altbn128;
 
 import java.math.BigInteger;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Adapted from the pc_ecc (Apache 2 License) implementation:
  * https://github.com/ethereum/py_ecc/blob/master/py_ecc/bn128/bn128_field_elements.py
@@ -46,7 +48,7 @@ public interface FieldPoint<T extends FieldPoint> {
    * @param other the other
    * @return the t
    */
-  T multiply(T other);
+  @Nullable T multiply(T other);
 
   /**
    * Multiply t.


### PR DESCRIPTION
## PR description

Enable NullAway for the `crypto/algorithms` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.crypto`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and exposes JSpecify annotations with `compileOnlyApi`
- documents that signature recovery can return null when no public key can be recovered, including native secp256k1 and secp256r1 paths
- records the nullable JCA key encoding-format result
- records the existing nullable `FieldPoint.multiply(FieldPoint)` contract

Signature generation, verification, public-key recovery, native-library selection, and altbn128 arithmetic are unchanged.

## Fixed Issue(s)

Part of #10442 (`crypto/algorithms`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats or persisted data.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :crypto:algorithms:spotlessApply` and `./gradlew --no-daemon :crypto:algorithms:build :crypto:algorithms:spotlessCheck --rerun-tasks`
- [x] unit tests: `./gradlew --no-daemon :crypto:algorithms:test --rerun-tasks`, plus `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense`.