### PR TITLE
Replay block pre-execution before tracing transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Replay block pre-execution state changes before JSON-RPC transaction tracing, so traces that depend on EIP-4788 beacon roots or EIP-2935 historical block hashes match block execution. [#9699](https://github.com/besu-eth/besu/issues/9699)
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)
 - Bonsai world state rolling failures are now logged at `WARN` instead of `INFO`, and a missing block header or trie log during a roll reports which block hash or trie log was missing. [#10859](https://github.com/besu-eth/besu/issues/10859)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Serialize `BftMiningCoordinator` `enable()`/`disable()` with `start()`/`stop()` so the mining state flips and their surrounding checks can no longer interleave with concurrent lifecycle transitions. [#10887](https://github.com/besu-eth/besu/pull/10887)
 - An EIP-7702 transaction with an empty `authorization_list` is now rejected by transaction validation rather than by RLP decoding. Over the Engine API such a transaction made the whole payload report `Failed to decode transactions from block parameter`, hiding both the rule that was broken and any other defect the transaction had. [#11193](https://github.com/besu-eth/besu/pull/11193)
 - `engine_newPayloadV4`+ now returns `-32602` for an `executionRequests` element consisting only of a type byte, as execution-apis requires, including when that type byte is one Besu does not recognize. Such an element was previously answered with an `INVALID` payload status. [#11194](https://github.com/besu-eth/besu/pull/11194)
+- Replay block pre-execution state changes before JSON-RPC transaction tracing, so traces that depend on EIP-4788 beacon roots or EIP-2935 historical block hashes match block execution. [#9699](https://github.com/besu-eth/besu/issues/9699)
 
 ### Additions and Improvements
 

--- a/app/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.datatypes.BlobGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceBlock.ChainUpdater;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.Tracer;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -155,17 +154,17 @@ public class TraceServiceImpl implements TraceService {
                         .getBlockByNumber(number)
                         .orElseThrow(() -> new RuntimeException("Block not found " + number)))
             .toList();
-    Tracer.processTracing(
-        blockchainQueries,
-        blocks.getFirst().getHash(),
-        traceableState -> {
-          final WorldUpdater worldStateUpdater = traceableState.updater();
-          final ChainUpdater chainUpdater = new ChainUpdater(traceableState, worldStateUpdater);
+    blockchainQueries.getAndMapWorldState(
+        blocks.getFirst().getHeader().getParentHash(),
+        mutableWorldState -> {
+          final WorldUpdater worldStateUpdater = mutableWorldState.updater();
+          final ChainUpdater chainUpdater = new ChainUpdater(mutableWorldState, worldStateUpdater);
           beforeTracing.accept(worldStateUpdater);
           final List<TransactionProcessingResult> results = new ArrayList<>();
           blocks.forEach(
               block ->
-                  results.addAll(trace(blockchain, block, traceableState, chainUpdater, tracer)));
+                  results.addAll(
+                      trace(blockchain, block, mutableWorldState, chainUpdater, tracer)));
           afterTracing.accept(chainUpdater.getNextUpdater());
           return Optional.of(results);
         });
@@ -177,16 +176,15 @@ public class TraceServiceImpl implements TraceService {
     final Blockchain blockchain = blockchainQueries.getBlockchain();
 
     final Optional<List<TransactionProcessingResult>> results =
-        Tracer.processTracing(
-            blockchainQueries,
-            block.getHash(),
-            traceableState ->
+        blockchainQueries.getAndMapWorldState(
+            block.getHeader().getParentHash(),
+            mutableWorldState ->
                 Optional.of(
                     trace(
                         blockchain,
                         block,
-                        traceableState,
-                        new ChainUpdater(traceableState),
+                        mutableWorldState,
+                        new ChainUpdater(mutableWorldState),
                         tracer)));
 
     return results;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHash.java
@@ -68,35 +68,33 @@ public abstract class AbstractTraceByHash implements JsonRpcMethod {
     return Tracer.processTracing(
             blockchainQueries,
             Optional.of(block.getHeader()),
-            mutableWorldState -> {
-              final TransactionTrace transactionTrace = getTransactionTrace(block, transactionHash);
+            traceableState -> {
+              final TransactionTrace transactionTrace =
+                  getTransactionTrace(traceableState, block, transactionHash);
               return Optional.ofNullable(getTraceStream(transactionTrace, block));
             })
         .orElse(Stream.empty());
   }
 
-  private TransactionTrace getTransactionTrace(final Block block, final Hash transactionHash) {
-    return Tracer.processTracing(
-            blockchainQueries,
-            Optional.of(block.getHeader()),
-            mutableWorldState ->
-                blockTracerSupplier
-                    .get()
-                    .trace(
-                        mutableWorldState,
-                        block,
-                        new DebugOperationTracer(
-                            OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                                .traceStorage(false)
-                                .traceMemory(false)
-                                .traceStack(true)
-                                .build(),
-                            false))
-                    .map(BlockTrace::getTransactionTraces)
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .filter(trxTrace -> trxTrace.getTransaction().getHash().equals(transactionHash))
-                    .findFirst())
+  private TransactionTrace getTransactionTrace(
+      final Tracer.TraceableState traceableState, final Block block, final Hash transactionHash) {
+    return blockTracerSupplier
+        .get()
+        .trace(
+            traceableState,
+            block,
+            new DebugOperationTracer(
+                OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                    .traceStorage(false)
+                    .traceMemory(false)
+                    .traceStack(true)
+                    .build(),
+                false))
+        .map(BlockTrace::getTransactionTraces)
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(trxTrace -> trxTrace.getTransaction().getHash().equals(transactionHash))
+        .findFirst()
         .orElseThrow();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
@@ -152,72 +152,82 @@ public class TraceFilter extends TraceBlock {
       return new JsonRpcSuccessResponse(
           requestContext.getRequest().getId(), resultArrayNode.getArrayNode());
     }
-    final BlockHeader header = block.get().getHeader();
+    final List<Block> blockList = getBlockList(currentBlockNumber, toBlock, block);
+    for (final Block blockToTrace : blockList) {
+      if (resultArrayNode.isFull()
+          || !traceBlockWithPipeline(filterParameter, blockToTrace, resultArrayNode)) {
+        break;
+      }
+    }
 
-    List<Block> blockList = getBlockList(currentBlockNumber, toBlock, block);
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(), resultArrayNode.getArrayNode());
+  }
 
-    ArrayNodeWrapper result =
-        Tracer.processTracing(
-                getBlockchainQueries(),
-                Optional.of(header),
-                traceableState -> {
-                  TraceFilterSource traceFilterSource =
-                      new TraceFilterSource(blockList, resultArrayNode);
-                  final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(header);
-                  final MainnetTransactionProcessor transactionProcessor =
-                      protocolSpec.getTransactionProcessor();
-                  final ChainUpdater chainUpdater = new ChainUpdater(traceableState);
-                  DebugOperationTracer debugOperationTracer =
-                      new DebugOperationTracer(
-                          OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                              .traceStorage(false)
-                              .traceMemory(false)
-                              .traceStack(true)
-                              .build(),
-                          false);
-                  ExecuteTransactionStep executeTransactionStep =
-                      new ExecuteTransactionStep(
-                          chainUpdater,
-                          transactionProcessor,
-                          getBlockchainQueries().getBlockchain(),
-                          debugOperationTracer,
-                          protocolSpec);
+  private boolean traceBlockWithPipeline(
+      final FilterParameter filterParameter,
+      final Block block,
+      final ArrayNodeWrapper resultArrayNode) {
+    final BlockHeader header = block.getHeader();
+    return Tracer.processTracing(
+            getBlockchainQueries(),
+            Optional.of(header),
+            traceableState -> {
+              final TraceFilterSource traceFilterSource =
+                  new TraceFilterSource(List.of(block), resultArrayNode);
+              final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(header);
+              final MainnetTransactionProcessor transactionProcessor =
+                  protocolSpec.getTransactionProcessor();
+              final ChainUpdater chainUpdater = new ChainUpdater(traceableState);
+              final DebugOperationTracer debugOperationTracer =
+                  new DebugOperationTracer(
+                      OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+                          .traceStorage(false)
+                          .traceMemory(false)
+                          .traceStack(true)
+                          .build(),
+                      false);
+              final ExecuteTransactionStep executeTransactionStep =
+                  new ExecuteTransactionStep(
+                      chainUpdater,
+                      transactionProcessor,
+                      getBlockchainQueries().getBlockchain(),
+                      debugOperationTracer,
+                      protocolSpec,
+                      block);
 
-                  Function<TransactionTrace, CompletableFuture<Stream<FlatTrace>>>
-                      traceFlatTransactionStep =
-                          new TraceFlatTransactionStep(
-                              protocolSchedule, null, Optional.of(filterParameter));
+              final Function<TransactionTrace, CompletableFuture<Stream<FlatTrace>>>
+                  traceFlatTransactionStep =
+                      new TraceFlatTransactionStep(
+                          protocolSchedule, block, Optional.of(filterParameter));
 
-                  BuildArrayNodeCompleterStep buildArrayNodeStep =
-                      new BuildArrayNodeCompleterStep(resultArrayNode);
-                  Pipeline<TransactionTrace> traceBlockPipeline =
-                      createPipelineFrom(
-                              "getTransactions",
-                              traceFilterSource,
-                              4,
-                              outputCounter,
-                              false,
-                              "trace_block_transactions")
-                          .thenProcess("executeTransaction", executeTransactionStep)
-                          .thenProcessAsyncOrdered(
-                              "traceFlatTransaction", traceFlatTransactionStep, 4)
-                          .andFinishWith(
-                              "buildArrayNode",
-                              traceStream -> traceStream.forEachOrdered(buildArrayNodeStep));
+              final BuildArrayNodeCompleterStep buildArrayNodeStep =
+                  new BuildArrayNodeCompleterStep(resultArrayNode);
+              final Pipeline<TransactionTrace> traceBlockPipeline =
+                  createPipelineFrom(
+                          "getTransactions",
+                          traceFilterSource,
+                          4,
+                          outputCounter,
+                          false,
+                          "trace_block_transactions")
+                      .thenProcess("executeTransaction", executeTransactionStep)
+                      .thenProcessAsyncOrdered("traceFlatTransaction", traceFlatTransactionStep, 4)
+                      .andFinishWith(
+                          "buildArrayNode",
+                          traceStream -> traceStream.forEachOrdered(buildArrayNodeStep));
 
-                  try {
-                    ethScheduler.startPipeline(traceBlockPipeline).get();
-                  } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                  } catch (ExecutionException e) {
-                    throw new RuntimeException(e);
-                  }
-                  return Optional.of(resultArrayNode);
-                })
-            .orElse(emptyResult());
-
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result.getArrayNode());
+              try {
+                ethScheduler.startPipeline(traceBlockPipeline).get();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+              }
+              return Optional.of(resultArrayNode);
+            })
+        .isPresent();
   }
 
   @NotNull

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/Tracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/Tracer.java
@@ -18,7 +18,11 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.hyperledger.besu.plugin.services.worldstate.StateRootCommitter;
@@ -43,13 +47,34 @@ public class Tracer {
       final BlockchainQueries blockchainQueries,
       final Optional<BlockHeader> blockHeader,
       final Function<TraceableState, ? extends Optional<TRACE>> mapper) {
-    return blockHeader
-        .map(BlockHeader::getParentHash)
-        .flatMap(
-            parentHash ->
-                blockchainQueries.getAndMapWorldState(
-                    parentHash,
-                    mutableWorldState -> mapper.apply(new TraceableState(mutableWorldState))));
+    return blockHeader.flatMap(
+        header ->
+            blockchainQueries.getAndMapWorldState(
+                header.getParentHash(),
+                mutableWorldState -> {
+                  processPreExecution(blockchainQueries, header, mutableWorldState);
+                  return mapper.apply(new TraceableState(mutableWorldState));
+                }));
+  }
+
+  private static void processPreExecution(
+      final BlockchainQueries blockchainQueries,
+      final BlockHeader blockHeader,
+      final MutableWorldState mutableWorldState) {
+    final ProtocolSpec protocolSpec = blockchainQueries.getProtocolSpec(blockHeader);
+    final BlockHashLookup blockHashLookup =
+        protocolSpec
+            .getPreExecutionProcessor()
+            .createBlockHashLookup(blockchainQueries.getBlockchain(), blockHeader);
+    final BlockProcessingContext blockProcessingContext =
+        new BlockProcessingContext(
+            blockHeader,
+            mutableWorldState,
+            protocolSpec,
+            blockHashLookup,
+            OperationTracer.NO_TRACING,
+            Optional.empty());
+    protocolSpec.getPreExecutionProcessor().process(blockProcessingContext, Optional.empty());
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/pluginadapter/TraceServiceImpl.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/pluginadapter/TraceServiceImpl.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.datatypes.BlobGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceBlock.ChainUpdater;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.Tracer;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -155,17 +154,17 @@ public class TraceServiceImpl implements TraceService {
                         .getBlockByNumber(number)
                         .orElseThrow(() -> new RuntimeException("Block not found " + number)))
             .toList();
-    Tracer.processTracing(
-        blockchainQueries,
-        blocks.getFirst().getHash(),
-        traceableState -> {
-          final WorldUpdater worldStateUpdater = traceableState.updater();
-          final ChainUpdater chainUpdater = new ChainUpdater(traceableState, worldStateUpdater);
+    blockchainQueries.getAndMapWorldState(
+        blocks.getFirst().getHeader().getParentHash(),
+        mutableWorldState -> {
+          final WorldUpdater worldStateUpdater = mutableWorldState.updater();
+          final ChainUpdater chainUpdater = new ChainUpdater(mutableWorldState, worldStateUpdater);
           beforeTracing.accept(worldStateUpdater);
           final List<TransactionProcessingResult> results = new ArrayList<>();
           blocks.forEach(
               block ->
-                  results.addAll(trace(blockchain, block, traceableState, chainUpdater, tracer)));
+                  results.addAll(
+                      trace(blockchain, block, mutableWorldState, chainUpdater, tracer)));
           afterTracing.accept(chainUpdater.getNextUpdater());
           return Optional.of(results);
         });
@@ -177,16 +176,15 @@ public class TraceServiceImpl implements TraceService {
     final Blockchain blockchain = blockchainQueries.getBlockchain();
 
     final Optional<List<TransactionProcessingResult>> results =
-        Tracer.processTracing(
-            blockchainQueries,
-            block.getHash(),
-            traceableState ->
+        blockchainQueries.getAndMapWorldState(
+            block.getHeader().getParentHash(),
+            mutableWorldState ->
                 Optional.of(
                     trace(
                         blockchain,
                         block,
-                        traceableState,
-                        new ChainUpdater(traceableState),
+                        mutableWorldState,
+                        new ChainUpdater(mutableWorldState),
                         tracer)));
 
     return results;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -203,6 +203,10 @@ public class BlockchainQueries {
     return blockchain;
   }
 
+  public ProtocolSpec getProtocolSpec(final BlockHeader blockHeader) {
+    return protocolSchedule.getByBlockHeader(blockHeader);
+  }
+
   public WorldStateArchive getWorldStateArchive() {
     return worldStateArchive;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHashTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.Tracer;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTraceGenerator;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
+import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
+import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractTraceByHashTest {
+
+  @Mock private Supplier<BlockTracer> blockTracerSupplier;
+  @Mock private BlockTracer blockTracer;
+  @Mock private BlockchainQueries blockchainQueries;
+  @Mock private Blockchain blockchain;
+  @Mock private ProtocolSchedule protocolSchedule;
+  @Mock private ProtocolSpec protocolSpec;
+  @Mock private PreExecutionProcessor preExecutionProcessor;
+  @Mock private BlockHashLookup blockHashLookup;
+  @Mock private MutableWorldState mutableWorldState;
+  @Mock private WorldUpdater worldUpdater;
+  @Mock private TransactionWithMetadata transactionWithMetadata;
+  @Mock private Block block;
+  @Mock private BlockHeader blockHeader;
+  @Mock private BlockBody blockBody;
+  @Mock private Transaction transaction;
+  @Mock private TransactionTrace transactionTrace;
+  @Mock private FlatTrace flatTrace;
+
+  private AbstractTraceByHash traceByHash;
+
+  @BeforeEach
+  void setUp() {
+    traceByHash = new TraceTransaction(blockTracerSupplier, protocolSchedule, blockchainQueries);
+  }
+
+  @Test
+  void reusesPreExecutedWorldStateForBlockTracing() {
+    final Hash transactionHash = Hash.fromHexStringLenient("0x01");
+    final Hash parentHash = Hash.fromHexStringLenient("0x02");
+    final long blockNumber = 3L;
+
+    when(blockchainQueries.transactionByHash(transactionHash))
+        .thenReturn(Optional.of(transactionWithMetadata));
+    when(transactionWithMetadata.getBlockNumber()).thenReturn(Optional.of(blockNumber));
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getBlockByNumber(blockNumber)).thenReturn(Optional.of(block));
+    when(block.getBody()).thenReturn(blockBody);
+    when(blockBody.getTransactions()).thenReturn(List.of(transaction));
+    when(block.getHeader()).thenReturn(blockHeader);
+    when(blockHeader.getParentHash()).thenReturn(parentHash);
+    when(blockchainQueries.getProtocolSpec(blockHeader)).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
+    when(preExecutionProcessor.createBlockHashLookup(blockchain, blockHeader))
+        .thenReturn(blockHashLookup);
+    when(blockchainQueries.getAndMapWorldState(eq(parentHash), any()))
+        .thenAnswer(
+            invocation -> {
+              final Function<MutableWorldState, ? extends Optional<Stream<FlatTrace>>> mapper =
+                  invocation.getArgument(1);
+              return mapper.apply(mutableWorldState);
+            });
+    when(blockTracerSupplier.get()).thenReturn(blockTracer);
+    when(blockTracer.trace(
+            any(Tracer.TraceableState.class), same(block), any(DebugOperationTracer.class)))
+        .thenReturn(Optional.of(new BlockTrace(List.of(transactionTrace))));
+    when(transactionTrace.getTransaction()).thenReturn(transaction);
+    when(transaction.getHash()).thenReturn(transactionHash);
+    when(mutableWorldState.updater()).thenReturn(worldUpdater);
+
+    try (final MockedStatic<FlatTraceGenerator> flatTraceGenerator =
+        mockStatic(FlatTraceGenerator.class)) {
+      flatTraceGenerator
+          .when(
+              () ->
+                  FlatTraceGenerator.generateFromTransactionTraceAndBlock(
+                      protocolSchedule, transactionTrace, block))
+          .thenReturn(Stream.of(flatTrace));
+
+      assertThat(traceByHash.resultByTransactionHash(transactionHash)).containsExactly(flatTrace);
+
+      flatTraceGenerator.verify(
+          () ->
+              FlatTraceGenerator.generateFromTransactionTraceAndBlock(
+                  protocolSchedule, transactionTrace, block));
+    }
+
+    verify(blockchainQueries, times(1)).getAndMapWorldState(eq(parentHash), any());
+
+    final ArgumentCaptor<BlockProcessingContext> contextCaptor =
+        ArgumentCaptor.forClass(BlockProcessingContext.class);
+    verify(preExecutionProcessor, times(1)).process(contextCaptor.capture(), eq(Optional.empty()));
+    assertThat(contextCaptor.getValue().getWorldState()).isSameAs(mutableWorldState);
+
+    final ArgumentCaptor<Tracer.TraceableState> traceableStateCaptor =
+        ArgumentCaptor.forClass(Tracer.TraceableState.class);
+    verify(blockTracer)
+        .trace(traceableStateCaptor.capture(), same(block), any(DebugOperationTracer.class));
+    assertThat(traceableStateCaptor.getValue().updater()).isSameAs(worldUpdater);
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
@@ -37,6 +37,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.tracing.TraceFrame;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -72,6 +74,8 @@ class DebugAccountAtTest {
   @Mock private Transaction transaction;
   @Mock private WorldUpdater worldUpdater;
   @Mock private MutableWorldState worldState;
+  @Mock private ProtocolSpec protocolSpec;
+  @Mock private PreExecutionProcessor preExecutionProcessor;
 
   @Mock private Account account;
 
@@ -173,14 +177,7 @@ class DebugAccountAtTest {
 
   @Test
   void testTransactionNotFoundResponse() {
-    doAnswer(
-            invocation ->
-                invocation
-                    .<Function<MutableWorldState, Optional<? extends JsonRpcResponse>>>getArgument(
-                        1)
-                    .apply(worldState))
-        .when(blockchainQueries)
-        .getAndMapWorldState(any(), any());
+    setupTracing();
 
     setupMockBlock();
     Mockito.when(blockWithMetadata.getTransactions())
@@ -199,14 +196,7 @@ class DebugAccountAtTest {
 
   @Test
   void testNoAccountFoundResponse() {
-    doAnswer(
-            invocation ->
-                invocation
-                    .<Function<MutableWorldState, Optional<? extends JsonRpcResponse>>>getArgument(
-                        1)
-                    .apply(worldState))
-        .when(blockchainQueries)
-        .getAndMapWorldState(any(), any());
+    setupTracing();
 
     setupMockTransaction();
     setupMockBlock();
@@ -225,14 +215,7 @@ class DebugAccountAtTest {
 
   @Test
   void shouldBeSuccessfulWhenTransactionsAndAccountArePresent() {
-    doAnswer(
-            invocation ->
-                invocation
-                    .<Function<MutableWorldState, Optional<? extends JsonRpcResponse>>>getArgument(
-                        1)
-                    .apply(worldState))
-        .when(blockchainQueries)
-        .getAndMapWorldState(any(), any());
+    setupTracing();
 
     final String codeString =
         "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b";
@@ -271,6 +254,20 @@ class DebugAccountAtTest {
     Mockito.when(traceFrame.getWorldUpdater()).thenReturn(worldUpdater);
     Mockito.when(worldUpdater.get(any())).thenReturn(account);
     Mockito.when(account.getAddress()).thenReturn(Address.ZERO);
+  }
+
+  private void setupTracing() {
+    doAnswer(
+            invocation ->
+                invocation
+                    .<Function<MutableWorldState, Optional<? extends JsonRpcResponse>>>getArgument(
+                        1)
+                    .apply(worldState))
+        .when(blockchainQueries)
+        .getAndMapWorldState(any(), any());
+    Mockito.when(blockWithMetadata.getHeader()).thenReturn(blockHeader);
+    Mockito.when(blockchainQueries.getProtocolSpec(blockHeader)).thenReturn(protocolSpec);
+    Mockito.when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
   }
 
   private void setupMockTransaction() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
@@ -33,6 +33,8 @@ import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.nio.file.Path;
@@ -56,6 +58,8 @@ public class DebugStandardTraceBadBlockToFileTest {
 
   private final ProtocolContext protocolContext = mock(ProtocolContext.class);
   private final TransactionTracer transactionTracer = mock(TransactionTracer.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+  private final PreExecutionProcessor preExecutionProcessor = mock(PreExecutionProcessor.class);
 
   private final BadBlockManager badBlockManager = new BadBlockManager();
 
@@ -66,6 +70,8 @@ public class DebugStandardTraceBadBlockToFileTest {
   @BeforeEach
   public void setup() {
     when(protocolContext.getBadBlockManager()).thenReturn(badBlockManager);
+    when(blockchainQueries.getProtocolSpec(any())).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
     doAnswer(
             invocation ->
                 invocation

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFileTest.java
@@ -30,6 +30,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 import java.nio.file.Path;
@@ -49,6 +51,8 @@ public class DebugStandardTraceBlockToFileTest {
   private final Blockchain blockchain = mock(Blockchain.class);
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final TransactionTracer transactionTracer = mock(TransactionTracer.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+  private final PreExecutionProcessor preExecutionProcessor = mock(PreExecutionProcessor.class);
   private final DebugStandardTraceBlockToFile debugStandardTraceBlockToFile =
       new DebugStandardTraceBlockToFile(() -> transactionTracer, blockchainQueries, folder);
 
@@ -77,6 +81,8 @@ public class DebugStandardTraceBlockToFileTest {
     when(blockchain.getBlockByHash(block.getHash())).thenReturn(Optional.of(block));
     when(blockchain.getBlockHeader(genesis.getHash())).thenReturn(Optional.of(genesis.getHeader()));
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchainQueries.getProtocolSpec(block.getHeader())).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
 
     when(blockchainQueries.getAndMapWorldState(any(), any()))
         .thenAnswer(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
@@ -40,6 +40,8 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.AccountStorageEntry;
 import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
@@ -73,6 +75,8 @@ public class DebugStorageRangeAtTest {
   private final Account account = mock(Account.class);
   private final MainnetTransactionProcessor transactionProcessor =
       mock(MainnetTransactionProcessor.class);
+  private final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+  private final PreExecutionProcessor preExecutionProcessor = mock(PreExecutionProcessor.class);
   private final Transaction transaction = mock(Transaction.class);
 
   private final BlockHeader blockHeader = mock(BlockHeader.class, Answers.RETURNS_DEEP_STUBS);
@@ -85,6 +89,8 @@ public class DebugStorageRangeAtTest {
   @BeforeEach
   public void setUp() {
     when(transaction.getHash()).thenReturn(transactionHash);
+    when(blockchainQueries.getProtocolSpec(blockHeader)).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -15,8 +15,15 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
@@ -24,17 +31,35 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParam
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.mainnet.BlockProcessor;
+import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
+import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.hyperledger.besu.testutil.DeterministicEthScheduler;
 
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,6 +71,100 @@ public class TraceFilterTest {
   @Mock Supplier<BlockTracer> blockTracerSupplier;
   @Mock ProtocolSchedule protocolSchedule;
   @Mock BlockchainQueries blockchainQueries;
+
+  @Test
+  public void shouldApplyPreExecutionForEveryBlockInRange() throws InterruptedException {
+    final BlockDataGenerator blockGenerator = new BlockDataGenerator();
+    final Block genesis = blockGenerator.genesisBlock();
+    final Block firstBlock =
+        blockGenerator.block(
+            new BlockDataGenerator.BlockOptions()
+                .setBlockNumber(1)
+                .setParentHash(genesis.getHash())
+                .hasTransactions(false)
+                .hasOmmers(false));
+    final Block secondBlock =
+        blockGenerator.block(
+            new BlockDataGenerator.BlockOptions()
+                .setBlockNumber(2)
+                .setParentHash(firstBlock.getHash())
+                .hasTransactions(false)
+                .hasOmmers(false));
+    final Blockchain blockchain = mock(Blockchain.class);
+    final ProtocolSpec firstProtocolSpec = mock(ProtocolSpec.class);
+    final ProtocolSpec secondProtocolSpec = mock(ProtocolSpec.class);
+    final PreExecutionProcessor firstPreExecutionProcessor = mock(PreExecutionProcessor.class);
+    final PreExecutionProcessor secondPreExecutionProcessor = mock(PreExecutionProcessor.class);
+    final BlockHashLookup firstBlockHashLookup = mock(BlockHashLookup.class);
+    final BlockHashLookup secondBlockHashLookup = mock(BlockHashLookup.class);
+    final MutableWorldState firstWorldState = mock(MutableWorldState.class);
+    final MutableWorldState secondWorldState = mock(MutableWorldState.class);
+
+    when(blockchainQueries.headBlockNumber()).thenReturn(2L);
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getBlockByNumber(1L)).thenReturn(Optional.of(firstBlock));
+    when(blockchain.getBlockByNumber(2L)).thenReturn(Optional.of(secondBlock));
+    setupProtocolSpec(
+        blockchain,
+        firstBlock,
+        firstProtocolSpec,
+        firstPreExecutionProcessor,
+        firstBlockHashLookup);
+    setupProtocolSpec(
+        blockchain,
+        secondBlock,
+        secondProtocolSpec,
+        secondPreExecutionProcessor,
+        secondBlockHashLookup);
+
+    doAnswer(
+            invocation -> {
+              final Function<MutableWorldState, ?> mapper = invocation.getArgument(1);
+              return mapper.apply(
+                  invocation.getArgument(0).equals(firstBlock.getHeader().getParentHash())
+                      ? firstWorldState
+                      : secondWorldState);
+            })
+        .when(blockchainQueries)
+        .getAndMapWorldState(any(), any());
+
+    final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
+    final EthScheduler ethScheduler = new EthScheduler(1, 1, 1, metricsSystem);
+    method =
+        new TraceFilter(protocolSchedule, blockchainQueries, 100L, metricsSystem, ethScheduler);
+    final FilterParameter filterParameter =
+        new FilterParameter(
+            new BlockParameter(1L), new BlockParameter(2L), null, null, null, null, null, 1, 1);
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("2.0", "trace_filter", new Object[] {filterParameter}));
+
+    try {
+      final JsonRpcResponse response = method.response(request);
+
+      assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
+      assertThat((ArrayNode) ((JsonRpcSuccessResponse) response).getResult()).hasSize(1);
+      assertPreExecutionContext(
+          firstPreExecutionProcessor,
+          firstBlock,
+          firstProtocolSpec,
+          firstBlockHashLookup,
+          firstWorldState);
+      assertPreExecutionContext(
+          secondPreExecutionProcessor,
+          secondBlock,
+          secondProtocolSpec,
+          secondBlockHashLookup,
+          secondWorldState);
+      verify(blockchainQueries)
+          .getAndMapWorldState(eq(firstBlock.getHeader().getParentHash()), any());
+      verify(blockchainQueries)
+          .getAndMapWorldState(eq(secondBlock.getHeader().getParentHash()), any());
+    } finally {
+      ethScheduler.stop();
+      ethScheduler.awaitStop();
+    }
+  }
 
   @ParameterizedTest
   @CsvSource({"0, 1001, 1000", "1, 6002, 1000", "1000, 3000, 500"})
@@ -83,5 +202,45 @@ public class TraceFilterTest {
 
     final JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(RpcErrorType.EXCEEDS_RPC_MAX_BLOCK_RANGE);
+  }
+
+  private void setupProtocolSpec(
+      final Blockchain blockchain,
+      final Block block,
+      final ProtocolSpec protocolSpec,
+      final PreExecutionProcessor preExecutionProcessor,
+      final BlockHashLookup blockHashLookup) {
+    final BlockProcessor blockProcessor = mock(BlockProcessor.class);
+    final MiningBeneficiaryCalculator miningBeneficiaryCalculator =
+        mock(MiningBeneficiaryCalculator.class);
+    when(blockchainQueries.getProtocolSpec(block.getHeader())).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockHeader(block.getHeader())).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
+    when(preExecutionProcessor.createBlockHashLookup(blockchain, block.getHeader()))
+        .thenReturn(blockHashLookup);
+    when(protocolSpec.getBlockReward()).thenReturn(Wei.ZERO);
+    when(protocolSpec.getBlockProcessor()).thenReturn(blockProcessor);
+    when(blockProcessor.getCoinbaseReward(Wei.ZERO, block.getHeader().getNumber(), 0))
+        .thenReturn(Wei.ZERO);
+    when(protocolSpec.getMiningBeneficiaryCalculator()).thenReturn(miningBeneficiaryCalculator);
+    when(miningBeneficiaryCalculator.calculateBeneficiary(block.getHeader()))
+        .thenReturn(Address.ZERO);
+  }
+
+  private void assertPreExecutionContext(
+      final PreExecutionProcessor preExecutionProcessor,
+      final Block block,
+      final ProtocolSpec protocolSpec,
+      final BlockHashLookup blockHashLookup,
+      final MutableWorldState worldState) {
+    final ArgumentCaptor<BlockProcessingContext> contextCaptor =
+        ArgumentCaptor.forClass(BlockProcessingContext.class);
+    verify(preExecutionProcessor).process(contextCaptor.capture(), eq(Optional.empty()));
+    assertThat(contextCaptor.getValue().getBlockHeader()).isEqualTo(block.getHeader());
+    assertThat(contextCaptor.getValue().getProtocolSpec()).isSameAs(protocolSpec);
+    assertThat(contextCaptor.getValue().getBlockHashLookup()).isSameAs(blockHashLookup);
+    assertThat(contextCaptor.getValue().getWorldState()).isSameAs(worldState);
+    assertThat(contextCaptor.getValue().getOperationTracer()).isSameAs(OperationTracer.NO_TRACING);
+    assertThat(contextCaptor.getValue().getBlockAccessListBuilder()).isEmpty();
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TracerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TracerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldState;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MiningConfiguration;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.blockhash.PreExecutionProcessor;
+import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TracerTest {
+
+  @Mock private ProtocolSchedule protocolSchedule;
+  @Mock private Blockchain blockchain;
+  @Mock private WorldStateArchive worldStateArchive;
+  @Mock private MiningConfiguration miningConfiguration;
+  @Mock private BlockHeader blockHeader;
+  @Mock private BlockHeader parentBlockHeader;
+  @Mock private ProtocolSpec protocolSpec;
+  @Mock private PreExecutionProcessor preExecutionProcessor;
+  @Mock private BlockHashLookup blockHashLookup;
+
+  @Test
+  void appliesPreExecutionStateChangesBeforeTracing() {
+    final Hash parentHash = Hash.fromHexStringLenient("0x01");
+    final Hash parentStateRoot = Hash.fromHexStringLenient("0x02");
+    final Address preExecutionAddress = Address.fromHexString("0x1234");
+    final long preExecutionNonce = 42L;
+    final MutableWorldState worldState = createInMemoryWorldState();
+    final BlockchainQueries blockchainQueries =
+        new BlockchainQueries(protocolSchedule, blockchain, worldStateArchive, miningConfiguration);
+
+    when(blockHeader.getParentHash()).thenReturn(parentHash);
+    when(blockchain.getBlockHeader(parentHash)).thenReturn(Optional.of(parentBlockHeader));
+    when(parentBlockHeader.getBlockHash()).thenReturn(parentHash);
+    when(parentBlockHeader.getStateRoot()).thenReturn(parentStateRoot);
+    when(worldStateArchive.getWorldState(any(WorldStateQueryParams.class)))
+        .thenReturn(Optional.of(worldState));
+    when(protocolSchedule.getByBlockHeader(blockHeader)).thenReturn(protocolSpec);
+    when(protocolSpec.getPreExecutionProcessor()).thenReturn(preExecutionProcessor);
+    when(preExecutionProcessor.createBlockHashLookup(blockchain, blockHeader))
+        .thenReturn(blockHashLookup);
+
+    doAnswer(
+            invocation -> {
+              final BlockProcessingContext context = invocation.getArgument(0);
+              final var updater = context.getWorldState().updater();
+              updater.getOrCreate(preExecutionAddress).setNonce(preExecutionNonce);
+              updater.commit();
+              return null;
+            })
+        .when(preExecutionProcessor)
+        .process(any(), eq(Optional.empty()));
+
+    final Optional<Long> result =
+        Tracer.processTracing(
+            blockchainQueries,
+            Optional.of(blockHeader),
+            traceableState -> Optional.of(traceableState.get(preExecutionAddress).getNonce()));
+
+    assertThat(result).contains(preExecutionNonce);
+
+    final ArgumentCaptor<BlockProcessingContext> contextCaptor =
+        ArgumentCaptor.forClass(BlockProcessingContext.class);
+    verify(preExecutionProcessor).process(contextCaptor.capture(), eq(Optional.empty()));
+
+    final BlockProcessingContext context = contextCaptor.getValue();
+    assertThat(context.getBlockHeader()).isSameAs(blockHeader);
+    assertThat(context.getWorldState()).isSameAs(worldState);
+    assertThat(context.getProtocolSpec()).isSameAs(protocolSpec);
+    assertThat(context.getBlockHashLookup()).isSameAs(blockHashLookup);
+    assertThat(context.getOperationTracer()).isSameAs(OperationTracer.NO_TRACING);
+    assertThat(context.getBlockAccessListBuilder()).isEmpty();
+  }
+}


### PR DESCRIPTION
## PR description

Historical JSON-RPC tracing starts from the parent world state but previously replayed transactions without applying the target block pre-execution state changes. On Cancun and Prague blocks, traced transactions could therefore observe state that differs from normal block execution, including EIP-4788 beacon roots and EIP-2935 historical block hashes.

This change:

- resolves the target block `ProtocolSpec`
- creates a branch-aware block-hash lookup for the target header
- runs target block pre-execution exactly once with `OperationTracer.NO_TRACING` before invoking the trace mapper
- replays every `trace_filter` block from its canonical parent state, preserving prior block withdrawals, requests, and reward effects while keeping global `after` and `count` pagination
- keeps the plugin `TraceService` on its existing block-aware pre-execution path to avoid duplicate processing
- adds real-state and multi-block regressions, including an empty-block range crossing different protocol specs
- records the user-visible fix in the changelog

This does not change public RPC schemas, Plugin API contracts, database formats, or persisted data.

## Fixed Issue(s)

Fixes #9699

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this does not change database formats or persisted data.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew :ethereum:api:spotlessApply :ethereum:api:spotlessCheck` and `./gradlew :ethereum:api:spotlessCheck :app:spotlessCheck`
- [x] unit tests: `GRADLE_MAX_TEST_FORKS=1 ./gradlew :ethereum:api:test` and `GRADLE_MAX_TEST_FORKS=1 ./gradlew :app:test`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests) — not run; this does not modify Engine or consensus-facing APIs.

Additional validation: focused `TracerTest`, `TraceFilterTest`, and `TraceServiceImplTest`; `git diff --check upstream/main...HEAD`.