### PR TITLE
Remove inert RocksDB partition filter option

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -298,7 +298,6 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
         .setFormatVersion(ROCKSDB_FORMAT_VERSION)
         .setBlockCache(cache)
         .setFilterPolicy(new BloomFilter(10, false))
-        .setPartitionFilters(true)
         .setCacheIndexAndFilterBlocks(segment.isCacheIndexAndFilterBlocks())
         .setBlockSize(ROCKSDB_BLOCK_SIZE);
   }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorageTest.java
@@ -52,6 +52,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.IndexType;
 
 public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValueStorageTest {
 
@@ -61,6 +63,21 @@ public abstract class RocksDBColumnarKeyValueStorageTest extends AbstractKeyValu
   @Mock private OperationTimer operationTimerMock;
 
   @TempDir public Path folder;
+
+  @Test
+  public void configuresNonPartitionedBloomFilters() throws Exception {
+    try (final RocksDBColumnarKeyValueStorage store =
+        (RocksDBColumnarKeyValueStorage) createSegmentedStore()) {
+      assertThat(store.columnDescriptors)
+          .allSatisfy(
+              descriptor -> {
+                final BlockBasedTableConfig tableConfig =
+                    (BlockBasedTableConfig) descriptor.getOptions().tableFormatConfig();
+                assertThat(tableConfig.indexType()).isEqualTo(IndexType.kBinarySearch);
+                assertThat(tableConfig.partitionFilters()).isFalse();
+              });
+    }
+  }
 
   @Test
   public void assertClear() throws Exception {


### PR DESCRIPTION
## PR description

RocksDB requires `IndexType.kTwoLevelIndexSearch` before partitioned filters can be enabled. Besu configures the default `kBinarySearch` index, so RocksDB has always sanitized `partition_filters` back to `false`.

This change removes the ineffective `setPartitionFilters(true)` call and adds regression coverage that verifies every configured column family uses the binary-search index with non-partitioned filters.

### Why remove the option instead of enabling it

The original bloom-filter change in #4682 explicitly introduced and benchmarked full, non-block Bloom filters. Enabling the two-level index now would change the format of newly written SST files and introduce a different memory and lookup-latency tradeoff without Besu-specific benchmark evidence.

Removing the inert option:

- matches Besu's effective behavior since 2022
- preserves existing database compatibility and runtime characteristics
- makes the configured behavior agree with the effective RocksDB options
- prevents downstream tools from interpreting the Java configuration as proof that Besu writes partitioned filters

The regression test runs against both transaction database implementations and checks the table configuration for every column family.

## Fixed Issue(s)

Fixes #10946

## Testing

- `./gradlew :plugins:rocksdb:test`
- `./gradlew :plugins:rocksdb:spotlessCheck`

## Documentation and compatibility

- [x] Contribution guidelines reviewed
- [x] User-facing documentation considered. No update is needed because effective runtime behavior is unchanged.
- [x] Changelog considered. No entry is needed because effective runtime behavior is unchanged.
- [x] Database compatibility considered. This change does not alter persisted data or the effective RocksDB configuration.
- [x] Plugin-scoped formatting checks pass.
- [x] Plugin-scoped unit tests pass.
- [ ] Acceptance tests are not applicable to this configuration cleanup.
