### PR TITLE
ForkchoiceUpdate: verify world state is available for the newHead otherwise return syncing

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -157,6 +157,13 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
 
     final BlockHeader newHead = maybeNewHead.get();
 
+    // verify world state is available for the newHead otherwise return syncing
+    if (!protocolContext
+        .getWorldStateArchive()
+        .isWorldStateAvailable(newHead.getStateRoot(), newHead.getHash())) {
+      return syncingResponse(requestId, forkChoice);
+    }
+
     // 5. Client software MUST return -38002: Invalid forkchoice state error if the payload
     // referenced by forkchoiceState.headBlockHash is VALID and a payload referenced by either
     // forkchoiceState.finalizedBlockHash or forkchoiceState.safeBlockHash does not belong to the

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -52,6 +52,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
@@ -91,13 +92,16 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   @Mock protected MergeMiningCoordinator mergeCoordinator;
   @Mock protected MutableBlockchain blockchain;
   @Mock protected EngineCallListener engineCallListener;
+  @Mock protected WorldStateArchive worldStateArchive;
 
   @Override
   @BeforeEach
   public void before() {
     super.before();
+    when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(true);
     when(protocolContext.safeConsensusContext(any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(protocolContext.getWorldStateArchive()).thenReturn(worldStateArchive);
     when(protocolSchedule.getForNextBlockHeader(any(), anyLong())).thenReturn(protocolSpec);
     when(mergeCoordinator.preparePayload(any())).thenReturn(new PayloadIdentifier(1337L));
     createMethod();
@@ -196,15 +200,23 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   }
 
   @Test
-  public void shouldReturnSyncingIfMissingNewHead() {
+  public void shouldReturnSyncingOnHeadBlockNotFound() {
     assertSuccessWithPayloadForForkchoiceResult(
         mockFcuParam, Optional.empty(), mock(ForkchoiceResult.class), SYNCING);
   }
 
   @Test
-  public void shouldReturnSyncingOnHeadNotFound() {
+  public void shouldReturnSyncingOnHeadWorldStateNotFound() {
+    // block for head hash exists, but world state does not
+    final BlockHeader mockHeader = blockHeaderBuilder.buildHeader();
+    when(mergeCoordinator.getOrSyncHeadByHash(mockHeader.getHash(), Hash.ZERO))
+        .thenReturn(Optional.of(mockHeader));
+    when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(false);
     assertSuccessWithPayloadForForkchoiceResult(
-        mockFcuParam, Optional.empty(), mock(ForkchoiceResult.class), SYNCING);
+        new ForkchoiceStateV1(mockHeader.getHash(), Hash.ZERO, Hash.ZERO),
+        Optional.empty(),
+        mock(ForkchoiceResult.class),
+        SYNCING);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -211,7 +211,9 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
     final BlockHeader mockHeader = blockHeaderBuilder.buildHeader();
     when(mergeCoordinator.getOrSyncHeadByHash(mockHeader.getHash(), Hash.ZERO))
         .thenReturn(Optional.of(mockHeader));
-    when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(false);
+    when(worldStateArchive.isWorldStateAvailable(
+            eq(mockHeader.getStateRoot()), eq(mockHeader.getHash())))
+        .thenReturn(false);
     assertSuccessWithPayloadForForkchoiceResult(
         new ForkchoiceStateV1(mockHeader.getHash(), Hash.ZERO, Hash.ZERO),
         Optional.empty(),


### PR DESCRIPTION
## PR description

In a FcU we check that the block corresponding to the newHead is present, otherwise we return syncing, but we do not check if the world state is present too, so during the initial snap sync, when the block could be present, but the state not yet, the FcU fails with the exception below.
This PR ensure the world state is present for the newHead, otherwise returns syncing.

```
{“@timestamp”:“2026-07-31T07:17:10,107",“level”:“INFO”,“thread”:“EthScheduler-Services-45 (importHeadersStep)“,”class”:“BackwardHeaderDriver”,“message”:“Header import progress 0.01%“,”throwable”:“”}
{“@timestamp”:“2026-07-31T07:17:10,172”,“level”:“WARN”,“thread”:“vert.x-worker-thread-0”,“class”:“PathBasedWorldStateProvider”,“message”:“Archive rolling failed for block hash 0x1af9ea1a4d1dc3364e2394b57fdf1d6de2236b0b0bd5738de235e6f433db0f28”,“throwable”:“java.lang.IllegalStateException: Missing trie log for block hash 0x1af9ea1a4d1dc3364e2394b57fdf1d6de2236b0b0bd5738de235e6f433db0f28
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.lambda$trieLogOrThrow$0(PathBasedWorldStateProvider.java:273)
at java.base/java.util.Optional.orElseThrow(Optional.java:403)
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.trieLogOrThrow(PathBasedWorldStateProvider.java:272)
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.rollFullWorldStateToBlockHash(PathBasedWorldStateProvider.java:305)
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.getFullWorldStateFromHead(PathBasedWorldStateProvider.java:211)
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.getFullWorldState(PathBasedWorldStateProvider.java:191)
at org.hyperledger.besu.ethereum.trie.pathbased.common.provider.PathBasedWorldStateProvider.getWorldState(PathBasedWorldStateProvider.java:154)
at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.moveWorldStateTo(MergeCoordinator.java:781)
at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.setNewHead(MergeCoordinator.java:754)
at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.applyForkChoice(MergeCoordinator.java:721)
at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.updateForkChoice(MergeCoordinator.java:702)
at org.hyperledger.besu.consensus.merge.blockcreation.TransitionCoordinator.updateForkChoice(TransitionCoordinator.java:154)
at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdatedV1.syncResponse(EngineForkchoiceUpdatedV1.java:213)
at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.lambda$response$0(ExecutionEngineJsonRpcMethod.java:168)
at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$5(ContextImpl.java:205)
at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
at io.vertx.core.impl.ContextImpl$1.execute(ContextImpl.java:221)
at io.vertx.core.impl.WorkerTask.run(WorkerTask.java:56)
at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:81)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.base/java.lang.Thread.run(Thread.java:1474)\n”}
{“@timestamp”:“2026-07-31T07:17:10,174”,“level”:“ERROR”,“thread”:“vert.x-eventloop-thread-0”,“class”:“EngineForkchoiceUpdatedV3”,“message”:“failed to exec consensus method engine_forkchoiceUpdatedV3, error: invalid”,“throwable”:“”}
```

Performance test shown not impact from the added test

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


