### PR TITLE
Enable NullAway for Ethereum EVM tool

### DIFF
--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -22,6 +22,19 @@ apply plugin: 'java-library'
 apply plugin: 'application'
 apply plugin: 'idea'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.evmtool')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -36,6 +49,9 @@ jar {
 }
 
 dependencies {
+
+  errorprone 'com.uber.nullaway:nullaway'
+  compileOnly 'org.jspecify:jspecify'
 
   implementation project(':app')
   implementation project(':config')

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/B11rSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/B11rSubCommand.java
@@ -143,7 +143,7 @@ public class B11rSubCommand implements Runnable {
   }
 
   /** Default constructor for the B11rSubCommand class. This is required by PicoCLI. */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public B11rSubCommand() {
     // PicoCLI requires this
     parentCommand = null;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
@@ -165,6 +165,7 @@ public class BenchmarkSubCommand implements Runnable {
    *
    * @param output the output stream to be used
    */
+  @SuppressWarnings("NullAway") // Picocli injects the parent command after construction.
   public BenchmarkSubCommand(final PrintStream output) {
     this.output = output;
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.evmtool.BlockchainTestSubCommand.COMMAND_NAME;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -71,6 +72,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes32;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
@@ -111,7 +113,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
       description =
           "Limit execution to tests whose name contains the given substring, or matches the given"
               + " pattern (a regex, with * and ? as wildcards).")
-  private String testName = null;
+  private @Nullable String testName = null;
 
   @Option(
       names = {"--test-name-regex"},
@@ -120,15 +122,15 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
               + " hive --sim.limit value: anchored at the start of the id, open at the end and"
               + " case-sensitive, as re.match is. Nothing is escaped or rewritten, so a published"
               + " hive filter can be passed exactly as it appears.")
-  private String testNameRegex = null;
+  private @Nullable String testNameRegex = null;
 
   // Compiled up front so a malformed expression fails before any fixture is read
-  private TestNameFilter nameFilter;
+  private @Nullable TestNameFilter nameFilter;
 
   @Option(
       names = {"--trace-output"},
       description = "Output file for traces (default: stderr). Requires --json or --trace flag.")
-  private String traceOutput = null;
+  private @Nullable String traceOutput = null;
 
   @Option(
       names = {"--workers"},
@@ -165,7 +167,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
    * Default constructor for the BlockchainTestSubCommand class. This constructor doesn't take any
    * arguments and initializes the parentCommand to null. PicoCLI requires this constructor.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public BlockchainTestSubCommand() {
     // PicoCLI requires this
     this(null);
@@ -318,7 +320,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
   }
 
   private boolean matchesTestName(final String test) {
-    return nameFilter.matches(test);
+    return requireNonNull(nameFilter).matches(test);
   }
 
   private void traceTestSpecs(
@@ -481,14 +483,15 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
 
     if (parentCommand.showJsonResults) {
       final long testDuration = System.currentTimeMillis() - testStartTime;
-      tracerManager.writeTestEnd(
-          test,
-          testPassed,
-          spec.getNetwork(),
-          testDuration,
-          totalGasUsed,
-          totalTxCount,
-          blockCount);
+      requireNonNull(tracerManager)
+          .writeTestEnd(
+              test,
+              testPassed,
+              spec.getNetwork(),
+              testDuration,
+              totalGasUsed,
+              totalTxCount,
+              blockCount);
     }
 
     if (!testPassed) {
@@ -645,7 +648,6 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
     private final boolean showStack;
     private final boolean showReturnData;
     private final boolean showStorage;
-    private StreamingOperationTracer currentTracer;
 
     /**
      * Constructs a BlockTestTracerManager with specified tracing options.
@@ -675,17 +677,15 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
      * @return a new StreamingOperationTracer instance
      */
     public StreamingOperationTracer createTracer() {
-      currentTracer =
-          new StreamingOperationTracer(
-              output,
-              OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                  .traceMemory(showMemory)
-                  .traceStack(showStack)
-                  .traceReturnData(showReturnData)
-                  .traceStorage(showStorage)
-                  .eip3155Strict(true)
-                  .build());
-      return currentTracer;
+      return new StreamingOperationTracer(
+          output,
+          OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+              .traceMemory(showMemory)
+              .traceStack(showStack)
+              .traceReturnData(showReturnData)
+              .traceStorage(showStorage)
+              .eip3155Strict(true)
+              .build());
     }
 
     /**

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.evmtool.BlockchainTestSubCommand.COMMAND_NAME;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -72,6 +73,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes32;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -106,12 +108,12 @@ public class BlockchainTestSubCommand implements Runnable {
       names = {"--test-name"},
       description =
           "Limit execution to tests whose name contains the given substring, or matches a glob pattern (using * and ?).")
-  private String testName = null;
+  private @Nullable String testName = null;
 
   @Option(
       names = {"--trace-output"},
       description = "Output file for traces (default: stderr). Requires --json or --trace flag.")
-  private String traceOutput = null;
+  private @Nullable String traceOutput = null;
 
   @Option(
       names = {"--cache-precompiles"},
@@ -172,7 +174,7 @@ public class BlockchainTestSubCommand implements Runnable {
    * Default constructor for the BlockchainTestSubCommand class. This constructor doesn't take any
    * arguments and initializes the parentCommand to null. PicoCLI requires this constructor.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public BlockchainTestSubCommand() {
     // PicoCLI requires this
     this(null);
@@ -269,14 +271,15 @@ public class BlockchainTestSubCommand implements Runnable {
   }
 
   private boolean matchesTestName(final String test) {
-    if (testName.contains("*") || testName.contains("?")) {
+    final String pattern = requireNonNull(testName);
+    if (pattern.contains("*") || pattern.contains("?")) {
       // Convert glob pattern to regex: * -> .*, ? -> .
       final String regex =
-          "(?i)" + testName.replace(".", "\\.").replace("*", ".*").replace("?", ".");
+          "(?i)" + pattern.replace(".", "\\.").replace("*", ".*").replace("?", ".");
       return test.matches(regex);
     }
     // Simple substring match (case-insensitive)
-    return test.toLowerCase(Locale.ROOT).contains(testName.toLowerCase(Locale.ROOT));
+    return test.toLowerCase(Locale.ROOT).contains(pattern.toLowerCase(Locale.ROOT));
   }
 
   private void traceTestSpecs(
@@ -435,14 +438,15 @@ public class BlockchainTestSubCommand implements Runnable {
 
     if (parentCommand.showJsonResults) {
       final long testDuration = System.currentTimeMillis() - testStartTime;
-      tracerManager.writeTestEnd(
-          test,
-          testPassed,
-          spec.getNetwork(),
-          testDuration,
-          totalGasUsed,
-          totalTxCount,
-          blockCount);
+      requireNonNull(tracerManager)
+          .writeTestEnd(
+              test,
+              testPassed,
+              spec.getNetwork(),
+              testDuration,
+              totalGasUsed,
+              totalTxCount,
+              blockCount);
     }
 
     if (!testPassed) {
@@ -589,7 +593,6 @@ public class BlockchainTestSubCommand implements Runnable {
     private final boolean showStack;
     private final boolean showReturnData;
     private final boolean showStorage;
-    private StreamingOperationTracer currentTracer;
 
     /**
      * Constructs a BlockTestTracerManager with specified tracing options.
@@ -619,17 +622,15 @@ public class BlockchainTestSubCommand implements Runnable {
      * @return a new StreamingOperationTracer instance
      */
     public StreamingOperationTracer createTracer() {
-      currentTracer =
-          new StreamingOperationTracer(
-              output,
-              OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
-                  .traceMemory(showMemory)
-                  .traceStack(showStack)
-                  .traceReturnData(showReturnData)
-                  .traceStorage(showStorage)
-                  .eip3155Strict(true)
-                  .build());
-      return currentTracer;
+      return new StreamingOperationTracer(
+          output,
+          OpCodeTracerConfigBuilder.createFrom(OpCodeTracerConfig.DEFAULT)
+              .traceMemory(showMemory)
+              .traceStack(showStack)
+              .traceReturnData(showReturnData)
+              .traceStorage(showStorage)
+              .eip3155Strict(true)
+              .build());
     }
 
     /**

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EngineTestExceptionMapper.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EngineTestExceptionMapper.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.referencetests.BlockExceptionMatcher;
 
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Checks a fixture's expected validation error against the message Besu returned, reproducing
  * hive's strict exception matching: when a fixture expects an {@code INVALID} payload with a
@@ -39,7 +41,8 @@ final class EngineTestExceptionMapper {
    * @return {@code null} when the actual error matches one of the expected alternatives, otherwise
    *     a failure reason
    */
-  static String mismatch(final String expectedValidationError, final String besuMessage) {
+  static @Nullable String mismatch(
+      final String expectedValidationError, final @Nullable String besuMessage) {
     if (besuMessage != null
         && BlockExceptionMatcher.matchesEngine(expectedValidationError, besuMessage)) {
       return null;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EngineTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EngineTestSubCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PARIS;
@@ -87,6 +88,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
@@ -126,7 +128,7 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
       description =
           "Limit execution to tests whose name contains the given substring, or matches the given"
               + " pattern (a regex, with * and ? as wildcards).")
-  private String testName = null;
+  private @Nullable String testName = null;
 
   @Option(
       names = {"--test-name-regex"},
@@ -135,10 +137,10 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
               + " hive --sim.limit value: anchored at the start of the id, open at the end and"
               + " case-sensitive, as re.match is. Nothing is escaped or rewritten, so a published"
               + " hive filter can be passed exactly as it appears.")
-  private String testNameRegex = null;
+  private @Nullable String testNameRegex = null;
 
   // Compiled up front so a malformed expression fails before any fixture is read
-  private TestNameFilter nameFilter;
+  private @Nullable TestNameFilter nameFilter;
 
   @Option(
       names = {"--workers"},
@@ -167,7 +169,7 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
   @Parameters private final List<Path> engineTestFiles = new ArrayList<>();
 
   /** Required by PicoCLI, which instantiates subcommands reflectively with no arguments. */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public EngineTestSubCommand() {
     this(null);
   }
@@ -376,7 +378,7 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
   private void executeEngineTests(
       final Map<String, EngineTestCaseSpec> tests, final FixtureRunner.TestResults results) {
     for (final Map.Entry<String, EngineTestCaseSpec> entry : tests.entrySet()) {
-      if (nameFilter != null && !nameFilter.matches(entry.getKey())) continue;
+      if (nameFilter != null && !requireNonNull(nameFilter).matches(entry.getKey())) continue;
       try {
         runSingleEngineTest(entry.getKey(), entry.getValue(), results);
       } catch (final RuntimeException e) {
@@ -398,8 +400,8 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
    * @param actualCode the error code the engine method returned
    * @return {@code null} when the outcome matches expectations, otherwise a failure reason
    */
-  private static String checkExpectedErrorCode(
-      final int payloadIndex, final String expectedErrorCode, final int actualCode) {
+  private static @Nullable String checkExpectedErrorCode(
+      final int payloadIndex, final @Nullable String expectedErrorCode, final int actualCode) {
     if (expectedErrorCode == null) {
       return String.format(
           "payload %d: unexpected Engine API error code %d", payloadIndex, actualCode);
@@ -821,7 +823,7 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
   private void recordResult(
       final String test,
       final EngineTestCaseSpec spec,
-      final MutableBlockchain blockchain,
+      final @Nullable MutableBlockchain blockchain,
       final boolean testPassed,
       final String failureReason,
       final FixtureRunner.TestResults results) {
@@ -841,10 +843,10 @@ public class EngineTestSubCommand implements Runnable, IExitCodeGenerator {
   private void recordResult(
       final String test,
       final EngineTestCaseSpec spec,
-      final MutableBlockchain blockchain,
+      final @Nullable MutableBlockchain blockchain,
       final boolean testPassed,
       final String failureReason,
-      final EngineStatus lastPayloadStatus,
+      final @Nullable EngineStatus lastPayloadStatus,
       final FixtureRunner.TestResults results) {
     if (testPassed) {
       if (verbose) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import org.hyperledger.besu.config.NetworkDefinition;
@@ -66,6 +67,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -245,12 +247,12 @@ public class EvmToolCommand implements Runnable {
   @Option(
       names = {"--prestate", "--genesis"},
       description = "The genesis file containing account data for this invocation.")
-  private final File genesisFile = null;
+  private final @Nullable File genesisFile = null;
 
   @Option(
       names = {"--chain"},
       description = "Name of a well known network that will be used for this invocation.")
-  private final NetworkDefinition network = null;
+  private final @Nullable NetworkDefinition network = null;
 
   @Option(
       names = {"--repeat"},
@@ -324,8 +326,8 @@ public class EvmToolCommand implements Runnable {
             .build());
 
     // Enumerate forks to support execution-spec-tests
-    addForkHelp(commandLine.getSubcommands().get("t8n"));
-    addForkHelp(commandLine.getSubcommands().get("t8n-server"));
+    addForkHelp(requireNonNull(commandLine.getSubcommands().get("t8n")));
+    addForkHelp(requireNonNull(commandLine.getSubcommands().get("t8n-server")));
 
     commandLine.setExecutionStrategy(
         parseResult -> {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import org.hyperledger.besu.config.NetworkDefinition;
@@ -66,6 +67,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -244,12 +246,12 @@ public class EvmToolCommand implements Runnable {
   @Option(
       names = {"--prestate", "--genesis"},
       description = "The genesis file containing account data for this invocation.")
-  private final File genesisFile = null;
+  private final @Nullable File genesisFile = null;
 
   @Option(
       names = {"--chain"},
       description = "Name of a well known network that will be used for this invocation.")
-  private final NetworkDefinition network = null;
+  private final @Nullable NetworkDefinition network = null;
 
   @Option(
       names = {"--repeat"},
@@ -323,8 +325,8 @@ public class EvmToolCommand implements Runnable {
             .build());
 
     // Enumerate forks to support execution-spec-tests
-    addForkHelp(commandLine.getSubcommands().get("t8n"));
-    addForkHelp(commandLine.getSubcommands().get("t8n-server"));
+    addForkHelp(requireNonNull(commandLine.getSubcommands().get("t8n")));
+    addForkHelp(requireNonNull(commandLine.getSubcommands().get("t8n-server")));
 
     commandLine.setExecutionStrategy(
         parseResult -> {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
@@ -64,7 +65,7 @@ public class EvmToolCommandOptionsModule {
       names = {"--fork"},
       paramLabel = "<String>",
       description = "Fork to evaluate, overriding network setting.")
-  String fork = null;
+  @Nullable String fork = null;
 
   @Provides
   @Named("Fork")

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -62,6 +62,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -96,32 +97,32 @@ public class StateTestSubCommand implements Runnable {
   @Option(
       names = {"--fork"},
       description = "Force the state tests to run on a specific fork.")
-  private String fork = null;
+  private @Nullable String fork = null;
 
   @Option(
       names = {"--test-name"},
       description = "Limit execution to one named test.")
-  private String testName = null;
+  private @Nullable String testName = null;
 
   @Option(
       names = {"--data-index"},
       description = "Limit execution to one data variable.")
-  private Integer dataIndex = null;
+  private @Nullable Integer dataIndex = null;
 
   @Option(
       names = {"--gas-index"},
       description = "Limit execution to one gas variable.")
-  private Integer gasIndex = null;
+  private @Nullable Integer gasIndex = null;
 
   @Option(
       names = {"--value-index"},
       description = "Limit execution to one value variable.")
-  private Integer valueIndex = null;
+  private @Nullable Integer valueIndex = null;
 
   @Option(
       names = {"--fork-index"},
       description = "Limit execution to one fork.")
-  private String forkIndex = null;
+  private @Nullable String forkIndex = null;
 
   @Option(
       names = {"--cache-precompiles"},
@@ -139,7 +140,7 @@ public class StateTestSubCommand implements Runnable {
    * Default constructor for the StateTestSubCommand class. This constructor doesn't take any
    * arguments and initializes the parentCommand to null. PicoCLI requires this constructor.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public StateTestSubCommand() {
     // PicoCLI requires this
     this(null);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evmtool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.ethereum.referencetests.ReferenceTestProtocolSchedules.shouldClearEmptyAccounts;
 import static org.hyperledger.besu.evmtool.StateTestSubCommand.COMMAND_NAME;
 
@@ -64,6 +65,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
@@ -102,14 +104,14 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   @Option(
       names = {"--fork"},
       description = "Force the state tests to run on a specific fork.")
-  private String fork = null;
+  private @Nullable String fork = null;
 
   @Option(
       names = {"--test-name"},
       description =
           "Limit execution to tests whose name contains the given substring, or matches the given"
               + " pattern (a regex, with * and ? as wildcards).")
-  private String testName = null;
+  private @Nullable String testName = null;
 
   @Option(
       names = {"--test-name-regex"},
@@ -118,10 +120,10 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
               + " hive --sim.limit value: anchored at the start of the id, open at the end and"
               + " case-sensitive, as re.match is. Nothing is escaped or rewritten, so a published"
               + " hive filter can be passed exactly as it appears.")
-  private String testNameRegex = null;
+  private @Nullable String testNameRegex = null;
 
   // Compiled up front so a malformed expression fails before any fixture is read
-  private TestNameFilter nameFilter;
+  private @Nullable TestNameFilter nameFilter;
 
   @Option(
       names = {"--workers"},
@@ -133,22 +135,22 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   @Option(
       names = {"--data-index"},
       description = "Limit execution to one data variable.")
-  private Integer dataIndex = null;
+  private @Nullable Integer dataIndex = null;
 
   @Option(
       names = {"--gas-index"},
       description = "Limit execution to one gas variable.")
-  private Integer gasIndex = null;
+  private @Nullable Integer gasIndex = null;
 
   @Option(
       names = {"--value-index"},
       description = "Limit execution to one value variable.")
-  private Integer valueIndex = null;
+  private @Nullable Integer valueIndex = null;
 
   @Option(
       names = {"--fork-index"},
       description = "Limit execution to one fork.")
-  private String forkIndex = null;
+  private @Nullable String forkIndex = null;
 
   @Option(
       names = {"--cache-precompiles"},
@@ -182,7 +184,7 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   private final List<String> unreadableFiles = Collections.synchronizedList(new ArrayList<>());
 
   // Cached across all tests; guarded by getSchedules()
-  private ReferenceTestProtocolSchedules cachedSchedules;
+  private @Nullable ReferenceTestProtocolSchedules cachedSchedules;
 
   // Shared for summary output; createObjectNode() is thread safe
   private static final ObjectMapper SHARED_OBJECT_MAPPER = JsonUtils.createObjectMapper();
@@ -194,7 +196,7 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
    * Default constructor for the StateTestSubCommand class. This constructor doesn't take any
    * arguments and initializes the parentCommand to null. PicoCLI requires this constructor.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public StateTestSubCommand() {
     // PicoCLI requires this
     this(null);
@@ -359,7 +361,7 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
 
   /** Whether {@code --test-name} selects the given test. With no filter, everything is selected. */
   private boolean selects(final String test) {
-    return nameFilter == null || nameFilter.matches(test);
+    return nameFilter == null || requireNonNull(nameFilter).matches(test);
   }
 
   /**

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.evmtool;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.hyperledger.besu.ethereum.core.Transaction.REPLAY_PROTECTED_V_BASE;
 import static org.hyperledger.besu.ethereum.core.Transaction.REPLAY_PROTECTED_V_MIN;
 import static org.hyperledger.besu.ethereum.core.Transaction.REPLAY_UNPROTECTED_V_BASE;
@@ -90,6 +91,7 @@ import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The T8nExecutor class is responsible for executing transactions in the context of the Ethereum
@@ -322,7 +324,9 @@ public class T8nExecutor {
           out.printf("TX json node unparseable: %s%n", txNode);
         }
       } catch (IllegalArgumentException | ArithmeticException e) {
-        rejections.add(new RejectedTransaction(i, e.getMessage()));
+        rejections.add(
+            new RejectedTransaction(
+                i, requireNonNullElse(e.getMessage(), e.getClass().getSimpleName())));
       }
       i++;
     }
@@ -331,8 +335,8 @@ public class T8nExecutor {
 
   static T8nResult runTest(
       final Long chainId,
-      final String fork,
-      final String rewardString,
+      final @Nullable String fork,
+      final @Nullable String rewardString,
       final ObjectMapper objectMapper,
       final ReferenceTestEnv referenceTestEnv,
       final ReferenceTestWorldState initialWorldState,
@@ -348,6 +352,9 @@ public class T8nExecutor {
     final BonsaiReferenceTestWorldState worldState =
         (BonsaiReferenceTestWorldState) initialWorldState.copy();
 
+    if (fork == null) {
+      throw new UnsupportedForkException("null");
+    }
     final ProtocolSchedule protocolSchedule = referenceTestProtocolSchedules.getByName(fork);
     if (protocolSchedule == null) {
       throw new UnsupportedForkException(fork);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nServerSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nServerSubCommand.java
@@ -98,7 +98,7 @@ public class T8nServerSubCommand implements Runnable {
    * Default constructor for the T8nServerSubCommand class. This constructor is required by PicoCLI
    * and assigns null to parentCommand.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public T8nServerSubCommand() {
     // PicoCLI requires this
     this(null);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nSubCommand.java
@@ -50,6 +50,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IParameterConsumer;
 import picocli.CommandLine.Model.ArgSpec;
@@ -90,7 +91,7 @@ public class T8nSubCommand implements Runnable {
       names = {"--state.fork"},
       paramLabel = "fork name",
       description = "The fork to run the transition against")
-  private String fork = null;
+  private @Nullable String fork = null;
 
   @Option(
       names = {"--input.env"},
@@ -145,7 +146,7 @@ public class T8nSubCommand implements Runnable {
       names = {"--state.reward"},
       paramLabel = "block mining reward",
       description = "The block reward to use in block tess")
-  private String rewardString = null;
+  private @Nullable String rewardString = null;
 
   @ParentCommand private final EvmToolCommand parentCommand;
 
@@ -171,7 +172,7 @@ public class T8nSubCommand implements Runnable {
    * Default constructor for the T8nSubCommand class. This constructor is required by PicoCLI and
    * assigns parent command to 'null'.
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "NullAway"}) // Picocli injects the parent after construction.
   public T8nSubCommand() {
     // PicoCLI requires this
     parentCommand = null;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
@@ -14,9 +14,13 @@
  */
 package org.hyperledger.besu.evmtool;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * The test-id filter used by {@code block-test}, {@code state-test} and {@code engine-test}, in two
@@ -39,11 +43,12 @@ import java.util.regex.PatternSyntaxException;
  */
 final class TestNameFilter {
 
-  private final Pattern regex;
-  private final String substring;
+  private final @Nullable Pattern regex;
+  private final @Nullable String substring;
   private final boolean wholeIdMatch;
 
-  private TestNameFilter(final Pattern regex, final String substring, final boolean wholeIdMatch) {
+  private TestNameFilter(
+      final @Nullable Pattern regex, final @Nullable String substring, final boolean wholeIdMatch) {
     this.regex = regex;
     this.substring = substring;
     this.wholeIdMatch = wholeIdMatch;
@@ -57,7 +62,8 @@ final class TestNameFilter {
    * @return the compiled filter, or null when neither option was given
    * @throws IllegalArgumentException if both are given, or the expression is not a valid pattern
    */
-  static TestNameFilter fromOptions(final String testName, final String testNameRegex) {
+  static @Nullable TestNameFilter fromOptions(
+      final @Nullable String testName, final @Nullable String testNameRegex) {
     if (testName != null && testNameRegex != null) {
       throw new IllegalArgumentException(
           "--test-name and --test-name-regex are mutually exclusive: --test-name rewrites '*' and"
@@ -77,7 +83,7 @@ final class TestNameFilter {
    * @param testNameRegex the {@code --test-name-regex} expression, or null
    * @return a phrase to append to the message, empty when no filter was given
    */
-  static String describe(final String testName, final String testNameRegex) {
+  static String describe(final @Nullable String testName, final @Nullable String testNameRegex) {
     if (testNameRegex != null) {
       return " matching --test-name-regex '" + testNameRegex + "'";
     }
@@ -136,7 +142,7 @@ final class TestNameFilter {
    */
   boolean matches(final String test) {
     if (regex == null) {
-      return test.toLowerCase(Locale.ROOT).contains(substring);
+      return test.toLowerCase(Locale.ROOT).contains(requireNonNull(substring));
     }
     // lookingAt(), not matches(), for the regex form: Python's re.match anchors at the start only.
     return wholeIdMatch ? regex.matcher(test).matches() : regex.matcher(test).lookingAt();

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/BenchmarkExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/BenchmarkExecutor.java
@@ -34,6 +34,8 @@ import org.hyperledger.besu.evm.gascalculator.OsakaGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.ShanghaiGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.SpuriousDragonGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.TangerineWhistleGasCalculator;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
 import java.io.PrintStream;
@@ -266,11 +268,10 @@ public abstract class BenchmarkExecutor {
         .asyncProfilerOptions()
         .ifPresent(
             options -> {
-              asyncProfiler.set(AsyncProfiler.getInstance());
+              final AsyncProfiler profiler = AsyncProfiler.getInstance();
+              asyncProfiler.set(profiler);
               try {
-                asyncProfiler
-                    .get()
-                    .execute(processProfilerArgs(options, testName.replaceAll("\\s", "-")));
+                profiler.execute(processProfilerArgs(options, testName.replaceAll("\\s", "-")));
               } catch (Throwable t) {
                 output.println("async profiler unavailable: " + t.getMessage());
               }
@@ -287,9 +288,10 @@ public abstract class BenchmarkExecutor {
       executions++;
     }
 
-    if (asyncProfiler.get() != null) {
+    final AsyncProfiler profiler = asyncProfiler.get();
+    if (profiler != null) {
       try {
-        asyncProfiler.get().stop();
+        profiler.stop();
       } catch (Throwable t) {
         output.println("async profiler unavailable: " + t.getMessage());
       }
@@ -328,8 +330,8 @@ public abstract class BenchmarkExecutor {
     return switch (EvmSpecVersion.valueOf(fork.toUpperCase(Locale.ROOT))) {
       case HOMESTEAD -> new HomesteadGasCalculator();
       case FRONTIER -> new FrontierGasCalculator();
-      case TANGERINE_WHISTLE -> null;
-      case SPURIOUS_DRAGON -> null;
+      case TANGERINE_WHISTLE -> new TangerineWhistleGasCalculator();
+      case SPURIOUS_DRAGON -> new SpuriousDragonGasCalculator();
       case BYZANTIUM -> new ByzantiumGasCalculator();
       case CONSTANTINOPLE -> new ConstantinopleGasCalculator();
       case PETERSBURG -> new PetersburgGasCalculator();


### PR DESCRIPTION
## PR description

Enable NullAway for the `ethereum/evmtool` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.evmtool`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and JSpecify annotations with `compileOnly`
- models optional CLI values and reflective Picocli parent-command injection explicitly
- uses `requireNonNull(...)` at command and lifecycle boundaries where values are guaranteed to be present
- keeps rejection messages non-null even when an exception has no message
- returns the existing fork-specific gas calculators for Tangerine Whistle and Spurious Dragon instead of nullable sentinels

The CLI surface, output formats, and execution behavior for valid inputs are unchanged.

## Fixed Issue(s)

Part of #10442 (`ethereum/evmtool`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required because this is an internal null-safety migration.
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — not applicable; this module does not change database formats or persisted data.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :ethereum:evmtool:spotlessApply` and `./gradlew --no-daemon :ethereum:evmtool:build :ethereum:evmtool:spotlessCheck --rerun-tasks`
- [x] unit tests: `./gradlew --no-daemon :ethereum:evmtool:test --rerun-tasks` and `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests) — not applicable; no Engine or RPC behavior is modified.

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense` and `git diff --check upstream/main...HEAD`.
