### PR TITLE
Enable NullAway for RocksDB plugin

### DIFF
--- a/plugins/rocksdb/build.gradle
+++ b/plugins/rocksdb/build.gradle
@@ -13,6 +13,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.plugin.services.storage.rocksdb')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -27,6 +40,9 @@ jar {
 }
 
 dependencies {
+  errorprone 'com.uber.nullaway:nullaway'
+  compileOnlyApi 'org.jspecify:jspecify'
+
   api project(':plugin-api')
   api 'org.slf4j:slf4j-api'
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.BONSAI_ARCHIVE_WITH_RECEIPT_COMPACTION;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.BONSAI_WITH_RECEIPT_COMPACTION;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.BaseVersionedStorageFormat.BONSAI_WITH_VARIABLES;
@@ -50,6 +51,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,9 +69,9 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
           BONSAI_ARCHIVE_WITH_RECEIPT_COMPACTION);
   private static final String NAME = "rocksdb";
   private final RocksDBMetricsFactory rocksDBMetricsFactory;
-  private DatabaseMetadata databaseMetadata;
-  private RocksDBColumnarKeyValueStorage segmentedStorage;
-  private RocksDBConfiguration rocksDBConfiguration;
+  private @Nullable DatabaseMetadata databaseMetadata;
+  private @Nullable RocksDBColumnarKeyValueStorage segmentedStorage;
+  private @Nullable RocksDBConfiguration rocksDBConfiguration;
 
   private final Supplier<RocksDBFactoryConfiguration> configuration;
   private final List<SegmentIdentifier> configuredSegments;
@@ -144,24 +146,26 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
     }
 
     if (segmentedStorage == null) {
+      final DatabaseMetadata currentMetadata = requireNonNull(databaseMetadata);
+      final RocksDBConfiguration currentConfiguration = requireNonNull(rocksDBConfiguration);
       final List<SegmentIdentifier> segmentsForFormat =
           configuredSegments.stream()
               .filter(
                   segmentId ->
                       segmentId.includeInDatabaseFormat(
-                          databaseMetadata.getVersionedStorageFormat().getFormat()))
+                          currentMetadata.getVersionedStorageFormat().getFormat()))
               .toList();
 
       // It's probably a good idea for the creation logic to be entirely dependent on the database
       // version. Introducing intermediate booleans that represent database properties and
       // dispatching
       // creation logic based on them is error-prone.
-      switch (databaseMetadata.getVersionedStorageFormat().getFormat()) {
+      switch (currentMetadata.getVersionedStorageFormat().getFormat()) {
         case FOREST -> {
           LOG.debug("FOREST mode detected, using TransactionDB.");
           segmentedStorage =
               new TransactionDBRocksDBColumnarKeyValueStorage(
-                  rocksDBConfiguration,
+                  currentConfiguration,
                   segmentsForFormat,
                   ignorableSegments,
                   metricsSystem,
@@ -171,7 +175,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
           LOG.debug("BONSAI mode detected, Using OptimisticTransactionDB.");
           segmentedStorage =
               new OptimisticRocksDBColumnarKeyValueStorage(
-                  rocksDBConfiguration,
+                  currentConfiguration,
                   segmentsForFormat,
                   ignorableSegments,
                   metricsSystem,
@@ -179,7 +183,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
         }
       }
     }
-    return segmentedStorage;
+    return requireNonNull(segmentedStorage);
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
+import static java.util.Objects.requireNonNull;
+
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -29,6 +31,7 @@ import java.util.Optional;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +43,8 @@ public class RocksDBPlugin implements BesuPlugin {
 
   private final RocksDBCLIOptions options;
   private final List<SegmentIdentifier> ignorableSegments = new ArrayList<>();
-  private ServiceManager context;
-  private RocksDBKeyValueStorageFactory factory;
+  private @Nullable ServiceManager context;
+  private @Nullable RocksDBKeyValueStorageFactory factory;
 
   /** Instantiates a newRocksDb plugin. */
   public RocksDBPlugin() {
@@ -158,7 +161,7 @@ public class RocksDBPlugin implements BesuPlugin {
   }
 
   private void createFactoriesAndRegisterWithStorageService() {
-    context
+    requireNonNull(context)
         .getService(StorageService.class)
         .ifPresentOrElse(
             this::createAndRegister,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
-import static java.util.Objects.requireNonNull;
-
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -161,7 +159,11 @@ public class RocksDBPlugin implements BesuPlugin {
   }
 
   private void createFactoriesAndRegisterWithStorageService() {
-    requireNonNull(context)
+    final ServiceManager serviceManager = context;
+    if (serviceManager == null) {
+      throw new IllegalStateException("RocksDB plugin must be registered before it can be started");
+    }
+    serviceManager
         .getService(StorageService.class)
         .ifPresentOrElse(
             this::createAndRegister,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
+import static java.util.Objects.requireNonNull;
+
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 
 import java.util.Objects;
@@ -65,7 +67,7 @@ public class RocksDbSegmentIdentifier {
    * @return the column family handle
    */
   public ColumnFamilyHandle get() {
-    return reference.get();
+    return requireNonNull(reference.get());
   }
 
   @Override
@@ -82,6 +84,6 @@ public class RocksDbSegmentIdentifier {
 
   @Override
   public int hashCode() {
-    return reference.get().hashCode();
+    return get().hashCode();
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -183,7 +183,7 @@ public class RocksDBConfigurationBuilder {
    */
   public RocksDBConfiguration build() {
     return new RocksDBConfiguration(
-        requireNonNull(databaseDir),
+        requireNonNull(databaseDir, "RocksDB database directory is required"),
         maxOpenFiles,
         backgroundThreadCount,
         cacheCapacity,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb.configuration;
 
+import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_ENABLE_READ_CACHE_FOR_SNAPSHOTS;
@@ -23,10 +24,12 @@ import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration
 import java.nio.file.Path;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 /** The RocksDb configuration builder. */
 public class RocksDBConfigurationBuilder {
 
-  private Path databaseDir;
+  private @Nullable Path databaseDir;
   private String label = "blockchain";
   private int maxOpenFiles = DEFAULT_MAX_OPEN_FILES;
   private long cacheCapacity = DEFAULT_CACHE_CAPACITY;
@@ -180,7 +183,7 @@ public class RocksDBConfigurationBuilder {
    */
   public RocksDBConfiguration build() {
     return new RocksDBConfiguration(
-        databaseDir,
+        requireNonNull(databaseDir),
         maxOpenFiles,
         backgroundThreadCount,
         cacheCapacity,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
@@ -85,7 +85,7 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, this.metrics),
+            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, getMetrics()),
         this.closed::get);
   }
 
@@ -97,7 +97,7 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     writeOptions.setLowPri(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, this.metrics),
+            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, getMetrics()),
         this.closed::get);
   }
 
@@ -111,6 +111,6 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
   public RocksDBColumnarKeyValueSnapshot takeSnapshot() throws StorageException {
     throwIfClosed();
     return new RocksDBColumnarKeyValueSnapshot(
-        db, configuration.isReadCacheEnabledForSnapshots(), this::safeColumnHandle, metrics);
+        db, configuration.isReadCacheEnabledForSnapshots(), this::safeColumnHandle, getMetrics());
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
 
@@ -45,6 +46,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
 import org.rocksdb.AbstractRocksIterator;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
@@ -108,7 +110,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   protected final RocksDBConfiguration configuration;
 
   /** RocksDB DB options */
-  protected DBOptions options;
+  protected final DBOptions options;
 
   /** RocksDb transactionDB options */
   protected TransactionDBOptions txOptions;
@@ -120,10 +122,11 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   protected final Statistics stats = new Statistics();
 
   /** RocksDB metrics */
-  protected RocksDBMetrics metrics;
+  protected @Nullable RocksDBMetrics metrics;
 
   /** Map of the columns handles by name */
-  protected Map<SegmentIdentifier, RocksDbSegmentIdentifier> columnHandlesBySegmentIdentifier;
+  protected @Nullable Map<SegmentIdentifier, RocksDbSegmentIdentifier>
+      columnHandlesBySegmentIdentifier;
 
   /** Column descriptors */
   protected List<ColumnFamilyDescriptor> columnDescriptors;
@@ -172,7 +175,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
               .map(segment -> createColumnDescriptor(segment, configuration))
               .collect(Collectors.toList());
 
-      setGlobalOptions(configuration, stats);
+      options = createGlobalOptions(configuration, stats);
 
       txOptions = new TransactionDBOptions();
       columnHandles = new ArrayList<>(columnDescriptors.size());
@@ -309,9 +312,10 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * @param configuration RocksDB configuration
    * @param stats The statistics object
    */
-  private void setGlobalOptions(final RocksDBConfiguration configuration, final Statistics stats) {
-    options = new DBOptions();
-    options
+  private static DBOptions createGlobalOptions(
+      final RocksDBConfiguration configuration, final Statistics stats) {
+    final DBOptions options = new DBOptions();
+    return options
         .setCreateIfMissing(true)
         .setMaxOpenFiles(configuration.getMaxOpenFiles())
         .setStatistics(stats)
@@ -345,7 +349,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
     // parse out unprintable segment names for a more useful exception:
     String columnExceptionMessagePrefix = "Column families not opened: ";
-    if (message.contains(columnExceptionMessagePrefix)) {
+    if (message != null && message.contains(columnExceptionMessagePrefix)) {
       String substring = message.substring(message.indexOf(": ") + 2);
 
       List<String> unHandledSegments = new ArrayList<>();
@@ -405,13 +409,26 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   }
 
   /**
+   * Returns the metrics initialized after the database is opened.
+   *
+   * @return the initialized RocksDB metrics
+   */
+  protected RocksDBMetrics getMetrics() {
+    return requireNonNull(metrics);
+  }
+
+  private Map<SegmentIdentifier, RocksDbSegmentIdentifier> getColumnHandlesBySegmentIdentifier() {
+    return requireNonNull(columnHandlesBySegmentIdentifier);
+  }
+
+  /**
    * Safe method to map segment identifier to column handle.
    *
    * @param segment segment identifier
    * @return column handle
    */
   protected ColumnFamilyHandle safeColumnHandle(final SegmentIdentifier segment) {
-    RocksDbSegmentIdentifier safeRef = columnHandlesBySegmentIdentifier.get(segment);
+    RocksDbSegmentIdentifier safeRef = getColumnHandlesBySegmentIdentifier().get(segment);
     if (safeRef == null) {
       throw new RuntimeException("Column handle not found for segment " + segment.getName());
     }
@@ -423,7 +440,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       throws StorageException {
     throwIfClosed();
 
-    try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
+    try (final OperationTimer.TimingContext ignored = getMetrics().getReadLatency().startTimer()) {
       return Optional.ofNullable(getDB().get(safeColumnHandle(segment), readOptions, key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
@@ -523,7 +540,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   @Override
   public void clear(final SegmentIdentifier segmentIdentifier) {
-    Optional.ofNullable(columnHandlesBySegmentIdentifier.get(segmentIdentifier))
+    Optional.ofNullable(getColumnHandlesBySegmentIdentifier().get(segmentIdentifier))
         .ifPresent(RocksDbSegmentIdentifier::reset);
   }
 
@@ -532,7 +549,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     if (closed.compareAndSet(false, true)) {
       txOptions.close();
       tryDeleteOptions.close();
-      columnHandlesBySegmentIdentifier.values().stream()
+      getColumnHandlesBySegmentIdentifier().values().stream()
           .map(RocksDbSegmentIdentifier::get)
           .forEach(ColumnFamilyHandle::close);
       getDB().close();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
@@ -88,7 +88,7 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, metrics),
+            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, getMetrics()),
         this.closed::get);
   }
 
@@ -100,7 +100,7 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     writeOptions.setLowPri(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, metrics),
+            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, getMetrics()),
         this.closed::get);
   }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPluginTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPluginTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RocksDBPluginTest {
+
+  @Test
+  void shouldFailToStartBeforeRegistration() {
+    final RocksDBPlugin plugin = new RocksDBPlugin();
+
+    assertThatThrownBy(plugin::start)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("RocksDB plugin must be registered before it can be started");
+  }
+}

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilderTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.storage.rocksdb.configuration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RocksDBConfigurationBuilderTest {
+
+  @Test
+  void shouldRequireDatabaseDirectory() {
+    assertThatThrownBy(() -> new RocksDBConfigurationBuilder().build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("RocksDB database directory is required");
+  }
+}


### PR DESCRIPTION
## PR description

Enable NullAway for the `plugins/rocksdb` module.

This change:
- enforces NullAway at `ERROR` severity for production sources under `org.hyperledger.besu.plugin.services.storage.rocksdb`
- keeps NullAway disabled for test compilation, following the migration recipe
- adds the NullAway Error Prone dependency and exposes JSpecify annotations with `compileOnlyApi` where protected members carry nullness metadata
- models plugin, factory, and native database lifecycle state as explicitly nullable
- uses `requireNonNull(...)` only after the existing initialization and lifecycle checks guarantee availability
- initializes global RocksDB options during construction and handles a nullable native exception message safely

Database schemas, column families, persisted formats, transaction boundaries, effective RocksDB options, and native handle closing order are unchanged.

## Fixed Issue(s)

Part of #10442 (`plugins/rocksdb`)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). No documentation changes are required.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). No changelog entry is required because this is an internal null-safety migration.
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests — no compatibility test is required because schemas, persisted formats, and effective RocksDB options are unchanged.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew --no-daemon :plugins:rocksdb:spotlessApply` and `./gradlew --no-daemon :plugins:rocksdb:build :plugins:rocksdb:spotlessCheck --rerun-tasks`
- [x] unit tests: `./gradlew --no-daemon :plugins:rocksdb:test --rerun-tasks` and `GRADLE_MAX_TEST_FORKS=1 ./gradlew --no-daemon --max-workers=1 build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests) — not applicable; no Engine or RPC behavior is modified.

Additional validation: `./gradlew --no-daemon --no-parallel checkLicense` and `git diff --check upstream/main...HEAD`.
