### PR TITLE
use timeout verify to mitigate flaky BackwardSyncAlgSpecTest

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpecTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncAlgSpecTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -190,8 +191,8 @@ public class BackwardSyncAlgSpecTest {
     voidCompletableFuture.get(1, TimeUnit.SECONDS);
 
     assertThat(voidCompletableFuture).isCompleted();
-    verify(context.getSyncState()).unsubscribeTTDReached(88L);
-    verify(context.getSyncState()).unsubscribeInitialConditionReached(99L);
+    verify(context.getSyncState(), timeout(1000)).unsubscribeTTDReached(88L);
+    verify(context.getSyncState(), timeout(1000)).unsubscribeInitialConditionReached(99L);
   }
 
   @Test


### PR DESCRIPTION
shouldAwokeWhenPeerConnectsAfterTTDReached accesses mock objects from
multiple threads concurrently (runAsync checkReadiness + thenRun callback),
which can corrupt Mockito's non-thread-safe InvocationContainerImpl.

Switching the post-async verify calls to timeout(1000) makes them poll
rather than assert synchronously, tolerating the thread scheduling race.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

## Fixed Issue(s)
fixes #10970 


