### PR TITLE
fix: wait for RPC readiness in snap sync fork recovery test

### DIFF
--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/snapsync/SnapSyncForkRecoveryAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/snapsync/SnapSyncForkRecoveryAcceptanceTest.java
@@ -359,6 +359,10 @@ public class SnapSyncForkRecoveryAcceptanceTest extends AcceptanceTestBase {
     // Restart against the same data directory and re-establish the peer + consensus head (runtime
     // peering and the newPayload header cache do not survive the restart).
     noDiscoveryCluster.startNode(syncNode);
+    // Wait until the RPC server is accepting connections before calling addPeer: the ports file
+    // is written when the port is bound, but the HTTP server may not be ready to handle requests
+    // yet. awaitPeerCount retries through ConnectException (WaitUtils ignoreExceptions).
+    syncNode.verify(net.awaitPeerCount(0));
     syncNode.execute(adminTransactions.addPeer(miner.enodeUrl()));
     syncNode.verify(net.awaitPeerCount(1));
     sendNewPayload(syncNode, head);


### PR DESCRIPTION
The ports file is written when the port is bound, but the HTTP server may not yet be accepting connections. Calling addPeer immediately after startNode hits this window on loaded CI agents, causing ConnectException.

Adding awaitPeerCount(0) before addPeer gates on actual RPC readiness: WaitUtils.waitFor uses ignoreExceptions() so it retries through any ConnectException until the server responds.

Fixes #10910
