### PR TITLE
Remove fork choice update from engine_newPayloadV*

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -44,7 +44,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
-import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -370,17 +369,6 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
 
     if (latestValidAncestor.isEmpty()) {
       return respondWith(reqId, blockParam, null, ACCEPTED);
-    }
-
-    final MutableBlockchain blockchain = protocolContext.getBlockchain();
-    if (!newBlockHeader.getParentHash().equals(blockchain.getChainHeadHash())) {
-      maybeParentHeader.ifPresent(
-          parentHeader -> {
-            mergeCoordinator.updateForkChoice(
-                parentHeader,
-                blockchain.getFinalized().orElse(Hash.ZERO),
-                blockchain.getSafeBlock().orElse(Hash.ZERO));
-          });
     }
 
     // execute block and return result response


### PR DESCRIPTION
## Summary

- Remove implicit `updateForkChoice` call from `AbstractEngineNewPayload` when the new payload parent is not the current chain head.
- Fork choice updates remain the responsibility of `engine_forkchoiceUpdated`.

## Test plan

- [x] `./gradlew :ethereum:api:spotlessApply`
- [x] `./gradlew :ethereum:api:compileJava`

Signed-off-by: Karim TAAM <karim.t2am@gmail.com>
