### PR TITLE
Revert #10721 and #10725

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -654,13 +654,11 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
   @Override
   public BlockProcessingResult validateBlock(final Block block) {
-    return validateBlock(block, Optional.empty(), false);
+    return validateBlock(block, Optional.empty());
   }
 
   private BlockProcessingResult validateBlock(
-      final Block block,
-      final Optional<BlockAccessList> blockAccessList,
-      final boolean shouldPersist) {
+      final Block block, final Optional<BlockAccessList> blockAccessList) {
     final var validationResult =
         protocolSchedule
             .getByBlockHeader(block.getHeader())
@@ -671,7 +669,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 HeaderValidationMode.FULL,
                 HeaderValidationMode.NONE,
                 blockAccessList,
-                shouldPersist);
+                false);
 
     return validationResult;
   }
@@ -704,22 +702,15 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Block block, final Optional<BlockAccessList> blockAccessList) {
     LOG.atDebug().setMessage("Remember block {}").addArgument(block::toLogString).log();
     final var chain = protocolContext.getBlockchain();
-    final boolean appendToCanonicalChain =
-        block.getHeader().getNumber() - protocolContext.getBlockchain().getChainHeadBlockNumber()
-            > 1;
-    final var validationResult = validateBlock(block, blockAccessList, appendToCanonicalChain);
+    final var validationResult = validateBlock(block, blockAccessList);
     validationResult
         .getYield()
         .ifPresentOrElse(
-            result -> {
-              final Optional<BlockAccessList> processedBlockAccessList =
-                  validationResult.getYield().flatMap(y -> y.getBlockAccessList());
-              if (appendToCanonicalChain) {
-                chain.appendBlock(block, result.getReceipts(), processedBlockAccessList);
-              } else {
-                chain.storeBlock(block, result.getReceipts(), processedBlockAccessList);
-              }
-            },
+            result ->
+                chain.storeBlock(
+                    block,
+                    result.getReceipts(),
+                    validationResult.getYield().flatMap(y -> y.getBlockAccessList())),
             () -> LOG.debug("empty yield in blockProcessingResult"));
     return validationResult;
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorCacheReorgTest.java
@@ -280,7 +280,6 @@ public class MergeCoordinatorCacheReorgTest implements MergeGenesisConfigHelper 
     // === Step 3: Import A1 — rememberBlock(A1) + FCU(A1) ===
     BlockProcessingResult resultA1 = coordinator.rememberBlock(blockA1);
     assertThat(resultA1.getYield()).describedAs("Block A1 should process successfully").isPresent();
-    resultA1.getYield().get().getWorldState().persist(blockA1.getHeader());
 
     coordinator.updateForkChoice(
         blockA1.getHeader(), genesisState.getBlock().getHash(), genesisState.getBlock().getHash());


### PR DESCRIPTION
## Summary

- Revert #10721 
and #10725.

## Test plan

- [x] `./gradlew :consensus:merge:spotlessApply :ethereum:api:spotlessApply`
- [x] `./gradlew :consensus:merge:compileJava :ethereum:api:compileJava`

Signed-off-by: Karim TAAM <karim.t2am@gmail.com>
