### PR TITLE
ci: bind docker/bft workflow inputs via env before shell

### DIFF
--- a/.github/workflows/bft-soak-test.yml
+++ b/.github/workflows/bft-soak-test.yml
@@ -56,7 +56,10 @@ jobs:
         with:
           cache-disabled: true
       - name: run BFT soak test
-        run: ./gradlew :acceptance-tests:tests:acceptanceTestBftSoak -Dacctests.soakTimeMins=${{ inputs['soak-time-mins'] }} -Dacctests.consensusType=${{ inputs.consensus-type }}
+        env:
+          SOAK_TIME_MINS: ${{ inputs['soak-time-mins'] }}
+          CONSENSUS_TYPE: ${{ inputs.consensus-type }}
+        run: ./gradlew :acceptance-tests:tests:acceptanceTestBftSoak -Dacctests.soakTimeMins="$SOAK_TIME_MINS" -Dacctests.consensusType="$CONSENSUS_TYPE"
       - name: Upload BFT Soak Test HTML Reports
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -44,8 +44,11 @@ jobs:
           distribution: temurin
           java-version: 25
       - name: Stage Docker build context
+        env:
+          ASSEMBLE_RUN_ID: ${{ inputs.assemble_run_id }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ -n "${{ inputs.assemble_run_id }}" ]]; then
+          if [[ -n "$ASSEMBLE_RUN_ID" ]]; then
             # Artifacts are pre-built and downloaded from a prior assemble workflow run,
             # so only bash is needed here — just unpack the tar and arrange the files into the layout the Dockerfile expects. No Java compilation required.
             TAR_FILE=$(find build/distributions -name "besu-*.tar.gz" | head -1)
@@ -54,9 +57,9 @@ jobs:
             rm -rf build/docker-besu/besu
             mv build/docker-besu/besu-* build/docker-besu/besu
             cp docker/Dockerfile docker/pyroscope.properties build/docker-besu/
-          elif [[ -n "${{ inputs.version }}" ]]; then
+          elif [[ -n "$VERSION" ]]; then
             # No pre-built artifact: compile and stage via Gradle with an explicit release version so the distribution carries the correct version string in its metadata.
-            ./gradlew --no-daemon -Prelease.releaseVersion=${{ inputs.version }} -Pversion=${{ inputs.version }} distDockerCopy
+            ./gradlew --no-daemon -Prelease.releaseVersion="$VERSION" -Pversion="$VERSION" distDockerCopy
           else
             # No pre-built artifact and no version override: compile and stage via Gradle for an unversioned development build (e.g. a local or PR test run).
             ./gradlew --no-daemon distDockerCopy

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,19 +62,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Stage Docker build context
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ "${{ inputs.version }}" =~ ^[0-9] ]]; then
-            ./gradlew --no-daemon -Prelease.releaseVersion=${{ inputs.version }} -Pversion=${{ inputs.version }} distDockerCopy
+          if [[ "$VERSION" =~ ^[0-9] ]]; then
+            ./gradlew --no-daemon -Prelease.releaseVersion="$VERSION" -Pversion="$VERSION" distDockerCopy
           else
             ./gradlew --no-daemon distDockerCopy
           fi
       - name: Compute Docker tags
         id: dockertags
+        env:
+          VERSION: ${{ inputs.version }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          TAGS="${{ secrets.DOCKER_ORG }}/besu:${{ inputs.version }}"
-          if [[ "${{ inputs.version }}" =~ ^[0-9] ]] && \
+          TAGS="${DOCKER_ORG}/besu:${VERSION}"
+          if [[ "$VERSION" =~ ^[0-9] ]] && \
              [[ "${TAGS^^}" != *"-RC"* ]]; then
-            TAGS="$TAGS,${{ secrets.DOCKER_ORG }}/besu:latest"
+            TAGS="$TAGS,${DOCKER_ORG}/besu:latest"
           fi
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
       - name: Login to Docker Hub


### PR DESCRIPTION
## Summary
- Bind `inputs.version` / `inputs.assemble_run_id` through `env:` before shell in docker-build-test and docker-publish.
- Bind BFT soak `soak-time-mins` / `consensus-type` through `env:` before the gradle command.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] docker-build-test still stages from assemble artifact, explicit version, or develop path
- [ ] docker-publish still tags version (+ latest when non-RC)
- [ ] BFT soak still receives soak time and consensus type


Made with [Cursor](https://cursor.com)