### PR TITLE
Rejoin TXT character-strings in DNS discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- EIP-1459 DNS discovery now rejoins TXT records split across multiple `<character-string>`s. Records longer than 255 bytes were truncated, so Besu silently discarded most of every tree, resolving 832 of 3000 nodes from the mainnet tree. [#10985](https://github.com/besu-eth/besu/pull/10985)
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)
 - Bonsai world state rolling failures are now logged at `WARN` instead of `INFO`, and a missing block header or trie log during a roll reports which block hash or trie log was missing. [#10859](https://github.com/besu-eth/besu/issues/10859)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 /** Resolves a set of ENR nodes from a host name. */
 public class DNSResolver {
   private static final Logger LOG = LoggerFactory.getLogger(DNSResolver.class);
+  private static final String ENR_TREE_ROOT_PREFIX = "enrtree-root:";
   private final String enrLink;
   private long seq;
   private final DnsClient dnsClient;
@@ -142,7 +143,12 @@ public class DNSResolver {
 
   private boolean internalVisit(
       final String entryName, final String domainName, final DNSVisitor visitor) {
-    final Optional<DNSEntry> optionalDNSEntry = resolveRecord(entryName + "." + domainName);
+    final String name = entryName + "." + domainName;
+    final Optional<String> rawRecord = resolveRawRecord(name);
+    if (rawRecord.isEmpty()) {
+      return true;
+    }
+    final Optional<DNSEntry> optionalDNSEntry = Optional.ofNullable(readDNSEntry(rawRecord.get()));
     if (optionalDNSEntry.isEmpty()) {
       return true;
     }
@@ -167,13 +173,25 @@ public class DNSResolver {
   }
 
   /**
-   * Maps TXT DNS record to DNSEntry.
+   * Maps the tree root TXT record of a domain to a DNSEntry.
+   *
+   * <p>A tree apex is an ordinary domain name that may also serve unrelated TXT records such as SPF
+   * or an ownership token. A root entry is around 173 bytes so it always fits a single
+   * &lt;character-string&gt;, which means the root can be picked out by its prefix instead of
+   * concatenating whatever else is published at that name into it.
    *
    * @param domainName the domain name to query
-   * @return the DNS entry read from the domain. Empty if no record is found.
+   * @return the tree root entry published at the domain. Empty if no root record is found.
    */
   Optional<DNSEntry> resolveRecord(final String domainName) {
-    return resolveRawRecord(domainName).map(DNSResolver::readDNSEntry);
+    return resolveTxtStrings(domainName)
+        .flatMap(
+            records ->
+                records.stream()
+                    .map(DNSResolver::trimQuotes)
+                    .filter(record -> record.startsWith(ENR_TREE_ROOT_PREFIX))
+                    .findFirst())
+        .map(DNSResolver::readDNSEntry);
   }
 
   /**
@@ -218,17 +236,31 @@ public class DNSResolver {
   }
 
   /**
-   * Resolves the first TXT record for a domain name and returns it.
+   * Resolves the TXT record for a domain name and returns it.
+   *
+   * <p>RFC 1035 caps a single &lt;character-string&gt; at 255 bytes, so a record longer than that
+   * is transported as several of them and must be rejoined without a separator. EIP-1459 budgets up
+   * to the 512 byte UDP limit per record, and EIP-778 permits a 300 byte ENR (about 404 characters
+   * once base64url encoded), so multi-string records are normal rather than exceptional. Reading
+   * only the first string silently truncates them.
    *
    * @param domainName the name of the DNS domain to query
-   * @return the first TXT entry of the DNS record. Empty if no record is found.
+   * @return the TXT entry of the DNS record. Empty if no record is found.
    */
   Optional<String> resolveRawRecord(final String domainName) {
+    return resolveTxtStrings(domainName).map(records -> String.join("", records));
+  }
+
+  private Optional<List<String>> resolveTxtStrings(final String domainName) {
     LOG.trace("Resolving TXT records on domain: {}", domainName);
     try {
       // Future.await parks current virtual thread and waits for the result. Any failure is
       // thrown as a Throwable.
-      return Future.await(dnsClient.resolveTXT(domainName)).stream().findFirst();
+      final List<String> records = Future.await(dnsClient.resolveTXT(domainName));
+      if (records == null || records.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(records);
     } catch (final Throwable e) {
       LOG.trace("Error while resolving TXT records on domain: {}", domainName, e);
       return Optional.empty();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSRecordEncodingTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSRecordEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSRecordEncodingTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSRecordEncodingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.p2p.discovery.dns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.Security;
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * RFC 1035 caps a TXT &lt;character-string&gt; at 255 bytes, so anything longer arrives as several
+ * of them in one RDATA. EIP-1459 budgets a record against the 512 byte UDP limit and EIP-778
+ * permits a 300 byte ENR (about 404 characters once base64url encoded), so records above 255 bytes
+ * are routine: go-ethereum's writer sizes branch entries up to 370 bytes deliberately.
+ */
+@ExtendWith(VertxExtension.class)
+class DNSRecordEncodingTest {
+  private static final String DOMAIN = "all.holesky.ethdisco.net";
+  private static final String ENR_LINK =
+      "enrtree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@" + DOMAIN;
+  private final MockDnsServerVerticle mockDnsServerVerticle = new MockDnsServerVerticle();
+
+  @BeforeAll
+  static void setup() {
+    Security.addProvider(new BouncyCastleProvider());
+  }
+
+  @BeforeEach
+  void prepare(final Vertx vertx, final VertxTestContext vertxTestContext) {
+    vertx.deployVerticle(mockDnsServerVerticle, vertxTestContext.succeedingThenComplete());
+  }
+
+  private DNSResolver resolver(final Vertx vertx) {
+    return new DNSResolver(
+        vertx, ENR_LINK, 0, Optional.of("127.0.0.1:" + mockDnsServerVerticle.port()));
+  }
+
+  @Test
+  @DisplayName("A record spanning several character-strings is rejoined, not truncated")
+  void multipleCharacterStringsAreRejoined(final Vertx vertx) {
+    final String content = "enrtree-branch:" + "A".repeat(700);
+    final String name = "multistring." + DOMAIN;
+    mockDnsServerVerticle.addTxtRecord(name, content);
+
+    final Optional<String> raw = resolver(vertx).resolveRawRecord(name);
+
+    assertThat(raw).isPresent();
+    assertThat(raw.get()).hasSize(content.length()).isEqualTo(content);
+  }
+
+  @Test
+  @DisplayName("A single character-string record is unchanged")
+  void singleCharacterStringIsUnchanged(final Vertx vertx) {
+    final String content = "enrtree-branch:SHORT";
+    final String name = "singlestring." + DOMAIN;
+    mockDnsServerVerticle.addTxtRecord(name, content);
+
+    assertThat(resolver(vertx).resolveRawRecord(name)).contains(content);
+  }
+
+  @Test
+  @DisplayName("An ENR longer than one character-string survives the round trip")
+  void longEnrRecordIsRejoined(final Vertx vertx) {
+    final String content = "enr:" + "B".repeat(400);
+    final String name = "longenr." + DOMAIN;
+    mockDnsServerVerticle.addTxtRecord(name, content);
+
+    assertThat(resolver(vertx).resolveRawRecord(name)).contains(content);
+  }
+
+  /**
+   * A tree apex is an ordinary name that may also publish SPF or an ownership token. Concatenating
+   * those into the root corrupts the trailing signature and the root then fails its signature
+   * check, so the comparison here is against the whole entry rather than a single field.
+   */
+  @Test
+  @DisplayName("The tree root is found intact alongside unrelated TXT records at the same name")
+  void rootIsSelectedAmongOtherTxtRecordsAtTheApex(final Vertx vertx) {
+    final String rootRecord =
+        "enrtree-root:v1 e=SNIGOIP7I67HGIGFKVFYHSSDYM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=1 "
+            + "sig=QSou7Q43nN2CKaxwAw868cUbKK-gl2FVCkpF86KFz4ghDqIo5hfqChZ5gEkaHfsBsfzEYMBjuYIxBNn0_cZQdAA";
+    final String apex = "coexisting." + DOMAIN;
+    mockDnsServerVerticle.addTxtRecord(apex, "v=spf1 -all");
+    mockDnsServerVerticle.appendTxtRecord(apex, rootRecord);
+
+    final Optional<DNSEntry> entry = resolver(vertx).resolveRecord(apex);
+
+    assertThat(entry).isPresent();
+    assertThat(entry.get()).isInstanceOf(DNSEntry.ENRTreeRoot.class);
+    assertThat(entry.get().toString()).isEqualTo(DNSResolver.readDNSEntry(rootRecord).toString());
+    assertThat(((DNSEntry.ENRTreeRoot) entry.get()).enrRoot())
+        .isEqualTo("SNIGOIP7I67HGIGFKVFYHSSDYM");
+  }
+}

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/MockDnsServerVerticle.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/MockDnsServerVerticle.java
@@ -17,7 +17,9 @@ package org.hyperledger.besu.ethereum.p2p.discovery.dns;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -36,7 +38,8 @@ import org.slf4j.LoggerFactory;
 /** Mock DNS server verticle. */
 public class MockDnsServerVerticle extends AbstractVerticle {
   private static final Logger LOG = LoggerFactory.getLogger(MockDnsServerVerticle.class);
-  private final Map<String, String> txtRecords = new HashMap<>();
+  private static final int MAX_CHARACTER_STRING = 255;
+  private final Map<String, List<String>> txtRecords = new HashMap<>();
   private int dnsPort;
 
   @Override
@@ -54,7 +57,7 @@ public class MockDnsServerVerticle extends AbstractVerticle {
             buffer -> {
               final JsonObject dnsEntries = new JsonObject(buffer.toString());
               final Map<String, Object> jsonMap = dnsEntries.getMap();
-              jsonMap.forEach((key, value) -> txtRecords.put(key, value.toString()));
+              jsonMap.forEach((key, value) -> addTxtRecord(key, value.toString()));
 
               // start the server
               return datagramSocket.listen(0, "127.0.0.1");
@@ -72,7 +75,14 @@ public class MockDnsServerVerticle extends AbstractVerticle {
   }
 
   public void addTxtRecord(final String key, final String value) {
-    txtRecords.put(key, value);
+    final List<String> records = new ArrayList<>();
+    records.add(value);
+    txtRecords.put(key, records);
+  }
+
+  /** Publishes an additional TXT record at a name that already has one. */
+  public void appendTxtRecord(final String key, final String value) {
+    txtRecords.computeIfAbsent(key, unused -> new ArrayList<>()).add(value);
   }
 
   @Override
@@ -127,14 +137,14 @@ public class MockDnsServerVerticle extends AbstractVerticle {
   }
 
   private Buffer createTXTResponse(
-      final short queryId, final String queryName, final String txtRecord) {
+      final short queryId, final String queryName, final List<String> records) {
     final Buffer buffer = Buffer.buffer();
 
     // Write DNS header
     buffer.appendShort(queryId); // Query Identifier
     buffer.appendShort((short) 0x8180); // Flags (Standard query response, No error)
     buffer.appendShort((short) 1); // Questions count
-    buffer.appendShort((short) 1); // Answers count
+    buffer.appendShort((short) records.size()); // Answers count
     buffer.appendShort((short) 0); // Authority RRs count
     buffer.appendShort((short) 0); // Additional RRs count
 
@@ -150,21 +160,32 @@ public class MockDnsServerVerticle extends AbstractVerticle {
     buffer.appendShort((short) 16); // Type (TXT)
     buffer.appendShort((short) 1); // Class (IN)
 
-    // Write answer
-    for (String label : queryLabels) {
-      buffer.appendByte((byte) label.length());
-      buffer.appendString(label.toLowerCase(Locale.ROOT));
+    for (final String txtRecord : records) {
+      for (String label : queryLabels) {
+        buffer.appendByte((byte) label.length());
+        buffer.appendString(label.toLowerCase(Locale.ROOT));
+      }
+      buffer.appendByte((byte) 0); // End of answer name
+
+      buffer.appendShort((short) 16); // TXT record type
+      buffer.appendShort((short) 1); // Class (IN)
+      buffer.appendInt(60); // TTL (60 seconds)
+
+      // RFC 1035 caps a <character-string> at 255 bytes, so a real server splits longer content
+      // into several of them within one RDATA. A single length byte would overflow past 255.
+      final byte[] txtBytes = txtRecord.getBytes(UTF_8);
+      final int chunks =
+          Math.max(1, (txtBytes.length + MAX_CHARACTER_STRING - 1) / MAX_CHARACTER_STRING);
+      buffer.appendShort((short) (txtBytes.length + chunks)); // Data length
+      for (int offset = 0; offset < txtBytes.length; offset += MAX_CHARACTER_STRING) {
+        final int length = Math.min(MAX_CHARACTER_STRING, txtBytes.length - offset);
+        buffer.appendByte((byte) length);
+        buffer.appendBytes(txtBytes, offset, length);
+      }
+      if (txtBytes.length == 0) {
+        buffer.appendByte((byte) 0);
+      }
     }
-    buffer.appendByte((byte) 0); // End of answer name
-
-    buffer.appendShort((short) 16); // TXT record type
-    buffer.appendShort((short) 1); // Class (IN)
-    buffer.appendInt(60); // TTL (60 seconds)
-
-    int txtRecordsLength = txtRecord.getBytes(UTF_8).length;
-    buffer.appendShort((short) (txtRecordsLength + 1)); // Data length
-    buffer.appendByte((byte) txtRecordsLength); // TXT record length
-    buffer.appendString(txtRecord);
 
     return buffer;
   }


### PR DESCRIPTION
## PR description

Besu truncates DNS discovery records longer than 255 bytes, and silently drops most of every tree as
a result. On `all.mainnet.ethdisco.net` at seq 8392, Besu resolves 832 nodes. go-ethereum resolves
3000. After this change Besu resolves 3000 too.

`DNSResolver.resolveRawRecord` ended with `resolveTXT(...).stream().findFirst()`, so it kept only the
first `<character-string>` of each record.

RFC 1035 caps a `<character-string>` at 255 bytes. EIP-1459 budgets a record against the 512 byte UDP
limit, and EIP-778 permits a 300 byte ENR, which is about 404 characters once base64url encoded.
Records above 255 bytes are therefore normal rather than unusual. go-ethereum sizes branch entries up
to 370 bytes, and 219 of 300 sampled mainnet records span several character-strings. Vert.x returns
each one as a separate list element, so they must be rejoined with no separator. Go's resolver does
the same (`net/lookup.go`: "Multiple strings in one TXT record need to be concatenated without
separator").

The loss was silent because a truncated record simply failed to parse, and `internalVisit` treats a
parse failure as "keep going".

### Root selection

Rejoining introduces one hazard, fixed here too. A tree apex is an ordinary domain name that may also
publish SPF or an ownership token. Joining those into the root would corrupt its trailing signature.
A root is about 173 bytes, so it always fits one `<character-string>` and can be identified by its
`enrtree-root:` prefix. It is now selected that way. go-ethereum does this too.

### Test mock

`MockDnsServerVerticle` wrote a single length byte, so a 370 byte record produced
`(byte) 370 == 114` and a malformed packet. No test in the suite could express an oversized record,
which is why this went unnoticed. It now splits content into 255 byte character-strings and can serve
several TXT records per name.

`addTxtRecord` keeps its replace semantics, since `DNSDaemonTest` relies on overriding a fixture
entry. A new `appendTxtRecord` covers the multiple-records-per-name case.

### Tests

`DNSRecordEncodingTest` covers rejoining a multi-character-string record, leaving a single-string
record untouched, an ENR above 255 bytes, and root selection beside an unrelated TXT record.

Each was mutation tested, so none passes vacuously. Reverting the join fails the two rejoining tests.
Restoring the mock's single length byte fails the same two. Reverting root selection fails the apex
test.

`./gradlew :ethereum:p2p:test` passes. The test fixture is untouched by this PR.


## Fixed Issue(s)

None filed. This surfaced while validating a third-party enrtree publisher against go-ethereum. Happy to open one if you would prefer it tracked.

### Checklist

- [x] Checked out the contribution guidelines
- [ ] Documentation: no user-facing docs change, so no `doc-change-required` label
- [x] Changelog updated
- [ ] Database changes: none

Ran locally:

- [x] `./gradlew spotlessApply`
- [x] `./gradlew :ethereum:p2p:test`
- [ ] `./gradlew build` (not run in full; CI covers it)
- [ ] acceptance, integration, reference, hive tests (not run; no consensus or RPC surface touched)
