### PR TITLE
fix: make port clash detection protocol-aware (TCP vs UDP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Port clash detection (`checkPortClash` / `checkIfRequiredPortsAreAvailable`) now accounts for the transport protocol (TCP vs UDP) a port is bound on, instead of treating every configured port as a single flat namespace. [#10904](https://github.com/besu-eth/besu/issues/10904)
 - EIP-1459 DNS discovery now rejoins TXT records split across multiple `<character-string>`s. Records longer than 255 bytes were truncated, so Besu silently discarded most of every tree, resolving 832 of 3000 nodes from the mainnet tree. [#10985](https://github.com/besu-eth/besu/pull/10985)
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)

--- a/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -214,6 +214,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -340,7 +342,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final PreSynchronizationTaskRunner preSynchronizationTaskRunner =
       new PreSynchronizationTaskRunner();
 
-  private final Set<Integer> allocatedPorts = new HashSet<>();
+  private final Map<PortProtocol, Set<Integer>> allocatedPorts = new EnumMap<>(PortProtocol.class);
   private Supplier<GenesisConfig> genesisConfigSupplier =
       Suppliers.memoize(this::readGenesisConfig);
 
@@ -2763,20 +2765,45 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     return enodeDnsConfiguration;
   }
 
+  /** The transport-layer protocol a port is bound on. */
+  @VisibleForTesting
+  enum PortProtocol {
+    /** TCP transport. */
+    TCP,
+    /** UDP transport. */
+    UDP
+  }
+
+  /**
+   * A port together with the transport protocol(s) it is bound to. Two port assignments only clash
+   * when they share both the same port number and at least one protocol - e.g. a UDP-only discovery
+   * port and a TCP-only metrics port may safely use the same port number.
+   *
+   * @param port the port number
+   * @param protocols the transport protocol(s) the port is bound on
+   */
+  @VisibleForTesting
+  record EffectivePort(Integer port, EnumSet<PortProtocol> protocols) {}
+
   private void checkPortClash() {
     getEffectivePorts().stream()
-        .filter(Objects::nonNull)
-        .filter(port -> port > 0)
+        .filter(effectivePort -> effectivePort.port() != null && effectivePort.port() > 0)
         .forEach(
-            port -> {
-              if (!allocatedPorts.add(port)) {
-                throw new ParameterException(
-                    commandLine,
-                    "Port number '"
-                        + port
-                        + "' has been specified multiple times. Please review the supplied configuration.");
-              }
-            });
+            effectivePort ->
+                effectivePort
+                    .protocols()
+                    .forEach(
+                        protocol -> {
+                          if (!allocatedPorts
+                              .computeIfAbsent(protocol, unused -> new HashSet<>())
+                              .add(effectivePort.port())) {
+                            throw new ParameterException(
+                                commandLine,
+                                "Port number '"
+                                    + effectivePort.port()
+                                    + "' has been specified multiple times. Please review the supplied configuration.");
+                          }
+                        }));
   }
 
   /**
@@ -2787,18 +2814,16 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   protected void checkIfRequiredPortsAreAvailable() {
     final List<Integer> unavailablePorts = new ArrayList<>();
     getEffectivePorts().stream()
-        .filter(Objects::nonNull)
-        .filter(port -> port > 0)
+        .filter(effectivePort -> effectivePort.port() != null && effectivePort.port() > 0)
         .forEach(
-            port -> {
-              if (port.equals(p2PDiscoveryConfig.p2pPort())
-                  && (NetworkUtility.isPortUnavailableForTcp(port)
-                      || NetworkUtility.isPortUnavailableForUdp(port))) {
-                unavailablePorts.add(port);
-              }
-              if (!port.equals(p2PDiscoveryConfig.p2pPort())
-                  && NetworkUtility.isPortUnavailableForTcp(port)) {
-                unavailablePorts.add(port);
+            effectivePort -> {
+              final boolean unavailable =
+                  (effectivePort.protocols().contains(PortProtocol.TCP)
+                          && NetworkUtility.isPortUnavailableForTcp(effectivePort.port()))
+                      || (effectivePort.protocols().contains(PortProtocol.UDP)
+                          && NetworkUtility.isPortUnavailableForUdp(effectivePort.port()));
+              if (unavailable) {
+                unavailablePorts.add(effectivePort.port());
               }
             });
     if (!unavailablePorts.isEmpty()) {
@@ -2810,22 +2835,45 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   /**
-   * * Gets the list of effective ports (ports that are enabled).
+   * * Gets the list of effective ports (ports that are enabled), tagged with the transport
+   * protocol(s) they are bound on.
    *
    * @return The list of effective ports
    */
-  private List<Integer> getEffectivePorts() {
-    final List<Integer> effectivePorts = new ArrayList<>();
-    addPortIfEnabled(effectivePorts, p2PDiscoveryOptions.p2pPort, p2PDiscoveryOptions.p2pEnabled);
+  @VisibleForTesting
+  List<EffectivePort> getEffectivePorts() {
+    final List<EffectivePort> effectivePorts = new ArrayList<>();
+    // The P2P port currently serves both the TCP RLPx listener and the UDP discovery socket.
     addPortIfEnabled(
-        effectivePorts, graphQlOptions.getGraphQLHttpPort(), graphQlOptions.isGraphQLHttpEnabled());
+        effectivePorts,
+        p2PDiscoveryOptions.p2pPort,
+        p2PDiscoveryOptions.p2pEnabled,
+        EnumSet.of(PortProtocol.TCP, PortProtocol.UDP));
     addPortIfEnabled(
-        effectivePorts, jsonRpcHttpOptions.getRpcHttpPort(), jsonRpcHttpOptions.isRpcHttpEnabled());
+        effectivePorts,
+        graphQlOptions.getGraphQLHttpPort(),
+        graphQlOptions.isGraphQLHttpEnabled(),
+        EnumSet.of(PortProtocol.TCP));
     addPortIfEnabled(
-        effectivePorts, rpcWebsocketOptions.getRpcWsPort(), rpcWebsocketOptions.isRpcWsEnabled());
-    addPortIfEnabled(effectivePorts, engineRPCConfig.engineRpcPort(), isEngineApiEnabled());
+        effectivePorts,
+        jsonRpcHttpOptions.getRpcHttpPort(),
+        jsonRpcHttpOptions.isRpcHttpEnabled(),
+        EnumSet.of(PortProtocol.TCP));
     addPortIfEnabled(
-        effectivePorts, metricsOptions.getMetricsPort(), metricsOptions.getMetricsEnabled());
+        effectivePorts,
+        rpcWebsocketOptions.getRpcWsPort(),
+        rpcWebsocketOptions.isRpcWsEnabled(),
+        EnumSet.of(PortProtocol.TCP));
+    addPortIfEnabled(
+        effectivePorts,
+        engineRPCConfig.engineRpcPort(),
+        isEngineApiEnabled(),
+        EnumSet.of(PortProtocol.TCP));
+    addPortIfEnabled(
+        effectivePorts,
+        metricsOptions.getMetricsPort(),
+        metricsOptions.getMetricsEnabled(),
+        EnumSet.of(PortProtocol.TCP));
     return effectivePorts;
   }
 
@@ -2835,11 +2883,15 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
    * @param ports The list of ports
    * @param port The port value
    * @param enabled true if enabled, false otherwise
+   * @param protocols the transport protocol(s) the port is bound on
    */
   private void addPortIfEnabled(
-      final List<Integer> ports, final Integer port, final boolean enabled) {
+      final List<EffectivePort> ports,
+      final Integer port,
+      final boolean enabled,
+      final EnumSet<PortProtocol> protocols) {
     if (enabled) {
-      ports.add(port);
+      ports.add(new EffectivePort(port, protocols));
     }
   }
 

--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2476,6 +2476,45 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void effectivePortsTagP2pPortWithBothTcpAndUdp() {
+    final TestBesuCommand command = parseCommand("--p2p-port=30301");
+    assertThat(commandErrorOutput.toString(UTF_8)).doesNotContain("specified multiple times");
+
+    final Optional<BesuCommand.EffectivePort> p2pPort =
+        command.getEffectivePorts().stream().filter(p -> p.port() == 30301).findFirst();
+    assertThat(p2pPort).isPresent();
+    assertThat(p2pPort.get().protocols())
+        .containsExactlyInAnyOrder(BesuCommand.PortProtocol.TCP, BesuCommand.PortProtocol.UDP);
+  }
+
+  @Test
+  public void effectivePortsTagTcpOnlyServicesWithTcpOnly() {
+    final TestBesuCommand command =
+        parseCommand(
+            "--metrics-enabled",
+            "--metrics-port=9545",
+            "--rpc-http-enabled",
+            "--rpc-http-port=8555");
+    assertThat(commandErrorOutput.toString(UTF_8)).doesNotContain("specified multiple times");
+
+    final List<BesuCommand.EffectivePort> effectivePorts = command.getEffectivePorts();
+    assertThat(
+            effectivePorts.stream()
+                .filter(p -> p.port() == 9545)
+                .findFirst()
+                .orElseThrow()
+                .protocols())
+        .containsExactly(BesuCommand.PortProtocol.TCP);
+    assertThat(
+            effectivePorts.stream()
+                .filter(p -> p.port() == 8555)
+                .findFirst()
+                .orElseThrow()
+                .protocols())
+        .containsExactly(BesuCommand.PortProtocol.TCP);
+  }
+
+  @Test
   public void staticNodesFileOptionValueAbsentMessage() {
     parseCommand("--static-nodes-file");
     assertThat(commandErrorOutput.toString(UTF_8))

--- a/app/src/test/java/org/hyperledger/besu/cli/EphemeryTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/EphemeryTest.java
@@ -70,7 +70,9 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -307,11 +309,16 @@ public class EphemeryTest extends CommandTestAbstract {
     Field portsField = BesuCommand.class.getDeclaredField("allocatedPorts");
     portsField.setAccessible(true);
     @SuppressWarnings("unchecked")
-    Set<Integer> allocatedPorts = (Set<Integer>) portsField.get(besuCommand);
+    Map<BesuCommand.PortProtocol, Set<Integer>> allocatedPorts =
+        (Map<BesuCommand.PortProtocol, Set<Integer>>) portsField.get(besuCommand);
 
     // Add some ports
-    allocatedPorts.add(8545);
-    allocatedPorts.add(30303);
+    allocatedPorts
+        .computeIfAbsent(BesuCommand.PortProtocol.TCP, unused -> new HashSet<>())
+        .add(8545);
+    allocatedPorts
+        .computeIfAbsent(BesuCommand.PortProtocol.UDP, unused -> new HashSet<>())
+        .add(30303);
     assertThat(allocatedPorts).hasSizeGreaterThanOrEqualTo(2);
     besuCommand.clearAllocatedPorts();
 


### PR DESCRIPTION
checkPortClash and checkIfRequiredPortsAreAvailable treated every configured port as a single flat namespace, so a UDP-only service and a TCP-only service assigned the same port number were incorrectly flagged as clashing even though they don't collide at the OS level.

getEffectivePorts now tags each port with the transport protocol(s) it is bound on, and the two checks only compare ports within the same protocol. The P2P port is tagged TCP+UDP since it currently serves both the RLPx listener and the discovery socket; all other ports (metrics, RPC HTTP/WS, GraphQL, engine API) are TCP-only. This preserves all existing behaviour and lays the groundwork for protocol-specific ports (e.g. a separate discovery port) to coexist with same-numbered TCP-only ports.

Fixes #10904


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


