### PR TITLE
Revise COLD_STORAGE_ACCESS and ACCOUNT_WRITE values

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -271,7 +271,7 @@ class AbstractBlockProcessorIntegrationTest {
     MutableWorldState worldState = worldStateArchive.getWorldState();
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x3086411bd16f16bc32aa3d66fe714ad3b550f1cf984874a12eecea6c84d3b82a",
+            "0xbc68b632221f19f22fff7c5883755fe9610be5bbe8722cb6cdb6e8cbf9814a50",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -727,7 +727,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x3e8f3a9a2085f356f1fd3a6376fe1840e4cb46a363bafe48e8115d688dc55442",
+            "0x85af922b9234c2137cf2bd030036ac011f5753aa5aec4fa46ab96c284acff4bb",
             Wei.of(5),
             setSlot1Transaction,
             getSlot1Transaction,
@@ -790,7 +790,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xc8aeca86351eff24abc6f3b9a28982fb31822a427f44b70f5d7cec3bb31581a6",
+            "0xaf3d69d49cf2f4a00b81c634bb9b89371827870c6410e6beb48b901bda5bd2a5",
             Wei.of(5),
             getSlot1Transaction,
             setSlot1Transaction,
@@ -861,7 +861,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x1e3c5d762e099a7967d7d226b12692c0f61f2aa2f807b60fa253693d9aa53196",
+            "0xece29b75b27056f5794e428c553fcaf2e4e281ff4a7b2c4627b82def314188d4",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -932,7 +932,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0xdb50ddd7ca8b00ebcdf43b72adeea2d999bc3f50d00b9d0aca06f2bef3cd472f",
+            "0xfd9cc32aad4462bf112f8c6b35f24fe5fe3ef190dff017ffec1f1938c19bda0c",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,
@@ -1002,7 +1002,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x2fd424ddb705b55346a535e99bcceff9a8ae0b19d037ffcad09b2d951a7a6226",
+            "0xe7baefd8e65f1205bc45089d0b67d8caf169323ba0a859f319c871e043884a68",
             Wei.of(5),
             transactionTransfer,
             getcontractBalanceTransaction,
@@ -1074,7 +1074,7 @@ class AbstractBlockProcessorIntegrationTest {
 
     Block blockWithTransactions =
         createBlockWithTransactions(
-            "0x2fd424ddb705b55346a535e99bcceff9a8ae0b19d037ffcad09b2d951a7a6226",
+            "0xe7baefd8e65f1205bc45089d0b67d8caf169323ba0a859f319c871e043884a68",
             Wei.of(5),
             transactionTransfer,
             sendEthFromContractTransaction,

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -390,7 +390,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long selfDestructOperationGasCost(final Account recipient, final Wei inheritance) {
-    // EIP-8038: static cost (5,000) plus ACCOUNT_WRITE (8,000) when a positive balance is sent to a
+    // EIP-8038: static cost (5,000) plus ACCOUNT_WRITE (9,000) when a positive balance is sent to a
     // new (non-existent or empty) beneficiary. The cold-access surcharge is added by the operation;
     // the NEW_ACCOUNT state gas is charged at the call site in SelfDestructOperation.
     long cost = selfDestructOperationStaticGasCost();

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -68,10 +68,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   protected static final long COLD_ACCOUNT_ACCESS = 3_000L;
 
   /** Cold storage slot access cost. */
-  protected static final long COLD_STORAGE_ACCESS = 3_000L;
+  protected static final long COLD_STORAGE_ACCESS = 2_100L;
 
   /** Account write cost (value-bearing CALL / new account). */
-  protected static final long ACCOUNT_WRITE = 8_000L;
+  protected static final long ACCOUNT_WRITE = 9_000L;
 
   /**
    * Per-address cost of a transaction access list entry: the cold access it prepays, less the warm

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -80,34 +80,36 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void accessListGasCostIncludesDataFloor() {
-    // EIP-8038: per-entry access cost is COLD_ACCESS (3,000) - WARM_ACCESS (100) = 2,900 for both
-    // addresses and keys, so a prepaid entry is gas-neutral with a cold access.
+    // EIP-8038: per-address access cost is COLD_ACCOUNT_ACCESS (3,000) - WARM_ACCESS (100) =
+    // 2,900; per-key access cost is COLD_STORAGE_ACCESS (2,100) - WARM_ACCESS (100) = 2,000, so a
+    // prepaid entry is gas-neutral with a cold access.
     // EIP-7981 data floor: +1280/address + 2048/key.
     // One address + zero keys  = 2900 + 1280 = 4180
     assertThat(amsterdamGasCalculator.accessListGasCost(1, 0)).isEqualTo(4180L);
-    // One address + one key    = 4180 + 2900 + 2048 = 9128
-    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(9128L);
-    // Three addresses + five keys = 3*4180 + 5*(2900+2048) = 12540 + 24740 = 37280
-    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(37280L);
+    // One address + one key    = 4180 + 2000 + 2048 = 8228
+    assertThat(amsterdamGasCalculator.accessListGasCost(1, 1)).isEqualTo(8228L);
+    // Three addresses + five keys = 3*4180 + 5*(2000+2048) = 12540 + 20240 = 32780
+    assertThat(amsterdamGasCalculator.accessListGasCost(3, 5)).isEqualTo(32780L);
   }
 
   @Test
   void eip8038CreateAccessGasCost() {
-    // EIP-8038: CREATE/CREATE2 regular-gas cost = CREATE_ACCESS = ACCOUNT_WRITE (8,000)
-    // + COLD_STORAGE_ACCESS (3,000) = 11,000.
-    assertThat(amsterdamGasCalculator.txCreateCost()).isEqualTo(11_000L);
+    // EIP-8038: CREATE/CREATE2 regular-gas cost = CREATE_ACCESS = ACCOUNT_WRITE (9,000)
+    // + COLD_ACCOUNT_ACCESS (3,000) = 12,000.
+    assertThat(amsterdamGasCalculator.txCreateCost()).isEqualTo(12_000L);
   }
 
   @Test
   void eip8038StateAccessGasRepricing() {
-    // EIP-8038: cold access raised to 3,000 (account was 2,600, storage slot was 2,100).
+    // EIP-8038: cold account access is 3,000 (was 2,600); cold storage access is 2,100 (was
+    // 3,000, briefly repriced up before this revision brought it back to the pre-8038 value).
     assertThat(amsterdamGasCalculator.getColdAccountAccessCost()).isEqualTo(3_000L);
-    assertThat(amsterdamGasCalculator.getColdSloadCost()).isEqualTo(3_000L);
+    assertThat(amsterdamGasCalculator.getColdSloadCost()).isEqualTo(2_100L);
     // SSTORE cold surcharge excludes the warm base (100) folded into slotAccessCost:
-    // COLD_STORAGE_ACCESS 3,000 - WARM_ACCESS 100 = 2,900.
-    assertThat(amsterdamGasCalculator.getSStoreColdAccessGasCost()).isEqualTo(2_900L);
-    // CALL value cost = ACCOUNT_WRITE (8,000) + CALL_STIPEND (2,300) = 10,300.
-    assertThat(amsterdamGasCalculator.callValueTransferGasCost()).isEqualTo(10_300L);
+    // COLD_STORAGE_ACCESS 2,100 - WARM_ACCESS 100 = 2,000.
+    assertThat(amsterdamGasCalculator.getSStoreColdAccessGasCost()).isEqualTo(2_000L);
+    // CALL value cost = ACCOUNT_WRITE (9,000) + CALL_STIPEND (2,300) = 11,300.
+    assertThat(amsterdamGasCalculator.callValueTransferGasCost()).isEqualTo(11_300L);
     // EXTCODESIZE base = extra WARM_ACCESS "code reading cost" (100).
     assertThat(amsterdamGasCalculator.getExtCodeSizeOperationGasCost()).isEqualTo(100L);
   }
@@ -143,9 +145,9 @@ class AmsterdamGasCalculatorTest {
         Arguments.of("ETH creating a new account", RECIPIENT, Wei.ONE, 21_000L),
         // to == null: contract creation. CREATE_ACCESS covers the recipient balance write and the
         // EIP-7708 transfer log is folded into TX_VALUE_COST, so value makes no difference.
-        Arguments.of("create, value = 0", null, Wei.ZERO, 23_000L),
-        Arguments.of("create, value > 0", null, Wei.ONE, 23_000L),
-        Arguments.of("create, target pre-exists", null, Wei.ZERO, 23_000L));
+        Arguments.of("create, value = 0", null, Wei.ZERO, 24_000L),
+        Arguments.of("create, value > 0", null, Wei.ONE, 24_000L),
+        Arguments.of("create, target pre-exists", null, Wei.ZERO, 24_000L));
   }
 
   @ParameterizedTest(name = "{0}")
@@ -167,10 +169,10 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void eip2780IntrinsicGasChargesInitCodeWords() {
-    // Creation of a 33-byte init code: 23,000 + CODE_INIT_PER_WORD (2) * ceil(33/32) = 23,004.
+    // Creation of a 33-byte init code: 24,000 + CODE_INIT_PER_WORD (2) * ceil(33/32) = 24,004.
     // All non-zero bytes, so data_cost = 33 * 4 * 4 = 528.
     final Transaction tx = transactionWith(null, Wei.ZERO, Bytes.repeat((byte) 0x1, 33), 0);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(23_532L);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(24_532L);
   }
 
   @Test
@@ -187,7 +189,7 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void eip2780AccountWriteGasCostIsExposedForTheTopFrameAuthorizationCharge() {
-    assertThat(amsterdamGasCalculator.getAccountWriteGasCost()).isEqualTo(8_000L);
+    assertThat(amsterdamGasCalculator.getAccountWriteGasCost()).isEqualTo(9_000L);
   }
 
   private Transaction transactionWith(
@@ -274,18 +276,18 @@ class AmsterdamGasCalculatorTest {
   @Test
   void eip8246SelfDestructOperationGasCost() {
     // EIP-8038/EIP-8246: static SELFDESTRUCT cost is 5,000; sending a positive balance to a new
-    // (non-existent or empty) beneficiary adds ACCOUNT_WRITE (8,000) => 13,000. The cold-access
+    // (non-existent or empty) beneficiary adds ACCOUNT_WRITE (9,000) => 14,000. The cold-access
     // surcharge and NEW_ACCOUNT state gas are charged elsewhere (in SelfDestructOperation).
 
-    // null beneficiary + positive balance => 5,000 + 8,000 = 13,000
+    // null beneficiary + positive balance => 5,000 + 9,000 = 14,000
     assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(null, Wei.ONE))
-        .isEqualTo(13_000L);
+        .isEqualTo(14_000L);
 
-    // empty beneficiary + positive balance => 5,000 + 8,000 = 13,000
+    // empty beneficiary + positive balance => 5,000 + 9,000 = 14,000
     final Account emptyBeneficiary = mock(Account.class);
     when(emptyBeneficiary.isEmpty()).thenReturn(true);
     assertThat(amsterdamGasCalculator.selfDestructOperationGasCost(emptyBeneficiary, Wei.ONE))
-        .isEqualTo(13_000L);
+        .isEqualTo(14_000L);
 
     // existing (non-empty) beneficiary + positive balance => static 5,000 only
     final Account aliveBeneficiary = mock(Account.class);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
@@ -271,9 +271,9 @@ class SStoreOperationTest {
 
     // No state gas for clearing when original was nonzero
     assertThat(frame.getStateGasUsed()).isEqualTo(0L);
-    // EIP-8038: storage-clear refund = (STORAGE_WRITE 10,000 + COLD_STORAGE_ACCESS 3,000) * 4800 /
-    // 5000 = 12,480 (replaces the London SSTORE_CLEARS_SCHEDULE of 4,800).
-    assertThat(frame.getGasRefund()).isEqualTo(12_480L);
+    // EIP-8038: storage-clear refund = (STORAGE_WRITE 10,000 + COLD_STORAGE_ACCESS 2,100) * 4800 /
+    // 5000 = 11,616 (replaces the London SSTORE_CLEARS_SCHEDULE of 4,800).
+    assertThat(frame.getGasRefund()).isEqualTo(11_616L);
   }
 
   @Test


### PR DESCRIPTION
## PR description

ref: https://github.com/ethereum/EIPs/pull/12083

Changes COLD_STORAGE_ACCESS to 2,100 (unchanged from its current value) and ACCOUNT_WRITE to 9,000

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


