### PR TITLE
Default --discovery-mode to V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `--network=dev` is no longer supported; use `ephemery` or Kurtosis for local devnets. [#10836](https://github.com/besu-eth/besu/pull/10836)
 - Plugin API: `HealthCheckProvider` now returns `HealthCheckResult` (status + details map) instead of `boolean` [#10687](https://github.com/besu-eth/besu/issues/10687)
 - The experimental `--Xmax-tracked-seen-txs-per-peer` alias is removed (deprecated since 26.4.0). Use `--Xmax-tracked-seen-txs` instead. [#11018](https://github.com/besu-eth/besu/pull/11018)
-- The experimental `--Xv5-discovery-enabled` flag is removed; use `--discovery-mode=V5` or `--discovery-mode=BOTH` instead.
+- The experimental `--Xv5-discovery-enabled` flag is removed; discovery now defaults to `--discovery-mode=V4`. Use `--discovery-mode=BOTH` or `V5` to enable DiscV5.
 - The genesis file `v5Bootnodes` key is removed; ENR bootnodes must now be listed in the unified `bootnodes` array alongside enode URLs. Besu's bundled network genesis files were migrated automatically - this only affects custom/downstream genesis files that still use the old `v5Bootnodes` key, whose ENR entries will otherwise be silently dropped.
 - Removed the legacy `PANTHEON_` environment variable prefix for configuration options, everyone should already use the `BESU_` prefix at this time.
 - Removed `--min-block-occupancy-ratio` option. The flag has been a silent no-op since 26.4.0. [#11017](https://github.com/besu-eth/besu/pull/11017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `--network=dev` is no longer supported; use `ephemery` or Kurtosis for local devnets. [#10836](https://github.com/besu-eth/besu/pull/10836)
 - Plugin API: `HealthCheckProvider` now returns `HealthCheckResult` (status + details map) instead of `boolean` [#10687](https://github.com/besu-eth/besu/issues/10687)
 - The experimental `--Xmax-tracked-seen-txs-per-peer` alias is removed (deprecated since 26.4.0). Use `--Xmax-tracked-seen-txs` instead. [#11018](https://github.com/besu-eth/besu/pull/11018)
-- The experimental `--Xv5-discovery-enabled` flag is removed; discovery now defaults to `--discovery-mode=V4`. Use `--discovery-mode=BOTH` or `V5` to enable DiscV5.
+- The experimental `--Xv5-discovery-enabled` flag is removed; discovery now defaults to `--discovery-mode=V4`. Use `--discovery-mode=BOTH` or `--discovery-mode=V5` to enable DiscV5.
 - The genesis file `v5Bootnodes` key is removed; ENR bootnodes must now be listed in the unified `bootnodes` array alongside enode URLs. Besu's bundled network genesis files were migrated automatically - this only affects custom/downstream genesis files that still use the old `v5Bootnodes` key, whose ENR entries will otherwise be silently dropped.
 - Removed the legacy `PANTHEON_` environment variable prefix for configuration options, everyone should already use the `BESU_` prefix at this time.
 - Removed `--min-block-occupancy-ratio` option. The flag has been a silent no-op since 26.4.0. [#11017](https://github.com/besu-eth/besu/pull/11017)

--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/config/BootNodesGenesisSetupTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/config/BootNodesGenesisSetupTest.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster;
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.ClusterConfigurationBuilder;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.BesuNodeConfigurationBuilder;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -68,6 +69,9 @@ public class BootNodesGenesisSetupTest extends AcceptanceTestBase {
   @ParameterizedTest
   @ValueSource(strings = {"enode", "enr"})
   public void shouldConnectNodesViaBootnodesInGenesis(final String bootnodeField) throws Exception {
+    // Pin discovery mode to the one that consumes this bootnode format.
+    final String discoveryMode = bootnodeField.equals("enr") ? "V5" : "V4";
+
     final KeyPair nodeAKeyPair =
         createKeyPair(
             Bytes32.fromHexString(
@@ -78,7 +82,8 @@ public class BootNodesGenesisSetupTest extends AcceptanceTestBase {
                 "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3"));
 
     // Start nodeA first with no genesis bootnodes — it just listens for incoming connections
-    final Node nodeA = besu.createNode("nodeA", b -> addDiscoveryBootnodes(b, nodeAKeyPair, null));
+    final Node nodeA =
+        besu.createNode("nodeA", b -> addDiscoveryBootnodes(b, nodeAKeyPair, null, discoveryMode));
     noDiscoveryCluster.addNode(nodeA);
 
     final Map<String, Object> nodeAInfo = nodeA.execute(admin.nodeInfo());
@@ -86,7 +91,8 @@ public class BootNodesGenesisSetupTest extends AcceptanceTestBase {
     assertThat(nodeABootnode).isNotNull();
 
     final Node nodeB =
-        besu.createNode("nodeB", b -> addDiscoveryBootnodes(b, nodeBKeyPair, nodeABootnode));
+        besu.createNode(
+            "nodeB", b -> addDiscoveryBootnodes(b, nodeBKeyPair, nodeABootnode, discoveryMode));
     noDiscoveryCluster.addNode(nodeB);
 
     nodeA.verify(net.awaitPeerCount(1));
@@ -99,7 +105,10 @@ public class BootNodesGenesisSetupTest extends AcceptanceTestBase {
   }
 
   private BesuNodeConfigurationBuilder addDiscoveryBootnodes(
-      final BesuNodeConfigurationBuilder b, final KeyPair keyPair, final String bootnode) {
+      final BesuNodeConfigurationBuilder b,
+      final KeyPair keyPair,
+      final String bootnode,
+      final String discoveryMode) {
     final String discoverySection =
         bootnode != null
             ? String.format("\"discovery\":{\"bootnodes\":[\"%s\"]}", bootnode)
@@ -113,6 +122,7 @@ public class BootNodesGenesisSetupTest extends AcceptanceTestBase {
                         "{\"config\":{\"ethash\":{},%s},\"gasLimit\":\"0x1\",\"difficulty\":\"0x1\"}",
                         discoverySection)))
         .bootnodeEligible(false)
+        .extraCLIOptions(List.of("--discovery-mode=" + discoveryMode))
         .jsonRpcEnabled()
         .jsonRpcAdmin();
   }

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -167,7 +167,7 @@ public class RunnerBuilder {
   private final Collection<Bytes> bannedNodeIds = new ArrayList<>();
   private boolean p2pEnabled = true;
   private boolean discoveryEnabled;
-  private DiscoveryMode discoveryMode = DiscoveryMode.BOTH;
+  private DiscoveryMode discoveryMode = DiscoveryMode.V4;
   private String p2pAdvertisedHost;
   private String p2pListenInterface = NetworkUtility.INADDR_ANY;
   private int p2pListenPort;

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -167,7 +167,7 @@ public class RunnerBuilder {
   private final Collection<Bytes> bannedNodeIds = new ArrayList<>();
   private boolean p2pEnabled = true;
   private boolean discoveryEnabled;
-  private DiscoveryMode discoveryMode = DiscoveryMode.V4;
+  private DiscoveryMode discoveryMode = DiscoveryMode.getDefault();
   private String p2pAdvertisedHost;
   private String p2pListenInterface = NetworkUtility.INADDR_ANY;
   private int p2pListenPort;

--- a/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
@@ -86,12 +86,11 @@ public class P2PDiscoveryOptions implements CLIOptions<P2PDiscoveryConfiguration
   @CommandLine.Option(
       names = {"--discovery-mode"},
       description =
-          "Discovery protocol(s) to run: V4 (default), V5, or BOTH. "
+          "Discovery protocol(s) to run: V4, V5, or BOTH (default: ${DEFAULT-VALUE}). "
               + "V4 runs only DiscV4. "
               + "V5 runs only DiscV5 (requires a secp256k1 node key; falls back to V4 if unsupported). "
-              + "BOTH runs DiscV4 and DiscV5 concurrently on a shared UDP socket.",
-      defaultValue = "V4")
-  public DiscoveryMode discoveryMode = DiscoveryMode.V4;
+              + "BOTH runs DiscV4 and DiscV5 concurrently on a shared UDP socket.")
+  public DiscoveryMode discoveryMode = DiscoveryMode.getDefault();
 
   /**
    * A list of bootstrap nodes can be passed and a hardcoded list will be used otherwise by the

--- a/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptions.java
@@ -86,12 +86,12 @@ public class P2PDiscoveryOptions implements CLIOptions<P2PDiscoveryConfiguration
   @CommandLine.Option(
       names = {"--discovery-mode"},
       description =
-          "Discovery protocol(s) to run: BOTH (default), V5, or V4. "
-              + "BOTH runs DiscV4 and DiscV5 concurrently on a shared UDP socket. "
+          "Discovery protocol(s) to run: V4 (default), V5, or BOTH. "
+              + "V4 runs only DiscV4. "
               + "V5 runs only DiscV5 (requires a secp256k1 node key; falls back to V4 if unsupported). "
-              + "V4 runs only DiscV4.",
-      defaultValue = "BOTH")
-  public DiscoveryMode discoveryMode = DiscoveryMode.BOTH;
+              + "BOTH runs DiscV4 and DiscV5 concurrently on a shared UDP socket.",
+      defaultValue = "V4")
+  public DiscoveryMode discoveryMode = DiscoveryMode.V4;
 
   /**
    * A list of bootstrap nodes can be passed and a hardcoded list will be used otherwise by the

--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -876,10 +876,10 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
-  public void discoveryModeDefaultIsBoth() {
+  public void discoveryModeDefault() {
     parseCommand();
 
-    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.BOTH));
+    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.V4));
     verify(mockRunnerBuilder).build();
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();

--- a/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -879,7 +879,7 @@ public class BesuCommandTest extends CommandTestAbstract {
   public void discoveryModeDefault() {
     parseCommand();
 
-    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.V4));
+    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.getDefault()));
     verify(mockRunnerBuilder).build();
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();

--- a/app/src/test/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptionsTest.java
@@ -427,10 +427,10 @@ public class P2PDiscoveryOptionsTest extends CommandTestAbstract {
   }
 
   @Test
-  public void discoveryModeDefaultIsBoth() {
+  public void discoveryModeDefault() {
     parseCommand();
 
-    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.BOTH));
+    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.V4));
     verify(mockRunnerBuilder).build();
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();

--- a/app/src/test/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptionsTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/options/P2PDiscoveryOptionsTest.java
@@ -430,7 +430,7 @@ public class P2PDiscoveryOptionsTest extends CommandTestAbstract {
   public void discoveryModeDefault() {
     parseCommand();
 
-    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.V4));
+    verify(mockRunnerBuilder).discoveryMode(eq(DiscoveryMode.getDefault()));
     verify(mockRunnerBuilder).build();
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
@@ -45,7 +45,7 @@ public class DiscoveryConfiguration {
   private int discV5DiscoveryIntervalSeconds = 1;
   private int discV5DiscoveryTimeoutSeconds = 60;
   private double discV5MinimumPeerRatio = 0.8;
-  private DiscoveryMode discoveryMode = DiscoveryMode.BOTH;
+  private DiscoveryMode discoveryMode = DiscoveryMode.V4;
 
   public static DiscoveryConfiguration create() {
     return new DiscoveryConfiguration();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
@@ -45,7 +45,7 @@ public class DiscoveryConfiguration {
   private int discV5DiscoveryIntervalSeconds = 1;
   private int discV5DiscoveryTimeoutSeconds = 60;
   private double discV5MinimumPeerRatio = 0.8;
-  private DiscoveryMode discoveryMode = DiscoveryMode.V4;
+  private DiscoveryMode discoveryMode = DiscoveryMode.getDefault();
 
   public static DiscoveryConfiguration create() {
     return new DiscoveryConfiguration();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
@@ -22,7 +22,7 @@ public enum DiscoveryMode {
   /** Run only DiscV5. Requires a secp256k1 node key; falls back to V4 if unsupported. */
   V5,
 
-  /** Run only DiscV4 (default). */
+  /** Run only DiscV4. */
   V4;
 
   /**

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
@@ -23,5 +23,14 @@ public enum DiscoveryMode {
   V5,
 
   /** Run only DiscV4 (default). */
-  V4
+  V4;
+
+  /**
+   * The discovery mode used when none is explicitly configured.
+   *
+   * @return the default discovery mode
+   */
+  public static DiscoveryMode getDefault() {
+    return V4;
+  }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryMode.java
@@ -16,12 +16,12 @@ package org.hyperledger.besu.ethereum.p2p.config;
 
 /** Controls which discovery protocol(s) the node runs. */
 public enum DiscoveryMode {
-  /** Run both DiscV4 and DiscV5 concurrently on a shared UDP socket (default). */
+  /** Run both DiscV4 and DiscV5 concurrently on a shared UDP socket. */
   BOTH,
 
   /** Run only DiscV5. Requires a secp256k1 node key; falls back to V4 if unsupported. */
   V5,
 
-  /** Run only DiscV4. */
+  /** Run only DiscV4 (default). */
   V4
 }


### PR DESCRIPTION
## PR description

Make Discovery V4 as default instead of BOTH


## Fixed Issue(s)

None filed yet for the peer-churn regression itself (currently tracked only via the staging dashboard); happy to file one if useful.

### Locally, you can run these tests to catch failures early:

- [x] spotless: not yet run
- [x] unit tests: `./gradlew :app:test --tests "*.BesuCommandTest" --tests "*.P2PDiscoveryOptionsTest"`, `./gradlew :ethereum:p2p:test --tests "*.DiscoveryConfigurationTest" --tests "*.CompositePeerDiscoveryAgentFactoryTest"` (targeted; full `./gradlew build` not yet run)
- [ ] acceptance tests
- [ ] integration tests
- [ ] reference tests
- [ ] hive tests