### PR TITLE
evmtool: parallel workers, filtering and directory input for the test runners

### DIFF
--- a/REFERENCE_TESTS.md
+++ b/REFERENCE_TESTS.md
@@ -112,6 +112,64 @@ ExecutionSpecDevnet{Blockchain,State}Test_{hardfork}_{eip_or_topic}_{batch_index
 
 The devnet fixtures are resolved from the same GitHub Ivy repository as stable fixtures. The dependency is declared separately via the `devnetTarConfig` configuration in `ethereum/referencetests/build.gradle`.
 
+## Fast State Test Runner (evmtool)
+
+The `referenceTests*` tasks above generate one JUnit test per fixture. In addition, `evmtool`'s `state-test` subcommand consumes the `state_tests` fixtures directly — no per-fixture code generation — which makes a whole fixture tree a seconds-long run rather than a build.
+
+### Gradle task
+
+`stateTestsDevnet` **reuses the same devnet fixture download/extract** as `referenceTestsDevnet` (the `extractDevnetFixtures` task — no separate download) and **fails the build on any test failure**.
+
+```bash
+./gradlew :ethereum:evmtool:stateTestsDevnet
+```
+
+| Property | Meaning |
+|----------|---------|
+| `-PstateTestWorkers=N` | Parallel workers (default: available processors) |
+| `-PstateTestPath=<subdir>` | Scope to a subdirectory, e.g. `for_amsterdam` |
+| `-PstateTestFilter=<substr>` | Only run tests whose node id matches — see [Filter syntax](#filter-syntax) |
+
+```bash
+./gradlew :ethereum:evmtool:stateTestsDevnet -PstateTestPath=for_amsterdam -PstateTestWorkers=8
+```
+
+### Filter syntax
+
+`--run` (and the `-PstateTestFilter` property) accepts two forms:
+
+- **No `*` or `?`** — a case-insensitive **substring** match against the node id.
+- **Contains `*` or `?`** — a case-insensitive **regex** that must match the *whole* node id. `*` is rewritten to `.*`, `?` to any single character, and `.` is escaped to a literal (node ids contain `.py`). Everything else reaches `java.util.regex`, so alternation and character classes work.
+
+Because the expression is a regex, the `[`, `]`, `(` and `)` that pytest node ids are full of are **metacharacters, not literals**. Escape them to match literally:
+
+```bash
+# WRONG: '[' opens a character class -> rejected before any test runs
+$EVM state-test --run '*[fork_Amsterdam*' <fixtures>
+#   Invalid --run/--test-name pattern '*[fork_Amsterdam*': Unclosed character class. …
+
+# RIGHT: escape it, or just use the substring form
+$EVM state-test --run '*\[fork_Amsterdam*' <fixtures>
+$EVM state-test --run 'fork_Amsterdam' <fixtures>
+```
+
+The pattern is compiled once before any fixture is read, so a malformed expression is an immediate, explicit failure (exit 1) rather than a run that quietly executes nothing. A filter that compiles but matches no test is also an error — an empty run never reports success.
+
+### Running the evmtool binary directly
+
+```bash
+./gradlew :ethereum:evmtool:installDist
+EVM=./ethereum/evmtool/build/install/evmtool/bin/evmtool
+
+$EVM state-test --workers 8 <path-to>/state_tests/
+```
+
+Flags: `--workers N`, `--run <substr-or-regex>`, `--json-array` to emit machine-readable results (`[{name, pass, fork, stateRoot, error}]`), and `--summary-only` to suppress the per-test JSON line that external tooling parses (which remains the default).
+
+The subcommand exits non-zero if any test fails, if no test ran at all, or if the `--run` pattern is malformed. Fixture files that cannot be read as a state test are listed separately under "Unreadable" and do **not** count as failures — they say nothing about Besu. As of the currently pinned `tests-glamsterdam-devnet` fixtures that is 14 `state_tests` files (`test_bad_v_r_s`), which carry a pre-signed transaction in `post[].txbytes` rather than a `secretKey` that `StateTestVersionedTransaction` can sign with. The JUnit `referenceTestsDevnet` gate drops those same fixtures, silently.
+
+> The gradle-extracted fixtures live at `ethereum/referencetests/build/execution-spec-devnet-tests/fixtures/state_tests/`, so you can point the binary there after running `referenceTestsDevnet` (or `extractDevnetFixtures`) once.
+
 ## Enabling JSON Tracing
 
 Besu supports detailed opcode-level JSON tracing. You can enable it using either a JVM system property or an environment variable.

--- a/REFERENCE_TESTS.md
+++ b/REFERENCE_TESTS.md
@@ -114,11 +114,11 @@ The devnet fixtures are resolved from the same GitHub Ivy repository as stable f
 
 ## Fast State Test Runner (evmtool)
 
-The `referenceTests*` tasks above generate one JUnit test per fixture. In addition, `evmtool`'s `state-test` subcommand consumes the `state_tests` fixtures directly — no per-fixture code generation — which makes a whole fixture tree a seconds-long run rather than a build.
+The `referenceTests*` tasks above generate one JUnit test per fixture. The `evmtool` `state-test` subcommand instead consumes the `state_tests` fixtures directly, with no per-fixture code generation, so a whole fixture tree runs in seconds rather than needing a build.
 
 ### Gradle task
 
-`stateTestsDevnet` **reuses the same devnet fixture download/extract** as `referenceTestsDevnet` (the `extractDevnetFixtures` task — no separate download) and **fails the build on any test failure**.
+`stateTestsDevnet` reuses the same devnet fixture download and extract as `referenceTestsDevnet` (the `extractDevnetFixtures` task, so there is no separate download) and fails the build on any test failure.
 
 ```bash
 ./gradlew :ethereum:evmtool:stateTestsDevnet
@@ -128,7 +128,7 @@ The `referenceTests*` tasks above generate one JUnit test per fixture. In additi
 |----------|---------|
 | `-PstateTestWorkers=N` | Parallel workers (default: available processors) |
 | `-PstateTestPath=<subdir>` | Scope to a subdirectory, e.g. `for_amsterdam` |
-| `-PstateTestFilter=<substr>` | Only run tests whose node id matches — see [Filter syntax](#filter-syntax) |
+| `-PstateTestFilter=<substr>` | Only run tests whose node id matches; see [Filter syntax](#filter-syntax) |
 
 ```bash
 ./gradlew :ethereum:evmtool:stateTestsDevnet -PstateTestPath=for_amsterdam -PstateTestWorkers=8
@@ -136,24 +136,24 @@ The `referenceTests*` tasks above generate one JUnit test per fixture. In additi
 
 ### Filter syntax
 
-`--run` (and the `-PstateTestFilter` property) accepts two forms:
+`--test-name` (and the `-PstateTestFilter` property) accepts two forms, and means the same thing in `state-test` and `block-test`:
 
-- **No `*` or `?`** — a case-insensitive **substring** match against the node id.
-- **Contains `*` or `?`** — a case-insensitive **regex** that must match the *whole* node id. `*` is rewritten to `.*`, `?` to any single character, and `.` is escaped to a literal (node ids contain `.py`). Everything else reaches `java.util.regex`, so alternation and character classes work.
+- No `*` or `?`: a case-insensitive substring match against the node id.
+- Contains `*` or `?`: a case-insensitive regex that must match the whole node id. `*` is rewritten to `.*`, `?` to any single character, and `.` is escaped to a literal (node ids contain `.py`). The rest is passed to `java.util.regex`, so alternation and character classes work.
 
-Because the expression is a regex, the `[`, `]`, `(` and `)` that pytest node ids are full of are **metacharacters, not literals**. Escape them to match literally:
+In the second form the `[`, `]`, `(` and `)` common in pytest node ids are regex metacharacters, not literals. Escape them to match literally:
 
 ```bash
 # WRONG: '[' opens a character class -> rejected before any test runs
-$EVM state-test --run '*[fork_Amsterdam*' <fixtures>
-#   Invalid --run/--test-name pattern '*[fork_Amsterdam*': Unclosed character class. …
+$EVM state-test --test-name '*[fork_Amsterdam*' <fixtures>
+#   Invalid --test-name pattern '*[fork_Amsterdam*': Unclosed character class. …
 
 # RIGHT: escape it, or just use the substring form
-$EVM state-test --run '*\[fork_Amsterdam*' <fixtures>
-$EVM state-test --run 'fork_Amsterdam' <fixtures>
+$EVM state-test --test-name '*\[fork_Amsterdam*' <fixtures>
+$EVM state-test --test-name 'fork_Amsterdam' <fixtures>
 ```
 
-The pattern is compiled once before any fixture is read, so a malformed expression is an immediate, explicit failure (exit 1) rather than a run that quietly executes nothing. A filter that compiles but matches no test is also an error — an empty run never reports success.
+The pattern is compiled before any fixture is read, so a malformed expression fails immediately with exit 1 rather than running nothing. A filter that compiles but matches no test is also an error: an empty run never reports success.
 
 ### Running the evmtool binary directly
 
@@ -164,9 +164,9 @@ EVM=./ethereum/evmtool/build/install/evmtool/bin/evmtool
 $EVM state-test --workers 8 <path-to>/state_tests/
 ```
 
-Flags: `--workers N`, `--run <substr-or-regex>`, `--json-array` to emit machine-readable results (`[{name, pass, fork, stateRoot, error}]`), and `--summary-only` to suppress the per-test JSON line that external tooling parses (which remains the default).
+Flags: `--workers N`, `--test-name <substr-or-regex>`, `--json-array` to emit machine-readable results (`[{name, pass, fork, stateRoot, error}]`), and `--summary-only` to suppress the per-test JSON line that external tooling parses (which remains the default).
 
-The subcommand exits non-zero if any test fails, if no test ran at all, or if the `--run` pattern is malformed. Fixture files that cannot be read as a state test are listed separately under "Unreadable" and do **not** count as failures — they say nothing about Besu. As of the currently pinned `tests-glamsterdam-devnet` fixtures that is 14 `state_tests` files (`test_bad_v_r_s`), which carry a pre-signed transaction in `post[].txbytes` rather than a `secretKey` that `StateTestVersionedTransaction` can sign with. The JUnit `referenceTestsDevnet` gate drops those same fixtures, silently.
+The subcommand exits non-zero if any test fails, if no test ran at all, or if the `--test-name` pattern is malformed.
 
 > The gradle-extracted fixtures live at `ethereum/referencetests/build/execution-spec-devnet-tests/fixtures/state_tests/`, so you can point the binary there after running `referenceTestsDevnet` (or `extractDevnetFixtures`) once.
 

--- a/REFERENCE_TESTS.md
+++ b/REFERENCE_TESTS.md
@@ -126,7 +126,7 @@ The `referenceTests*` tasks above generate one JUnit test per fixture. The `evmt
 
 | Property | Meaning |
 |----------|---------|
-| `-PstateTestWorkers=N` | Parallel workers (default: available processors) |
+| `-PstateTestWorkers=N` | Limit parallelism (the runner already defaults to all available cores) |
 | `-PstateTestPath=<subdir>` | Scope to a subdirectory, e.g. `for_amsterdam` |
 | `-PstateTestFilter=<substr>` | Only run tests whose node id matches; see [Filter syntax](#filter-syntax) |
 
@@ -153,7 +153,7 @@ $EVM state-test --test-name '*\[fork_Amsterdam*' <fixtures>
 $EVM state-test --test-name 'fork_Amsterdam' <fixtures>
 ```
 
-The pattern is compiled before any fixture is read, so a malformed expression fails immediately with exit 1 rather than running nothing. A filter that compiles but matches no test is also an error: an empty run never reports success.
+The pattern is compiled before any fixture is read, so a malformed expression fails immediately with exit 1 rather than running nothing. An empty run is an error too, whether or not a filter was given: a run that executed no test never reports success.
 
 ### Running the evmtool binary directly
 
@@ -161,10 +161,14 @@ The pattern is compiled before any fixture is read, so a malformed expression fa
 ./gradlew :ethereum:evmtool:installDist
 EVM=./ethereum/evmtool/build/install/evmtool/bin/evmtool
 
-$EVM state-test --workers 8 <path-to>/state_tests/
+$EVM state-test <path-to>/state_tests/
 ```
 
-Flags: `--workers N`, `--test-name <substr-or-regex>`, `--json-array` to emit machine-readable results (`[{name, pass, fork, stateRoot, error}]`), and `--summary-only` to suppress the per-test JSON line that external tooling parses (which remains the default).
+A directory argument is expanded recursively and spread over one worker per available core. Pass `--workers N` to use fewer, for instance to keep the output of a multi-file run in a predictable order.
+
+Flags: `--workers N`, `--test-name <substr-or-regex>`, `--json-array` to emit machine-readable results (`[{name, pass, fork, stateRoot, error}]`), and `--summary-only` to suppress the per-test JSON line that external tooling parses (which remains the default). Under `--json-array` nothing but the array is printed, so the exit code is what reports an empty or failed run.
+
+`--workers`, `--test-name` and `--json-array` work the same way on `block-test`.
 
 The subcommand exits non-zero if any test fails, if no test ran at all, or if the `--test-name` pattern is malformed.
 

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -75,6 +75,55 @@ application {
   mainClass = 'org.hyperledger.besu.evmtool.EvmTool'
 }
 
+// Runs the execution-spec devnet state_tests via the `state-test` subcommand. Reuses the devnet
+// fixture download/extract from the :ethereum:referencetests project (extractDevnetFixtures)
+// instead of fetching separately, and fails the build on any failure.
+//
+// Optional gradle properties:
+//   -PstateTestWorkers=N        parallelism (defaults to available processors)
+//   -PstateTestPath=<subdir>    scope to a subdirectory of state_tests (e.g. for_amsterdam)
+//   -PstateTestFilter=<substr>  only run tests whose name contains <substr> (or a *?-glob)
+tasks.register('stateTestsDevnet', JavaExec) {
+  description = 'Runs execution-spec devnet state_tests via the evmtool state-test runner.'
+  group = 'verification'
+
+  dependsOn ':ethereum:referencetests:extractDevnetFixtures'
+
+  classpath = sourceSets.main.runtimeClasspath
+  mainClass = 'org.hyperledger.besu.evmtool.EvmTool'
+
+  def stateFixtures = project(':ethereum:referencetests').layout.buildDirectory
+    .dir('execution-spec-devnet-tests/fixtures/state_tests')
+  def workerCount = project.findProperty('stateTestWorkers')?.toString()
+    ?: Runtime.runtime.availableProcessors().toString()
+  def subPath = project.findProperty('stateTestPath')?.toString()
+  def nameFilter = project.findProperty('stateTestFilter')?.toString()
+
+  doFirst {
+    def fixturesDir = stateFixtures.get().asFile
+    if (!fixturesDir.exists()) {
+      throw new GradleException(
+      "State fixtures not found at ${fixturesDir}.\n" +
+      "Check the devnetTarConfig version in ethereum/referencetests/build.gradle.")
+    }
+    def runDir = subPath ? new File(fixturesDir, subPath) : fixturesDir
+    if (!runDir.exists()) {
+      throw new GradleException("State fixtures path not found: ${runDir} (from -PstateTestPath=${subPath})")
+    }
+    def cmd = [
+      'state-test',
+      '--summary-only',
+      '--workers',
+      workerCount
+    ]
+    if (nameFilter != null) {
+      cmd += ['--run', nameFilter]
+    }
+    cmd += runDir.absolutePath
+    args = cmd
+  }
+}
+
 
 // rename the top level dir from besu-<version> to besu and this makes it really
 // simple for use in docker

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -80,7 +80,7 @@ application {
 // instead of fetching separately, and fails the build on any failure.
 //
 // Optional gradle properties:
-//   -PstateTestWorkers=N        parallelism (defaults to available processors)
+//   -PstateTestWorkers=N        limit parallelism (the runner defaults to all available cores)
 //   -PstateTestPath=<subdir>    scope to a subdirectory of state_tests (e.g. for_amsterdam)
 //   -PstateTestFilter=<substr>  only run tests whose name contains <substr> (or a *?-glob)
 tasks.register('stateTestsDevnet', JavaExec) {
@@ -95,7 +95,6 @@ tasks.register('stateTestsDevnet', JavaExec) {
   def stateFixtures = project(':ethereum:referencetests').layout.buildDirectory
     .dir('execution-spec-devnet-tests/fixtures/state_tests')
   def workerCount = project.findProperty('stateTestWorkers')?.toString()
-    ?: Runtime.runtime.availableProcessors().toString()
   def subPath = project.findProperty('stateTestPath')?.toString()
   def nameFilter = project.findProperty('stateTestFilter')?.toString()
 
@@ -112,10 +111,11 @@ tasks.register('stateTestsDevnet', JavaExec) {
     }
     def cmd = [
       'state-test',
-      '--summary-only',
-      '--workers',
-      workerCount
+      '--summary-only'
     ]
+    if (workerCount != null) {
+      cmd += ['--workers', workerCount]
+    }
     if (nameFilter != null) {
       cmd += ['--test-name', nameFilter]
     }

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -117,7 +117,7 @@ tasks.register('stateTestsDevnet', JavaExec) {
       workerCount
     ]
     if (nameFilter != null) {
-      cmd += ['--run', nameFilter]
+      cmd += ['--test-name', nameFilter]
     }
     cmd += runDir.absolutePath
     args = cmd

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -58,21 +58,21 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes32;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
@@ -94,7 +94,11 @@ import picocli.CommandLine.ParentCommand;
     description = "Execute an Ethereum Blockchain Test.",
     mixinStandardHelpOptions = true,
     versionProvider = VersionProvider.class)
-public class BlockchainTestSubCommand implements Runnable {
+public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
+
+  /** Process exit code: 0 when all executed tests pass, 1 when any failed or nothing ran. */
+  private volatile int exitCode = 0;
+
   /**
    * The name of the command for the BlockchainTestSubCommand. This constant is used as the name
    * parameter in the @CommandLine.Command annotation. It defines the command name that users should
@@ -103,15 +107,32 @@ public class BlockchainTestSubCommand implements Runnable {
   public static final String COMMAND_NAME = "block-test";
 
   @Option(
-      names = {"--test-name"},
+      names = {"--test-name", "--run"},
       description =
-          "Limit execution to tests whose name contains the given substring, or matches a glob pattern (using * and ?).")
+          "Limit execution to tests whose name contains the given substring, or matches the given"
+              + " pattern (a regex, with * and ? as wildcards).")
   private String testName = null;
+
+  // Compiled up front so a malformed expression fails before any fixture is read
+  private TestNameFilter nameFilter;
 
   @Option(
       names = {"--trace-output"},
       description = "Output file for traces (default: stderr). Requires --json or --trace flag.")
   private String traceOutput = null;
+
+  @Option(
+      names = {"--workers"},
+      description = "Number of parallel workers for processing fixture files.",
+      defaultValue = "1")
+  private int workers = 1;
+
+  @Option(
+      names = {"--json-array"},
+      description = "Output results as a JSON array: name, pass, fork, lastBlockHash, error.")
+  private boolean jsonArray = false;
+
+  private final List<ObjectNode> jsonArrayResults = Collections.synchronizedList(new ArrayList<>());
 
   @Option(
       names = {"--cache-precompiles"},
@@ -130,43 +151,8 @@ public class BlockchainTestSubCommand implements Runnable {
   // picocli does it magically
   @Parameters private final List<Path> blockchainTestFiles = new ArrayList<>();
 
-  /** Helper class to track test execution results for summary reporting. */
-  private static class TestResults {
-    private static final String SEPARATOR = "=".repeat(80);
-    private final AtomicInteger passedTests = new AtomicInteger(0);
-    private final AtomicInteger failedTests = new AtomicInteger(0);
-    private final Map<String, String> failures = new LinkedHashMap<>();
-
-    void recordPass() {
-      passedTests.incrementAndGet();
-    }
-
-    void recordFailure(final String testName, final String reason) {
-      failedTests.incrementAndGet();
-      failures.put(testName, reason);
-    }
-
-    boolean hasTests() {
-      return passedTests.get() + failedTests.get() > 0;
-    }
-
-    void printSummary(final java.io.PrintWriter out) {
-      final int totalTests = passedTests.get() + failedTests.get();
-      out.println();
-      out.println(SEPARATOR);
-      out.println("TEST SUMMARY");
-      out.println(SEPARATOR);
-      out.printf("Total tests:  %d%n", totalTests);
-      out.printf("Passed:       %d%n", passedTests.get());
-      out.printf("Failed:       %d%n", failedTests.get());
-
-      if (!failures.isEmpty()) {
-        out.println("\nFailed tests:");
-        failures.forEach((testName, reason) -> out.printf("  - %s: %s%n", testName, reason));
-      }
-      out.println(SEPARATOR);
-    }
-  }
+  // Cache protocol schedules across all tests — creating all 30+ schedules is very expensive
+  private volatile ReferenceTestProtocolSchedules cachedSchedules;
 
   /**
    * Default constructor for the BlockchainTestSubCommand class. This constructor doesn't take any
@@ -183,27 +169,42 @@ public class BlockchainTestSubCommand implements Runnable {
   }
 
   @Override
+  public int getExitCode() {
+    return exitCode;
+  }
+
+  @Override
   public void run() {
     AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     AbstractBLS12PrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     KZGPointEvalPrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     final ObjectMapper blockchainTestMapper = JsonUtils.createObjectMapper();
-    final TestResults results = new TestResults();
+    final FixtureRunner.TestResults results = new FixtureRunner.TestResults();
 
     final JavaType javaType =
         blockchainTestMapper
             .getTypeFactory()
             .constructParametricType(
                 Map.class, String.class, BlockchainReferenceTestCaseSpec.class);
+    if (testName != null) {
+      try {
+        nameFilter = TestNameFilter.compile(testName);
+      } catch (final IllegalArgumentException e) {
+        parentCommand.out.println(e.getMessage());
+        exitCode = 1;
+        return;
+      }
+    }
+
+    boolean setupFailed = false;
     try {
       if (blockchainTestFiles.isEmpty()) {
-        // if no state tests were specified, use standard input to get filenames
+        // if no files were specified, use standard input to get filenames
         final BufferedReader in =
             new BufferedReader(new InputStreamReader(parentCommand.in, UTF_8));
         while (true) {
           final String fileName = in.readLine();
           if (fileName == null) {
-            // Reached end-of-file. Stop the loop.
             break;
           }
           final File file = new File(fileName);
@@ -216,24 +217,35 @@ public class BlockchainTestSubCommand implements Runnable {
           }
         }
       } else {
-        for (final Path blockchainTestFile : blockchainTestFiles) {
-          final Map<String, BlockchainReferenceTestCaseSpec> blockchainTests;
-          if ("stdin".equals(blockchainTestFile.toString())) {
-            blockchainTests = blockchainTestMapper.readValue(parentCommand.in, javaType);
-          } else {
-            blockchainTests = blockchainTestMapper.readValue(blockchainTestFile.toFile(), javaType);
-          }
-          executeBlockchainTest(blockchainTests, results);
-        }
+        FixtureRunner.runFiles(
+            FixtureRunner.collectFiles(blockchainTestFiles),
+            workers,
+            file -> runFile(file, blockchainTestMapper, javaType, results));
       }
     } catch (final JsonProcessingException jpe) {
+      setupFailed = true;
       parentCommand.out.println("File content error: " + jpe);
     } catch (final IOException e) {
-      System.err.println("Unable to read state file");
+      setupFailed = true;
+      System.err.println("Unable to read state file: " + e.getMessage());
+    } catch (final Exception e) {
+      setupFailed = true;
+      System.err.println("Error: " + e.getMessage());
       e.printStackTrace(System.err);
     } finally {
-      // Always print summary, even if there were errors
-      if (results.hasTests()) {
+      // An empty run is not a pass: a typo in --run, or a fixture tree that failed to
+      // materialise, would otherwise be indistinguishable from a clean sweep.
+      boolean ranNothing = false;
+      if (!results.hasTests()) {
+        ranNothing = true;
+        parentCommand.out.printf(
+            "No blockchain test was executed%s.%n",
+            testName == null ? "" : " matching --run/--test-name '" + testName + "'");
+      }
+      exitCode = results.failed() > 0 || setupFailed || ranNothing ? 1 : 0;
+      if (jsonArray) {
+        FixtureRunner.printJsonArray(parentCommand.out, jsonArrayResults);
+      } else if (results.hasTests()) {
         results.printSummary(parentCommand.out);
       }
     }
@@ -241,7 +253,7 @@ public class BlockchainTestSubCommand implements Runnable {
 
   private void executeBlockchainTest(
       final Map<String, BlockchainReferenceTestCaseSpec> blockchainTests,
-      final TestResults results) {
+      final FixtureRunner.TestResults results) {
     final Map<String, BlockchainReferenceTestCaseSpec> filteredTests =
         blockchainTests.entrySet().stream()
             .filter(
@@ -268,21 +280,38 @@ public class BlockchainTestSubCommand implements Runnable {
     }
   }
 
-  private boolean matchesTestName(final String test) {
-    if (testName.contains("*") || testName.contains("?")) {
-      // Convert glob pattern to regex: * -> .*, ? -> .
-      final String regex =
-          "(?i)" + testName.replace(".", "\\.").replace("*", ".*").replace("?", ".");
-      return test.matches(regex);
+  /**
+   * Reads one fixture file and runs it. A file that cannot be read is reported in the summary, but
+   * kept apart from the test failures: it says nothing about Besu, only that the fixture has a
+   * shape this harness cannot build. Shared by the sequential and parallel paths so that the same
+   * directory yields the same counts whatever {@code --workers} is.
+   */
+  private void runFile(
+      final Path file,
+      final ObjectMapper mapper,
+      final JavaType javaType,
+      final FixtureRunner.TestResults results) {
+    final Map<String, BlockchainReferenceTestCaseSpec> blockchainTests;
+    try {
+      blockchainTests =
+          "stdin".equals(file.toString())
+              ? mapper.readValue(parentCommand.in, javaType)
+              : mapper.readValue(file.toFile(), javaType);
+    } catch (final Exception e) {
+      results.recordUnreadable(file.toString(), "not readable as a blockchain test fixture: " + e);
+      return;
     }
-    // Simple substring match (case-insensitive)
-    return test.toLowerCase(Locale.ROOT).contains(testName.toLowerCase(Locale.ROOT));
+    executeBlockchainTest(blockchainTests, results);
+  }
+
+  private boolean matchesTestName(final String test) {
+    return nameFilter.matches(test);
   }
 
   private void traceTestSpecs(
       final String test,
       final BlockchainReferenceTestCaseSpec spec,
-      final TestResults results,
+      final FixtureRunner.TestResults results,
       final boolean isLastIteration) {
     if (isLastIteration) {
       parentCommand.out.println("Running " + test);
@@ -300,9 +329,10 @@ public class BlockchainTestSubCommand implements Runnable {
                     genesisBlockHeader.getStateRoot(), genesisBlockHeader.getHash()))
             .orElseThrow();
 
-    final ProtocolSchedule schedule =
-        ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration())
-            .getByName(spec.getNetwork());
+    if (cachedSchedules == null) {
+      cachedSchedules = ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
+    }
+    final ProtocolSchedule schedule = cachedSchedules.getByName(spec.getNetwork());
 
     BlockTestTracerManager tracerManager = null;
     PrintStream traceWriter;
@@ -449,6 +479,16 @@ public class BlockchainTestSubCommand implements Runnable {
       results.recordFailure(test, failureReason);
     } else {
       results.recordPass();
+    }
+
+    if (jsonArray) {
+      final ObjectNode result = FixtureRunner.newResultNode();
+      result.put("name", test);
+      result.put("pass", testPassed);
+      result.put("fork", spec.getNetwork());
+      result.put("lastBlockHash", blockchain.getChainHeadHash().toHexString());
+      result.put("error", failureReason);
+      jsonArrayResults.add(result);
     }
   }
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -107,7 +107,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
   public static final String COMMAND_NAME = "block-test";
 
   @Option(
-      names = {"--test-name", "--run"},
+      names = {"--test-name"},
       description =
           "Limit execution to tests whose name contains the given substring, or matches the given"
               + " pattern (a regex, with * and ? as wildcards).")
@@ -151,7 +151,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
   // picocli does it magically
   @Parameters private final List<Path> blockchainTestFiles = new ArrayList<>();
 
-  // Cache protocol schedules across all tests — creating all 30+ schedules is very expensive
+  // Cached across all tests: building the 30+ reference test schedules is expensive
   private volatile ReferenceTestProtocolSchedules cachedSchedules;
 
   /**
@@ -233,14 +233,17 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
       System.err.println("Error: " + e.getMessage());
       e.printStackTrace(System.err);
     } finally {
-      // An empty run is not a pass: a typo in --run, or a fixture tree that failed to
-      // materialise, would otherwise be indistinguishable from a clean sweep.
+      // Fail an empty run, so a typo in --test-name or a fixture tree that did not materialise
+      // cannot be mistaken for a clean sweep.
       boolean ranNothing = false;
       if (!results.hasTests()) {
         ranNothing = true;
-        parentCommand.out.printf(
-            "No blockchain test was executed%s.%n",
-            testName == null ? "" : " matching --run/--test-name '" + testName + "'");
+        // Not printed under --json-array, where that output is parsed and only the array belongs.
+        if (!jsonArray) {
+          parentCommand.out.printf(
+              "No blockchain test was executed%s.%n",
+              testName == null ? "" : " matching --test-name '" + testName + "'");
+        }
       }
       exitCode = results.failed() > 0 || setupFailed || ranNothing ? 1 : 0;
       if (jsonArray) {
@@ -281,10 +284,10 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
   }
 
   /**
-   * Reads one fixture file and runs it. A file that cannot be read is reported in the summary, but
-   * kept apart from the test failures: it says nothing about Besu, only that the fixture has a
-   * shape this harness cannot build. Shared by the sequential and parallel paths so that the same
+   * Reads one fixture file and runs it. Used by both the sequential and the parallel path, so a
    * directory yields the same counts whatever {@code --workers} is.
+   *
+   * <p>A file that cannot be read is recorded as unreadable rather than as a test failure.
    */
   private void runFile(
       final Path file,

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -123,9 +123,10 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
 
   @Option(
       names = {"--workers"},
-      description = "Number of parallel workers for processing fixture files.",
-      defaultValue = "1")
-  private int workers = 1;
+      description =
+          "Number of parallel workers for processing fixture files. Defaults to the number of"
+              + " available cores (${DEFAULT-VALUE} here); lower it to run with less parallelism.")
+  private int workers = Runtime.getRuntime().availableProcessors();
 
   @Option(
       names = {"--json-array"},

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -152,8 +152,9 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
   // picocli does it magically
   @Parameters private final List<Path> blockchainTestFiles = new ArrayList<>();
 
-  // Cached across all tests: building the 30+ reference test schedules is expensive
-  private volatile ReferenceTestProtocolSchedules cachedSchedules;
+  // Cached across all tests: building the 30+ reference test schedules is expensive.
+  // Guarded by getSchedules().
+  private ReferenceTestProtocolSchedules cachedSchedules;
 
   /**
    * Default constructor for the BlockchainTestSubCommand class. This constructor doesn't take any
@@ -308,6 +309,18 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
     return nameFilter.matches(test);
   }
 
+  /**
+   * The reference test schedules, built once and shared by every worker. Building them is expensive
+   * — 30+ schedules per call — and {@code create} also initialises the KZG trusted setup, which is
+   * process-wide state, so the check-then-act has to be atomic rather than merely visible.
+   */
+  private synchronized ReferenceTestProtocolSchedules getSchedules() {
+    if (cachedSchedules == null) {
+      cachedSchedules = ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
+    }
+    return cachedSchedules;
+  }
+
   private void traceTestSpecs(
       final String test,
       final BlockchainReferenceTestCaseSpec spec,
@@ -329,10 +342,7 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
                     genesisBlockHeader.getStateRoot(), genesisBlockHeader.getHash()))
             .orElseThrow();
 
-    if (cachedSchedules == null) {
-      cachedSchedules = ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
-    }
-    final ProtocolSchedule schedule = cachedSchedules.getByName(spec.getNetwork());
+    final ProtocolSchedule schedule = getSchedules().getByName(spec.getNetwork());
 
     BlockTestTracerManager tracerManager = null;
     PrintStream traceWriter;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -235,18 +235,14 @@ public class BlockchainTestSubCommand implements Runnable, IExitCodeGenerator {
       e.printStackTrace(System.err);
     } finally {
       // Fail an empty run, so a typo in --test-name or a fixture tree that did not materialise
-      // cannot be mistaken for a clean sweep.
-      boolean ranNothing = false;
-      if (!results.hasTests()) {
-        ranNothing = true;
-        // Not printed under --json-array, where that output is parsed and only the array belongs.
-        if (!jsonArray) {
-          parentCommand.out.printf(
-              "No blockchain test was executed%s.%n",
-              testName == null ? "" : " matching --test-name '" + testName + "'");
-        }
+      // cannot be mistaken for a clean sweep. Not printed under --json-array, where that output is
+      // parsed and only the array belongs.
+      if (!results.hasTests() && !jsonArray) {
+        parentCommand.out.printf(
+            "No blockchain test was executed%s.%n",
+            testName == null ? "" : " matching --test-name '" + testName + "'");
       }
-      exitCode = results.failed() > 0 || setupFailed || ranNothing ? 1 : 0;
+      exitCode = results.failed() > 0 || setupFailed || !results.hasTests() ? 1 : 0;
       if (jsonArray) {
         FixtureRunner.printJsonArray(parentCommand.out, jsonArrayResults);
       } else if (results.hasTests()) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
@@ -31,6 +31,10 @@ public final class EvmTool {
     LogConfigurator.setLevel("", "OFF");
     final EvmToolCommand evmToolCommand = new EvmToolCommand();
 
-    evmToolCommand.execute(args);
+    final int exitCode = evmToolCommand.execute(args);
+    // Subcommands such as engine-test hold shared Vertx and EthScheduler pools whose non-daemon
+    // threads keep the JVM alive for their keep-alive window (~60s) past the last test, so the
+    // exit has to be explicit rather than by falling off the end of main.
+    System.exit(exitCode);
   }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
@@ -32,9 +32,8 @@ public final class EvmTool {
     final EvmToolCommand evmToolCommand = new EvmToolCommand();
 
     final int exitCode = evmToolCommand.execute(args);
-    // Subcommands such as engine-test hold shared Vertx and EthScheduler pools whose non-daemon
-    // threads keep the JVM alive for their keep-alive window (~60s) past the last test, so the
-    // exit has to be explicit rather than by falling off the end of main.
+    // Exit explicitly: returning from main always yields 0, which would hide a subcommand failure
+    // from CI and gradle.
     System.exit(exitCode);
   }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -292,11 +292,11 @@ public class EvmToolCommand implements Runnable {
     this.out = out;
   }
 
-  void execute(final String... args) {
-    execute(System.in, new PrintWriter(System.out, true, UTF_8), args);
+  int execute(final String... args) {
+    return execute(System.in, new PrintWriter(System.out, true, UTF_8), args);
   }
 
-  void execute(final InputStream input, final PrintWriter output, final String[] args) {
+  int execute(final InputStream input, final PrintWriter output, final String[] args) {
     final CommandLine commandLine = new CommandLine(this).setOut(output);
     out = output;
     in = input;
@@ -333,7 +333,7 @@ public class EvmToolCommand implements Runnable {
           }
           return new CommandLine.RunLast().execute(parseResult);
         });
-    commandLine.execute(args);
+    return commandLine.execute(args);
   }
 
   private static void addForkHelp(final CommandLine subCommandLine) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evmtool;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Scaffolding shared by the fixture-consuming subcommands — {@code block-test}, {@code state-test}
+ * and {@code engine-test}. They differ in what a test <em>is</em>, but agree on everything around
+ * it: expanding paths into fixture files, spreading those files over a worker pool, tallying the
+ * outcome, and emitting {@code --json-array}.
+ *
+ * <p>Keeping one copy is what makes the three subcommands report the same counts for the same
+ * directory; when this logic was inlined three times it drifted, and a difference in, say, which
+ * files a directory expands to is invisible in review until the totals disagree.
+ */
+final class FixtureRunner {
+
+  private static final ObjectMapper JSON_ARRAY_MAPPER = JsonUtils.createObjectMapper();
+
+  private FixtureRunner() {}
+
+  /**
+   * Collects the fixture files named by {@code paths}, expanding directories recursively.
+   *
+   * @param paths the paths given on the command line
+   * @return the {@code .json} fixture files to run, directories expanded and sorted
+   * @throws IOException if a path resolves to nothing, or a directory cannot be walked
+   */
+  static List<Path> collectFiles(final List<Path> paths) throws IOException {
+    final List<Path> files = new ArrayList<>();
+    for (final Path path : paths) {
+      if ("stdin".equals(path.toString())) {
+        files.add(path);
+      } else if (path.toFile().isDirectory()) {
+        try (Stream<Path> stream = Files.walk(path)) {
+          stream
+              .filter(p -> p.toString().endsWith(".json"))
+              .filter(p -> !p.toString().contains("/.meta/"))
+              .sorted()
+              .forEach(files::add);
+        }
+      } else if (path.toFile().isFile()) {
+        files.add(path);
+      } else {
+        // Callers read an empty file list as "no files given" and answer it by blocking on stdin
+        // for filenames, so a path that resolves to nothing has to be raised rather than dropped.
+        throw new FileNotFoundException("File not found: " + path);
+      }
+    }
+    return files;
+  }
+
+  /**
+   * Applies {@code task} to every file, on a pool of {@code workers} threads when there is more
+   * than one of each, and on the calling thread otherwise.
+   *
+   * @param files the fixture files to run
+   * @param workers the requested worker count
+   * @param task the per-file action
+   * @throws InterruptedException if interrupted while awaiting a worker
+   * @throws ExecutionException if a worker raised an exception
+   */
+  static void runFiles(final List<Path> files, final int workers, final Consumer<Path> task)
+      throws InterruptedException, ExecutionException {
+    if (workers > 1 && files.size() > 1) {
+      final ExecutorService executor = Executors.newFixedThreadPool(workers);
+      try {
+        final List<Future<?>> futures = new ArrayList<>();
+        for (final Path file : files) {
+          futures.add(executor.submit(() -> task.accept(file)));
+        }
+        for (final Future<?> future : futures) {
+          future.get();
+        }
+      } finally {
+        executor.shutdown();
+      }
+    } else {
+      for (final Path file : files) {
+        task.accept(file);
+      }
+    }
+  }
+
+  /**
+   * Prints the collected {@code --json-array} payload, falling back to an empty array so that a
+   * serialisation fault still yields parseable output.
+   *
+   * @param out where to print
+   * @param results the per-test result nodes
+   */
+  static void printJsonArray(final PrintWriter out, final List<ObjectNode> results) {
+    try {
+      out.println(JSON_ARRAY_MAPPER.writeValueAsString(results));
+    } catch (final JsonProcessingException e) {
+      out.println("[]");
+    }
+  }
+
+  /**
+   * Creates a node for one row of the {@code --json-array} payload.
+   *
+   * @return an empty object node
+   */
+  static ObjectNode newResultNode() {
+    return JSON_ARRAY_MAPPER.createObjectNode();
+  }
+
+  /**
+   * Pass/fail tallies and the end-of-run summary block, shared by the subcommands that report one.
+   *
+   * <p>Unreadable fixtures are tracked apart from failures on purpose: a file this harness cannot
+   * build a test from says nothing about Besu, and folding it into the failure count would make a
+   * fixture-format change look like a regression.
+   */
+  static final class TestResults {
+    private static final String SEPARATOR = "=".repeat(80);
+
+    private final AtomicInteger passedTests = new AtomicInteger(0);
+    private final AtomicInteger failedTests = new AtomicInteger(0);
+    private final Map<String, String> failures = Collections.synchronizedMap(new LinkedHashMap<>());
+    private final Map<String, String> unreadable =
+        Collections.synchronizedMap(new LinkedHashMap<>());
+
+    void recordPass() {
+      passedTests.incrementAndGet();
+    }
+
+    void recordFailure(final String testName, final String reason) {
+      failedTests.incrementAndGet();
+      failures.put(testName, reason);
+    }
+
+    void recordUnreadable(final String file, final String reason) {
+      unreadable.put(file, reason);
+    }
+
+    boolean hasTests() {
+      return passedTests.get() + failedTests.get() > 0;
+    }
+
+    int failed() {
+      return failedTests.get();
+    }
+
+    void printSummary(final PrintWriter out) {
+      final int totalTests = passedTests.get() + failedTests.get();
+      out.println();
+      out.println(SEPARATOR);
+      out.println("TEST SUMMARY");
+      out.println(SEPARATOR);
+      out.printf("Total tests:  %d%n", totalTests);
+      out.printf("Passed:       %d%n", passedTests.get());
+      out.printf("Failed:       %d%n", failedTests.get());
+      if (!unreadable.isEmpty()) {
+        out.printf("Unreadable:   %d file(s)%n", unreadable.size());
+      }
+      if (!failures.isEmpty()) {
+        out.println("\nFailed tests:");
+        failures.forEach((name, reason) -> out.printf("  - %s: %s%n", name, reason));
+      }
+      if (!unreadable.isEmpty()) {
+        out.println("\nUnreadable files (no test in them ran):");
+        unreadable.forEach((file, reason) -> out.printf("  - %s: %s%n", file, reason));
+      }
+      out.println(SEPARATOR);
+    }
+  }
+}

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
@@ -38,14 +38,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * Scaffolding shared by the fixture-consuming subcommands — {@code block-test}, {@code state-test}
- * and {@code engine-test}. They differ in what a test <em>is</em>, but agree on everything around
- * it: expanding paths into fixture files, spreading those files over a worker pool, tallying the
- * outcome, and emitting {@code --json-array}.
- *
- * <p>Keeping one copy is what makes the three subcommands report the same counts for the same
- * directory; when this logic was inlined three times it drifted, and a difference in, say, which
- * files a directory expands to is invisible in review until the totals disagree.
+ * Fixture handling shared by {@code block-test} and {@code state-test}: expanding paths into
+ * fixture files, running those files over a worker pool, tallying results, and emitting {@code
+ * --json-array}. Held in one place so both subcommands report the same counts for the same
+ * directory.
  */
 final class FixtureRunner {
 
@@ -76,8 +72,8 @@ final class FixtureRunner {
       } else if (path.toFile().isFile()) {
         files.add(path);
       } else {
-        // Callers read an empty file list as "no files given" and answer it by blocking on stdin
-        // for filenames, so a path that resolves to nothing has to be raised rather than dropped.
+        // An empty file list means "read filenames from stdin", so dropping an unresolvable path
+        // here would leave the command blocked on stdin instead of reporting the bad path.
         throw new FileNotFoundException("File not found: " + path);
       }
     }
@@ -117,8 +113,8 @@ final class FixtureRunner {
   }
 
   /**
-   * Prints the collected {@code --json-array} payload, falling back to an empty array so that a
-   * serialisation fault still yields parseable output.
+   * Prints the collected {@code --json-array} payload, falling back to an empty array so the output
+   * stays parseable if serialisation fails.
    *
    * @param out where to print
    * @param results the per-test result nodes
@@ -141,11 +137,11 @@ final class FixtureRunner {
   }
 
   /**
-   * Pass/fail tallies and the end-of-run summary block, shared by the subcommands that report one.
+   * Pass/fail tallies and the end-of-run summary block.
    *
-   * <p>Unreadable fixtures are tracked apart from failures on purpose: a file this harness cannot
-   * build a test from says nothing about Besu, and folding it into the failure count would make a
-   * fixture-format change look like a regression.
+   * <p>Unreadable fixtures are counted separately from failures. A file we cannot build a test from
+   * is a fixture problem rather than a Besu one, and counting it as a failure would make a fixture
+   * format change look like a regression.
    */
   static final class TestResults {
     private static final String SEPARATOR = "=".repeat(80);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/FixtureRunner.java
@@ -1,15 +1,14 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,8 +39,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Fixture handling shared by {@code block-test} and {@code state-test}: expanding paths into
  * fixture files, running those files over a worker pool, tallying results, and emitting {@code
- * --json-array}. Held in one place so both subcommands report the same counts for the same
- * directory.
+ * --json-array}.
  */
 final class FixtureRunner {
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -55,6 +55,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
@@ -63,6 +65,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.apache.tuweni.bytes.Bytes;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.IExitCodeGenerator;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
@@ -84,13 +87,16 @@ import picocli.CommandLine.ParentCommand;
     description = "Execute an Ethereum State Test.",
     mixinStandardHelpOptions = true,
     versionProvider = VersionProvider.class)
-public class StateTestSubCommand implements Runnable {
+public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   /**
    * The name of the command for the StateTestSubCommand. This constant is used as the name
    * parameter in the @CommandLine.Command annotation. It defines the command name that users should
    * enter on the command line to invoke this command.
    */
   public static final String COMMAND_NAME = "state-test";
+
+  /** Set when any executed test fails, so the process exits non-zero (for CI/gradle). */
+  private final AtomicBoolean anyFailure = new AtomicBoolean(false);
 
   @SuppressWarnings({"FieldCanBeFinal"})
   @Option(
@@ -100,8 +106,24 @@ public class StateTestSubCommand implements Runnable {
 
   @Option(
       names = {"--test-name"},
-      description = "Limit execution to one named test.")
+      description = "Limit execution to the test with exactly this name.")
   private String testName = null;
+
+  @Option(
+      names = {"--run"},
+      description =
+          "Limit execution to tests whose name contains the given substring, or matches the given"
+              + " pattern (a regex, with * and ? as wildcards).")
+  private String runFilter = null;
+
+  // Compiled up front so a malformed expression fails before any fixture is read
+  private TestNameFilter nameFilter;
+
+  @Option(
+      names = {"--workers"},
+      description = "Number of parallel workers for processing fixture files.",
+      defaultValue = "1")
+  private int workers = 1;
 
   @Option(
       names = {"--data-index"},
@@ -130,7 +152,35 @@ public class StateTestSubCommand implements Runnable {
       negatable = true)
   private Boolean enablePrecompileCache = false;
 
+  @Option(
+      names = {"--json-array"},
+      description =
+          "Output results as a JSON array with standard schema: name, pass, fork, stateRoot, error.")
+  private boolean jsonArray = false;
+
+  @Option(
+      names = {"--summary-only"},
+      description =
+          "Suppress the per-test result line for passing tests, printing only failures and the"
+              + " final summary. Useful when running whole fixture trees.")
+  private boolean summaryOnly = false;
+
+  private final AtomicInteger passCount = new AtomicInteger(0);
+  private final AtomicInteger failCount = new AtomicInteger(0);
+
   @ParentCommand private final EvmToolCommand parentCommand;
+
+  // Collected results for --json-array mode
+  private final List<ObjectNode> jsonArrayResults = Collections.synchronizedList(new ArrayList<>());
+
+  // Fixture files this harness could not build a test from — reported, never silently dropped
+  private final List<String> unreadableFiles = Collections.synchronizedList(new ArrayList<>());
+
+  // Cache protocol schedules across all tests — creating all 30+ schedules is very expensive
+  private volatile ReferenceTestProtocolSchedules cachedSchedules;
+
+  // Cached ObjectMapper for summary output — thread-safe for createObjectNode()
+  private static final ObjectMapper SHARED_OBJECT_MAPPER = JsonUtils.createObjectMapper();
 
   // picocli does it magically
   @Parameters private final List<Path> stateTestFiles = new ArrayList<>();
@@ -161,6 +211,16 @@ public class StateTestSubCommand implements Runnable {
         stateTestMapper
             .getTypeFactory()
             .constructParametricType(Map.class, String.class, GeneralStateTestCaseSpec.class);
+    if (runFilter != null) {
+      try {
+        nameFilter = TestNameFilter.compile(runFilter);
+      } catch (final IllegalArgumentException e) {
+        parentCommand.out.println(e.getMessage());
+        anyFailure.set(true);
+        return;
+      }
+    }
+
     try {
       if (stateTestFiles.isEmpty()) {
         // if no state tests were specified use standard input to get filenames
@@ -169,7 +229,6 @@ public class StateTestSubCommand implements Runnable {
         while (true) {
           final String fileName = in.readLine();
           if (fileName == null) {
-            // reached end of file.  Stop the loop.
             break;
           }
           final File file = new File(fileName);
@@ -182,22 +241,70 @@ public class StateTestSubCommand implements Runnable {
           }
         }
       } else {
-        for (final Path stateTestFile : stateTestFiles) {
-          final Map<String, GeneralStateTestCaseSpec> generalStateTests;
-          if ("stdin".equals(stateTestFile.toString())) {
-            generalStateTests = stateTestMapper.readValue(parentCommand.in, javaType);
-          } else {
-            generalStateTests = stateTestMapper.readValue(stateTestFile.toFile(), javaType);
-          }
-          executeStateTest(generalStateTests);
-        }
+        FixtureRunner.runFiles(
+            FixtureRunner.collectFiles(stateTestFiles),
+            workers,
+            file -> runFile(file, stateTestMapper, javaType));
       }
+    } catch (final UnsupportedForkException e) {
+      throw e;
     } catch (final JsonProcessingException jpe) {
       parentCommand.out.println("File content error: " + jpe);
     } catch (final IOException e) {
-      System.err.println("Unable to read state file");
+      System.err.println("Unable to read state file: " + e.getMessage());
+      anyFailure.set(true);
+    } catch (final Exception e) {
+      System.err.println("Error: " + e.getMessage());
       e.printStackTrace(System.err);
     }
+
+    if (runFilter != null && passCount.get() + failCount.get() == 0) {
+      // A filter that selects nothing is almost always a typo, and an empty run reporting success
+      // is indistinguishable from a clean sweep.
+      parentCommand.out.printf("No test matched --run '%s'; nothing was executed.%n", runFilter);
+      anyFailure.set(true);
+    }
+
+    if (jsonArray) {
+      FixtureRunner.printJsonArray(parentCommand.out, jsonArrayResults);
+    } else if (passCount.get() + failCount.get() > 0) {
+      parentCommand.out.printf(
+          "%nState test summary: %d passed, %d failed%n", passCount.get(), failCount.get());
+    }
+
+    if (!unreadableFiles.isEmpty()) {
+      parentCommand.out.printf(
+          "%n%d fixture file(s) were not readable as state tests (no test in them ran):%n",
+          unreadableFiles.size());
+      unreadableFiles.forEach(f -> parentCommand.out.println("  - " + f));
+    }
+  }
+
+  @Override
+  public int getExitCode() {
+    return anyFailure.get() ? 1 : 0;
+  }
+
+  /**
+   * Reads one fixture file and runs it. A file that cannot be read is reported, but kept apart from
+   * the test failures: it says nothing about Besu, only that the fixture has a shape this harness
+   * cannot build — the {@code test_bad_v_r_s} fixtures, say, carry a pre-signed transaction in
+   * {@code post[].txbytes} rather than a {@code secretKey} for {@code
+   * StateTestVersionedTransaction} to sign with. Shared by the sequential and parallel paths so the
+   * counts agree either way.
+   */
+  private void runFile(final Path file, final ObjectMapper mapper, final JavaType javaType) {
+    final Map<String, GeneralStateTestCaseSpec> generalStateTests;
+    try {
+      generalStateTests =
+          "stdin".equals(file.toString())
+              ? mapper.readValue(parentCommand.in, javaType)
+              : mapper.readValue(file.toFile(), javaType);
+    } catch (final Exception e) {
+      unreadableFiles.add(file + ": " + e);
+      return;
+    }
+    executeStateTest(generalStateTests);
   }
 
   private void executeStateTest(final Map<String, GeneralStateTestCaseSpec> generalStateTests) {
@@ -206,16 +313,44 @@ public class StateTestSubCommand implements Runnable {
       boolean isLastIteration = (i == repeatCount - 1);
       for (final Map.Entry<String, GeneralStateTestCaseSpec> generalStateTestEntry :
           generalStateTests.entrySet()) {
-        if (testName == null || testName.equals(generalStateTestEntry.getKey())) {
+        if (selects(generalStateTestEntry.getKey())) {
           generalStateTestEntry
               .getValue()
               .finalStateSpecs()
               .forEach(
-                  (__, specs) ->
-                      traceTestSpecs(generalStateTestEntry.getKey(), specs, isLastIteration));
+                  (__, specs) -> {
+                    try {
+                      traceTestSpecs(generalStateTestEntry.getKey(), specs, isLastIteration);
+                    } catch (final UnsupportedForkException e) {
+                      // A fork the reference-test schedules do not know about is a harness
+                      // configuration problem, not a per-test failure: surface it to the caller.
+                      throw e;
+                    } catch (final RuntimeException e) {
+                      // Charge an execution error to the test that caused it, so one broken
+                      // fixture cannot take the rest of the file down with it.
+                      if (isLastIteration) {
+                        failCount.incrementAndGet();
+                        anyFailure.set(true);
+                        parentCommand.out.printf(
+                            "FAIL: %s - execution error: %s%n", generalStateTestEntry.getKey(), e);
+                      }
+                    }
+                  });
         }
       }
     }
+  }
+
+  /**
+   * Whether the given test is selected by {@code --test-name} (an exact name) and {@code --run} (a
+   * case-insensitive substring, or a regex with {@code *} and {@code ?} as wildcards). Both default
+   * to selecting everything.
+   */
+  private boolean selects(final String test) {
+    if (testName != null && !testName.equals(test)) {
+      return false;
+    }
+    return nameFilter == null || nameFilter.matches(test);
   }
 
   private void traceTestSpecs(
@@ -236,7 +371,6 @@ public class StateTestSubCommand implements Runnable {
                     .build())
             : OperationTracer.NO_TRACING;
 
-    final ObjectMapper objectMapper = JsonUtils.createObjectMapper();
     for (final GeneralStateTestCaseEipSpec spec : specs) {
       if (dataIndex != null && spec.getDataIndex() != dataIndex) {
         continue;
@@ -253,7 +387,7 @@ public class StateTestSubCommand implements Runnable {
 
       final BlockHeader blockHeader = spec.getBlockHeader();
       final Transaction transaction = spec.getTransaction(0);
-      final ObjectNode summaryLine = objectMapper.createObjectNode();
+      final ObjectNode summaryLine = SHARED_OBJECT_MAPPER.createObjectNode();
       if (transaction == null) {
         if ((parentCommand.showJsonAlloc || parentCommand.showJsonResults) && isLastIteration) {
           parentCommand.out.println(
@@ -277,9 +411,11 @@ public class StateTestSubCommand implements Runnable {
         }
 
         final String forkName = fork == null ? spec.getFork() : fork;
-        final ProtocolSchedule protocolSchedule =
-            ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration())
-                .getByName(forkName);
+        if (cachedSchedules == null) {
+          cachedSchedules =
+              ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
+        }
+        final ProtocolSchedule protocolSchedule = cachedSchedules.getByName(forkName);
         if (protocolSchedule == null) {
           throw new UnsupportedForkException(forkName);
         }
@@ -348,14 +484,24 @@ public class StateTestSubCommand implements Runnable {
         final List<Log> logs = result.getLogs();
         final Hash actualLogsHash = Hash.hash(RLP.encode(out -> out.writeList(logs, Log::writeTo)));
         summaryLine.put("postLogsHash", actualLogsHash.getBytes().toHexString());
-        summaryLine.put(
-            "pass",
-            spec.getExpectException() == null
-                && worldState.rootHash().equals(spec.getExpectedRootHash())
-                && actualLogsHash.equals(spec.getExpectedLogsHash()));
+        // Every fixture requires the post state root and logs hash to match; one expecting an
+        // exception requires the rejection on top of that. Rejection alone would also be satisfied
+        // by rejecting for the wrong reason, or while corrupting state.
+        //
+        // The expected exception name itself is not compared: EELS spells it
+        // "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" where Besu reports a prose message, and
+        // there is no mapping between the two here yet (EngineTestExceptionMapper is the
+        // engine-side
+        // equivalent).
+        final boolean exceptionExpected = spec.getExpectException() != null;
+        final boolean postStateMatches =
+            worldState.rootHash().equals(spec.getExpectedRootHash())
+                && actualLogsHash.equals(spec.getExpectedLogsHash());
+        final boolean pass = postStateMatches && (!exceptionExpected || result.isInvalid());
+        summaryLine.put("pass", pass);
         if (result.isInvalid()) {
           summaryLine.put("validationError", result.getValidationResult().getErrorMessage());
-        } else if (spec.getExpectException() != null) {
+        } else if (exceptionExpected) {
           summaryLine.put(
               "validationError",
               "Exception '" + spec.getExpectException() + "' was expected but did not occur");
@@ -369,7 +515,35 @@ public class StateTestSubCommand implements Runnable {
       }
 
       if (isLastIteration) {
-        parentCommand.out.println(summaryLine);
+        final boolean testPassed = summaryLine.has("pass") && summaryLine.get("pass").asBoolean();
+        if (testPassed) {
+          passCount.incrementAndGet();
+        } else {
+          failCount.incrementAndGet();
+          anyFailure.set(true);
+        }
+        if (jsonArray) {
+          final ObjectNode standardResult = SHARED_OBJECT_MAPPER.createObjectNode();
+          standardResult.put(
+              "name", summaryLine.has("test") ? summaryLine.get("test").asText() : "");
+          standardResult.put(
+              "pass", summaryLine.has("pass") && summaryLine.get("pass").asBoolean());
+          standardResult.put(
+              "fork", summaryLine.has("fork") ? summaryLine.get("fork").asText() : "");
+          standardResult.put(
+              "stateRoot",
+              summaryLine.has("stateRoot") ? summaryLine.get("stateRoot").asText() : "");
+          String error = "";
+          if (summaryLine.has("validationError")) {
+            error = summaryLine.get("validationError").asText();
+          } else if (summaryLine.has("error")) {
+            error = summaryLine.get("error").asText();
+          }
+          standardResult.put("error", error);
+          jsonArrayResults.add(standardResult);
+        } else if (!summaryOnly || !testPassed) {
+          parentCommand.out.println(summaryLine);
+        }
       }
     }
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -116,9 +116,10 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
 
   @Option(
       names = {"--workers"},
-      description = "Number of parallel workers for processing fixture files.",
-      defaultValue = "1")
-  private int workers = 1;
+      description =
+          "Number of parallel workers for processing fixture files. Defaults to the number of"
+              + " available cores (${DEFAULT-VALUE} here); lower it to run with less parallelism.")
+  private int workers = Runtime.getRuntime().availableProcessors();
 
   @Option(
       names = {"--data-index"},

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -106,15 +106,10 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
 
   @Option(
       names = {"--test-name"},
-      description = "Limit execution to the test with exactly this name.")
-  private String testName = null;
-
-  @Option(
-      names = {"--run"},
       description =
           "Limit execution to tests whose name contains the given substring, or matches the given"
               + " pattern (a regex, with * and ? as wildcards).")
-  private String runFilter = null;
+  private String testName = null;
 
   // Compiled up front so a malformed expression fails before any fixture is read
   private TestNameFilter nameFilter;
@@ -173,13 +168,13 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   // Collected results for --json-array mode
   private final List<ObjectNode> jsonArrayResults = Collections.synchronizedList(new ArrayList<>());
 
-  // Fixture files this harness could not build a test from — reported, never silently dropped
+  // Fixture files we could not build a test from; reported at the end rather than dropped
   private final List<String> unreadableFiles = Collections.synchronizedList(new ArrayList<>());
 
-  // Cache protocol schedules across all tests — creating all 30+ schedules is very expensive
+  // Cached across all tests: building the 30+ reference test schedules is expensive
   private volatile ReferenceTestProtocolSchedules cachedSchedules;
 
-  // Cached ObjectMapper for summary output — thread-safe for createObjectNode()
+  // Shared for summary output; createObjectNode() is thread safe
   private static final ObjectMapper SHARED_OBJECT_MAPPER = JsonUtils.createObjectMapper();
 
   // picocli does it magically
@@ -211,9 +206,9 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
         stateTestMapper
             .getTypeFactory()
             .constructParametricType(Map.class, String.class, GeneralStateTestCaseSpec.class);
-    if (runFilter != null) {
+    if (testName != null) {
       try {
-        nameFilter = TestNameFilter.compile(runFilter);
+        nameFilter = TestNameFilter.compile(testName);
       } catch (final IllegalArgumentException e) {
         parentCommand.out.println(e.getMessage());
         anyFailure.set(true);
@@ -249,34 +244,44 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
     } catch (final UnsupportedForkException e) {
       throw e;
     } catch (final JsonProcessingException jpe) {
+      // A fixture that could not be parsed has to fail the run, otherwise a broken fixture tree
+      // reports success.
       parentCommand.out.println("File content error: " + jpe);
+      anyFailure.set(true);
     } catch (final IOException e) {
       System.err.println("Unable to read state file: " + e.getMessage());
       anyFailure.set(true);
     } catch (final Exception e) {
       System.err.println("Error: " + e.getMessage());
       e.printStackTrace(System.err);
+      anyFailure.set(true);
     }
 
-    if (runFilter != null && passCount.get() + failCount.get() == 0) {
-      // A filter that selects nothing is almost always a typo, and an empty run reporting success
-      // is indistinguishable from a clean sweep.
-      parentCommand.out.printf("No test matched --run '%s'; nothing was executed.%n", runFilter);
+    if (passCount.get() + failCount.get() == 0) {
+      // Fail an empty run, whether or not a filter was given, so a typo in --test-name or a fixture
+      // tree that did not materialise cannot be mistaken for a clean sweep. Matches block-test.
+      if (!jsonArray) {
+        parentCommand.out.printf(
+            "No state test was executed%s.%n",
+            testName == null ? "" : " matching --test-name '" + testName + "'");
+      }
       anyFailure.set(true);
     }
 
     if (jsonArray) {
       FixtureRunner.printJsonArray(parentCommand.out, jsonArrayResults);
-    } else if (passCount.get() + failCount.get() > 0) {
-      parentCommand.out.printf(
-          "%nState test summary: %d passed, %d failed%n", passCount.get(), failCount.get());
-    }
-
-    if (!unreadableFiles.isEmpty()) {
-      parentCommand.out.printf(
-          "%n%d fixture file(s) were not readable as state tests (no test in them ran):%n",
-          unreadableFiles.size());
-      unreadableFiles.forEach(f -> parentCommand.out.println("  - " + f));
+    } else {
+      if (passCount.get() + failCount.get() > 0) {
+        parentCommand.out.printf(
+            "%nState test summary: %d passed, %d failed%n", passCount.get(), failCount.get());
+      }
+      // Not printed under --json-array, where that output is parsed and only the array belongs.
+      if (!unreadableFiles.isEmpty()) {
+        parentCommand.out.printf(
+            "%n%d fixture file(s) were not readable as state tests (no test in them ran):%n",
+            unreadableFiles.size());
+        unreadableFiles.forEach(f -> parentCommand.out.println("  - " + f));
+      }
     }
   }
 
@@ -286,12 +291,12 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   }
 
   /**
-   * Reads one fixture file and runs it. A file that cannot be read is reported, but kept apart from
-   * the test failures: it says nothing about Besu, only that the fixture has a shape this harness
-   * cannot build — the {@code test_bad_v_r_s} fixtures, say, carry a pre-signed transaction in
-   * {@code post[].txbytes} rather than a {@code secretKey} for {@code
-   * StateTestVersionedTransaction} to sign with. Shared by the sequential and parallel paths so the
+   * Reads one fixture file and runs it. Used by both the sequential and the parallel path so the
    * counts agree either way.
+   *
+   * <p>A file that cannot be read is reported separately from the test failures. The {@code
+   * test_bad_v_r_s} fixtures, for example, carry a pre-signed transaction in {@code post[].txbytes}
+   * instead of a {@code secretKey} for {@code StateTestVersionedTransaction} to sign with.
    */
   private void runFile(final Path file, final ObjectMapper mapper, final JavaType javaType) {
     final Map<String, GeneralStateTestCaseSpec> generalStateTests;
@@ -322,12 +327,12 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
                     try {
                       traceTestSpecs(generalStateTestEntry.getKey(), specs, isLastIteration);
                     } catch (final UnsupportedForkException e) {
-                      // A fork the reference-test schedules do not know about is a harness
-                      // configuration problem, not a per-test failure: surface it to the caller.
+                      // An unknown fork is a harness configuration problem rather than a test
+                      // failure, so let it out.
                       throw e;
                     } catch (final RuntimeException e) {
-                      // Charge an execution error to the test that caused it, so one broken
-                      // fixture cannot take the rest of the file down with it.
+                      // Record against the test that caused it, so one broken fixture does not
+                      // abandon the rest of the file.
                       if (isLastIteration) {
                         failCount.incrementAndGet();
                         anyFailure.set(true);
@@ -341,15 +346,8 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
     }
   }
 
-  /**
-   * Whether the given test is selected by {@code --test-name} (an exact name) and {@code --run} (a
-   * case-insensitive substring, or a regex with {@code *} and {@code ?} as wildcards). Both default
-   * to selecting everything.
-   */
+  /** Whether {@code --test-name} selects the given test. With no filter, everything is selected. */
   private boolean selects(final String test) {
-    if (testName != null && !testName.equals(test)) {
-      return false;
-    }
     return nameFilter == null || nameFilter.matches(test);
   }
 
@@ -484,15 +482,13 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
         final List<Log> logs = result.getLogs();
         final Hash actualLogsHash = Hash.hash(RLP.encode(out -> out.writeList(logs, Log::writeTo)));
         summaryLine.put("postLogsHash", actualLogsHash.getBytes().toHexString());
-        // Every fixture requires the post state root and logs hash to match; one expecting an
-        // exception requires the rejection on top of that. Rejection alone would also be satisfied
-        // by rejecting for the wrong reason, or while corrupting state.
+        // Every fixture requires the post state root and the logs hash to match. A fixture that
+        // expects an exception additionally requires the transaction to be rejected; checking the
+        // rejection alone would also pass when we reject for the wrong reason or corrupt state.
         //
-        // The expected exception name itself is not compared: EELS spells it
-        // "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" where Besu reports a prose message, and
-        // there is no mapping between the two here yet (EngineTestExceptionMapper is the
-        // engine-side
-        // equivalent).
+        // The expected exception name is not compared. EELS writes it as
+        // "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" while Besu reports a prose message, and
+        // there is no mapping between the two yet.
         final boolean exceptionExpected = spec.getExpectException() != null;
         final boolean postStateMatches =
             worldState.rootHash().equals(spec.getExpectedRootHash())

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -172,7 +172,7 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   // Fixture files we could not build a test from; reported at the end rather than dropped
   private final List<String> unreadableFiles = Collections.synchronizedList(new ArrayList<>());
 
-  // Cached across all tests: building the 30+ reference test schedules is expensive
+  // Cached across all tests
   private volatile ReferenceTestProtocolSchedules cachedSchedules;
 
   // Shared for summary output; createObjectNode() is thread safe
@@ -294,10 +294,6 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   /**
    * Reads one fixture file and runs it. Used by both the sequential and the parallel path so the
    * counts agree either way.
-   *
-   * <p>A file that cannot be read is reported separately from the test failures. The {@code
-   * test_bad_v_r_s} fixtures, for example, carry a pre-signed transaction in {@code post[].txbytes}
-   * instead of a {@code secretKey} for {@code StateTestVersionedTransaction} to sign with.
    */
   private void runFile(final Path file, final ObjectMapper mapper, final JavaType javaType) {
     final Map<String, GeneralStateTestCaseSpec> generalStateTests;
@@ -483,14 +479,12 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
         final List<Log> logs = result.getLogs();
         final Hash actualLogsHash = Hash.hash(RLP.encode(out -> out.writeList(logs, Log::writeTo)));
         summaryLine.put("postLogsHash", actualLogsHash.getBytes().toHexString());
+
         // Every fixture requires the post state root and the logs hash to match. A fixture that
         // expects an exception additionally requires the transaction to be rejected; checking the
         // rejection alone would also pass when we reject for the wrong reason or corrupt state.
-        //
-        // The expected exception name is not compared. EELS writes it as
-        // "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" while Besu reports a prose message, and
-        // there is no mapping between the two yet.
         final boolean exceptionExpected = spec.getExpectException() != null;
+
         final boolean postStateMatches =
             worldState.rootHash().equals(spec.getExpectedRootHash())
                 && actualLogsHash.equals(spec.getExpectedLogsHash());

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -172,8 +172,8 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
   // Fixture files we could not build a test from; reported at the end rather than dropped
   private final List<String> unreadableFiles = Collections.synchronizedList(new ArrayList<>());
 
-  // Cached across all tests
-  private volatile ReferenceTestProtocolSchedules cachedSchedules;
+  // Cached across all tests; guarded by getSchedules()
+  private ReferenceTestProtocolSchedules cachedSchedules;
 
   // Shared for summary output; createObjectNode() is thread safe
   private static final ObjectMapper SHARED_OBJECT_MAPPER = JsonUtils.createObjectMapper();
@@ -348,6 +348,18 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
     return nameFilter == null || nameFilter.matches(test);
   }
 
+  /**
+   * The reference test schedules, built once and shared by every worker. Building them is expensive
+   * — 30+ schedules per call — and {@code create} also initialises the KZG trusted setup, which is
+   * process-wide state, so the check-then-act has to be atomic rather than merely visible.
+   */
+  private synchronized ReferenceTestProtocolSchedules getSchedules() {
+    if (cachedSchedules == null) {
+      cachedSchedules = ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
+    }
+    return cachedSchedules;
+  }
+
   private void traceTestSpecs(
       final String test,
       final List<GeneralStateTestCaseEipSpec> specs,
@@ -406,11 +418,7 @@ public class StateTestSubCommand implements Runnable, IExitCodeGenerator {
         }
 
         final String forkName = fork == null ? spec.getFork() : fork;
-        if (cachedSchedules == null) {
-          cachedSchedules =
-              ReferenceTestProtocolSchedules.create(parentCommand.getEvmConfiguration());
-        }
-        final ProtocolSchedule protocolSchedule = cachedSchedules.getByName(forkName);
+        final ProtocolSchedule protocolSchedule = getSchedules().getByName(forkName);
         if (protocolSchedule == null) {
           throw new UnsupportedForkException(forkName);
         }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evmtool;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * The {@code --run}/{@code --test-name} filter shared by the fixture runners: a case-insensitive
+ * substring match, or — when the expression contains {@code *} or {@code ?} — a case-insensitive
+ * regex in which {@code *} means {@code .*} and {@code ?} means any single character. Everything
+ * else reaches {@link Pattern} untouched, so alternation and character classes work, mirroring
+ * hive's {@code --sim.limit}.
+ *
+ * <p>Compiling once, before any fixture is read, is what makes a malformed expression an immediate
+ * failure rather than one raised part-way through a run, where callers would have to distinguish it
+ * from an unreadable fixture file.
+ */
+final class TestNameFilter {
+
+  private final Pattern regex;
+  private final String substring;
+
+  private TestNameFilter(final Pattern regex, final String substring) {
+    this.regex = regex;
+    this.substring = substring;
+  }
+
+  /**
+   * Compiles a filter expression.
+   *
+   * @param expression the {@code --run} expression, never null
+   * @return the compiled filter
+   * @throws IllegalArgumentException if the expression is not a valid pattern
+   */
+  static TestNameFilter compile(final String expression) {
+    if (expression.indexOf('*') < 0 && expression.indexOf('?') < 0) {
+      return new TestNameFilter(null, expression.toLowerCase(Locale.ROOT));
+    }
+    // '.' is a literal: test ids are pytest node ids, so they are full of ".py"
+    final String pattern = expression.replace(".", "\\.").replace("*", ".*").replace("?", ".");
+    try {
+      return new TestNameFilter(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE), null);
+    } catch (final PatternSyntaxException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid --run/--test-name pattern '%s': %s."
+                  + " Test ids contain regex metacharacters such as '[' and '(' — escape them"
+                  + " (\\[) if you mean them literally.",
+              expression, e.getDescription()),
+          e);
+    }
+  }
+
+  /**
+   * Whether the given test id matches this filter.
+   *
+   * @param test the test id
+   * @return true when it matches
+   */
+  boolean matches(final String test) {
+    return regex != null
+        ? regex.matcher(test).matches()
+        : test.toLowerCase(Locale.ROOT).contains(substring);
+  }
+}

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
@@ -1,15 +1,14 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/TestNameFilter.java
@@ -20,15 +20,14 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * The {@code --run}/{@code --test-name} filter shared by the fixture runners: a case-insensitive
- * substring match, or — when the expression contains {@code *} or {@code ?} — a case-insensitive
- * regex in which {@code *} means {@code .*} and {@code ?} means any single character. Everything
- * else reaches {@link Pattern} untouched, so alternation and character classes work, mirroring
- * hive's {@code --sim.limit}.
+ * The {@code --test-name} filter used by {@code block-test} and {@code state-test}. An expression
+ * without {@code *} or {@code ?} is a case-insensitive substring match. One with either is a
+ * case-insensitive regex that must match the whole test id, where {@code *} becomes {@code .*} and
+ * {@code ?} becomes {@code .}. The rest of the expression is passed to {@link Pattern} as-is, so
+ * alternation and character classes work, as in hive's {@code --sim.limit}.
  *
- * <p>Compiling once, before any fixture is read, is what makes a malformed expression an immediate
- * failure rather than one raised part-way through a run, where callers would have to distinguish it
- * from an unreadable fixture file.
+ * <p>Callers compile the expression before reading any fixture, so a malformed pattern fails up
+ * front rather than part-way through a run.
  */
 final class TestNameFilter {
 
@@ -43,7 +42,7 @@ final class TestNameFilter {
   /**
    * Compiles a filter expression.
    *
-   * @param expression the {@code --run} expression, never null
+   * @param expression the {@code --test-name} expression, never null
    * @return the compiled filter
    * @throws IllegalArgumentException if the expression is not a valid pattern
    */
@@ -51,16 +50,16 @@ final class TestNameFilter {
     if (expression.indexOf('*') < 0 && expression.indexOf('?') < 0) {
       return new TestNameFilter(null, expression.toLowerCase(Locale.ROOT));
     }
-    // '.' is a literal: test ids are pytest node ids, so they are full of ".py"
+    // '.' is escaped: test ids are pytest node ids, which contain ".py"
     final String pattern = expression.replace(".", "\\.").replace("*", ".*").replace("?", ".");
     try {
       return new TestNameFilter(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE), null);
     } catch (final PatternSyntaxException e) {
       throw new IllegalArgumentException(
           String.format(
-              "Invalid --run/--test-name pattern '%s': %s."
-                  + " Test ids contain regex metacharacters such as '[' and '(' — escape them"
-                  + " (\\[) if you mean them literally.",
+              "Invalid --test-name pattern '%s': %s."
+                  + " Test ids contain regex metacharacters such as '[' and '('."
+                  + " Escape them (\\[) to match literally.",
               expression, e.getDescription()),
           e);
     }

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
@@ -44,6 +44,49 @@ class StateTestSubCommandTest {
   }
 
   @Test
+  void testNameMatchesExactlyAndRunMatchesSubstrings() {
+    // Conflating the two would make a caller that passes an exact test id run every test whose
+    // name merely contains it.
+    assertThat(runWithArgs("--test-name", "accessLis", "access-list.json")).doesNotContain("\"d\"");
+    assertThat(runWithArgs("--test-name", "accessList", "access-list.json")).contains("\"d\"");
+    assertThat(runWithArgs("--run", "accessLis", "access-list.json")).contains("\"d\"");
+    assertThat(runWithArgs("--run", "*ccess?ist", "access-list.json")).contains("\"d\"");
+  }
+
+  @Test
+  void summaryOnlySuppressesThePerTestLineForPassingTests() {
+    assertThat(runWithArgs("access-list.json")).contains("\"pass\":true");
+    assertThat(runWithArgs("--summary-only", "access-list.json"))
+        .doesNotContain("\"pass\":true")
+        .contains("State test summary: ");
+  }
+
+  @Test
+  void missingFileIsReportedRatherThanReadAsAListOfFilenamesFromStdin() {
+    // An empty file list means "read filenames from stdin", so a path that resolves to nothing
+    // has to be an error rather than a silent drop, or the command blocks forever.
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final StateTestSubCommand stateTestSubCommand =
+        new StateTestSubCommand(new EvmToolCommand(System.in, new PrintWriter(baos, true, UTF_8)));
+    new CommandLine(stateTestSubCommand).parseArgs("./file-does-not-exist.json");
+    stateTestSubCommand.run();
+    assertThat(stateTestSubCommand.getExitCode()).isEqualTo(1);
+  }
+
+  private String runWithArgs(final String... args) {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final EvmToolCommand parentCommand =
+        new EvmToolCommand(System.in, new PrintWriter(baos, true, UTF_8));
+    final StateTestSubCommand stateTestSubCommand = new StateTestSubCommand(parentCommand);
+    final String[] resolved = args.clone();
+    resolved[resolved.length - 1] =
+        StateTestSubCommandTest.class.getResource(resolved[resolved.length - 1]).getPath();
+    new CommandLine(stateTestSubCommand).parseArgs(resolved);
+    stateTestSubCommand.run();
+    return baos.toString(UTF_8);
+  }
+
+  @Test
   void shouldWorkWithValidStateTest() {
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     EvmToolCommand parentCommand =

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
@@ -44,13 +44,41 @@ class StateTestSubCommandTest {
   }
 
   @Test
-  void testNameMatchesExactlyAndRunMatchesSubstrings() {
-    // Conflating the two would make a caller that passes an exact test id run every test whose
-    // name merely contains it.
-    assertThat(runWithArgs("--test-name", "accessLis", "access-list.json")).doesNotContain("\"d\"");
+  void testNameMatchesSubstringsAndPatterns() {
+    // Same semantics as block-test: a substring, or a whole-id regex once the expression carries a
+    // wildcard.
     assertThat(runWithArgs("--test-name", "accessList", "access-list.json")).contains("\"d\"");
-    assertThat(runWithArgs("--run", "accessLis", "access-list.json")).contains("\"d\"");
-    assertThat(runWithArgs("--run", "*ccess?ist", "access-list.json")).contains("\"d\"");
+    assertThat(runWithArgs("--test-name", "accessLis", "access-list.json")).contains("\"d\"");
+    assertThat(runWithArgs("--test-name", "*ccess?ist", "access-list.json")).contains("\"d\"");
+  }
+
+  @Test
+  void aTestNameThatMatchesNothingIsAnErrorRatherThanAnEmptyPass() {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final StateTestSubCommand stateTestSubCommand =
+        new StateTestSubCommand(new EvmToolCommand(System.in, new PrintWriter(baos, true, UTF_8)));
+    new CommandLine(stateTestSubCommand)
+        .parseArgs(
+            "--test-name",
+            "noSuchTest",
+            StateTestSubCommandTest.class.getResource("access-list.json").getPath());
+    stateTestSubCommand.run();
+    assertThat(stateTestSubCommand.getExitCode()).isEqualTo(1);
+    assertThat(baos.toString(UTF_8))
+        .contains("No state test was executed matching --test-name 'noSuchTest'");
+  }
+
+  @Test
+  void anEmptyRunIsAnErrorEvenWithoutAFilter() {
+    // Not gated on --test-name, so a fixture tree that did not materialise also fails the run.
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final StateTestSubCommand stateTestSubCommand =
+        new StateTestSubCommand(
+            new EvmToolCommand(
+                new ByteArrayInputStream(new byte[0]), new PrintWriter(baos, true, UTF_8)));
+    stateTestSubCommand.run();
+    assertThat(stateTestSubCommand.getExitCode()).isEqualTo(1);
+    assertThat(baos.toString(UTF_8)).contains("No state test was executed.");
   }
 
   @Test
@@ -63,8 +91,8 @@ class StateTestSubCommandTest {
 
   @Test
   void missingFileIsReportedRatherThanReadAsAListOfFilenamesFromStdin() {
-    // An empty file list means "read filenames from stdin", so a path that resolves to nothing
-    // has to be an error rather than a silent drop, or the command blocks forever.
+    // An empty file list means "read filenames from stdin", so dropping an unresolvable path here
+    // would leave the command blocked on stdin.
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     final StateTestSubCommand stateTestSubCommand =
         new StateTestSubCommand(new EvmToolCommand(System.in, new PrintWriter(baos, true, UTF_8)));
@@ -173,6 +201,8 @@ class StateTestSubCommandTest {
         new StateTestSubCommand(new EvmToolCommand(bais, new PrintWriter(baos, true, UTF_8)));
     stateTestSubCommand.run();
     assertThat(baos.toString(UTF_8)).contains("File content error: ");
+    // A fixture that could not be parsed has to fail the run.
+    assertThat(stateTestSubCommand.getExitCode()).isEqualTo(1);
   }
 
   @Test

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evmtool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestNameFilterTest {
+
+  private static final String NODE_ID =
+      "tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_fork_transition.py"
+          + "::test_intrinsic_reduction[fork_BPO2ToAmsterdamAtTime15k-non-zero_value-plain_call]";
+
+  @Test
+  void substringMatchIsCaseInsensitive() {
+    assertThat(TestNameFilter.compile("FORK_bpo2toamsterdam").matches(NODE_ID)).isTrue();
+    assertThat(TestNameFilter.compile("fork_Osaka").matches(NODE_ID)).isFalse();
+  }
+
+  @Test
+  void alternationWorks() {
+    // The hive --sim.limit equivalent, as documented in REFERENCE_TESTS.md.
+    assertThat(
+            TestNameFilter.compile("*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka)*")
+                .matches(NODE_ID))
+        .isTrue();
+    assertThat(TestNameFilter.compile("*fork_(Cancun|Prague)*").matches(NODE_ID)).isFalse();
+  }
+
+  @Test
+  void dotIsALiteralNotAWildcard() {
+    assertThat(TestNameFilter.compile("*test_fork_transition.py*").matches(NODE_ID)).isTrue();
+    assertThat(TestNameFilter.compile("*test_fork_transitionXpy*").matches(NODE_ID)).isFalse();
+  }
+
+  @Test
+  void questionMarkMatchesASingleCharacter() {
+    assertThat(TestNameFilter.compile("*plain_cal?]").matches(NODE_ID)).isTrue();
+    assertThat(TestNameFilter.compile("*plain_ca?]").matches(NODE_ID)).isFalse();
+  }
+
+  @Test
+  void patternMustMatchTheWholeName() {
+    assertThat(TestNameFilter.compile("tests/amsterdam*").matches(NODE_ID)).isTrue();
+    assertThat(TestNameFilter.compile("eip2780*").matches(NODE_ID)).isFalse();
+  }
+
+  @Test
+  void malformedPatternFailsAtCompileTimeWithAnActionableMessage() {
+    assertThatThrownBy(() -> TestNameFilter.compile("*[fork_Amsterdam*"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid --run/--test-name pattern '*[fork_Amsterdam*'")
+        .hasMessageContaining("escape them");
+  }
+
+  @Test
+  void metacharactersCanBeEscapedToMatchLiterally() {
+    assertThat(TestNameFilter.compile("*\\[fork_BPO2ToAmsterdamAtTime15k*").matches(NODE_ID))
+        .isTrue();
+  }
+}

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
@@ -1,15 +1,14 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/TestNameFilterTest.java
@@ -61,11 +61,11 @@ class TestNameFilterTest {
   }
 
   @Test
-  void malformedPatternFailsAtCompileTimeWithAnActionableMessage() {
+  void malformedPatternIsRejectedWhenCompiled() {
     assertThatThrownBy(() -> TestNameFilter.compile("*[fork_Amsterdam*"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid --run/--test-name pattern '*[fork_Amsterdam*'")
-        .hasMessageContaining("escape them");
+        .hasMessageContaining("Invalid --test-name pattern '*[fork_Amsterdam*'")
+        .hasMessageContaining("Escape them");
   }
 
   @Test


### PR DESCRIPTION
## PR description

`state-test` and `block-test` take one fixture file at a time and offer no way to scope a run, which makes a whole execution-spec fixture tree impractical to run locally. This gives both the same treatment:

- A directory argument is expanded recursively instead of needing one path per file, and the files are spread over a worker pool. `--workers` defaults to one worker per available core; pass a lower number to reduce parallelism. Single-file and stdin runs stay sequential.
- `--test-name` takes a case-insensitive substring, or a regex when it contains `*` or `?`. It is compiled before any fixture is read, so a malformed pattern fails immediately rather than quietly running nothing (`TestNameFilter`).
- `--json-array` emits machine-readable results, and is the only thing printed in that mode so the output stays parseable.
- Both exit non-zero on any test failure, on an empty run, on a bad filter, and on a fixture that cannot be parsed (`IExitCodeGenerator`; `EvmToolCommand.execute` now returns the code, and `EvmTool` exits explicitly because returning from `main` always yields 0).
- Fixture files that cannot be read as a test of the expected kind are reported apart from failures, since they are a fixture problem rather than a Besu one.

`state-test` also gains `--summary-only`, and its expected-exception oracle is fixed: pass was `expectException == null && rootsMatch`, so every fixture that expected a rejection was reported as a failure even when Besu correctly rejected the transaction.

`FixtureRunner` holds what the subcommands share: collecting fixture files, the worker pool, the result tallies and summary block, and the `--json-array` payload. Keeping it in one place is what makes the same directory report the same counts whichever subcommand reads it.

The new `stateTestsDevnet` gradle task reuses the existing `extractDevnetFixtures` download. It is opt-in and is not wired into CI.

## Behaviour change

`state-test --test-name` was an exact match and is now the substring/regex match described above, so an expression that is a prefix of other test ids will select more tests than it used to. `block-test --test-name` already matched substrings and is unchanged. There is one filter flag with one meaning across both subcommands.

## Testing

- `:ethereum:evmtool:test` and `spotlessCheck` green.
- `./gradlew :ethereum:evmtool:stateTestsDevnet -PstateTestPath=for_paris` → 2236 passed, 3 failed. The 3 are pre-existing `test_invalid_chain_id` failures that the JUnit `referenceTestsDevnet` gate also fails on `main`; they are not introduced here. One fixture file in that scope (`bad_v_r_s.json`) is reported as unreadable rather than failed: it carries a pre-signed transaction in `post[].txbytes` rather than a `secretKey` that `StateTestVersionedTransaction` can sign with.

## Notes

This is part 1 of 3, splitting up #10184 (which is closed in favour of this stack). Parts 2 and 3 build on it; this part stands alone and is independently useful.

Original work by @spencer-tb, preserved as commit author.
