### PR TITLE
referencetests: engine fixture spec and devnet transition-fork schedules

### DIFF
--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
@@ -226,7 +226,6 @@ public class EngineTestCaseSpec {
             SHARED_TRIE_LOADER,
             SHARED_SERVICE_MANAGER,
             EvmConfiguration.DEFAULT,
-            () -> (__, ___) -> {},
             new PathBasedCodeCache());
 
     final MutableWorldState worldState = worldStateArchive.getWorldState();

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
@@ -1,15 +1,14 @@
 /*
  * Copyright contributors to Besu.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -158,11 +157,17 @@ public class EngineTestCaseSpec {
     return Optional.of(new BlobScheduleOptions(root));
   }
 
+  /**
+   * Reads one blob schedule parameter, which fixtures encode either as a JSON number or as a hex
+   * string. Overflow throws rather than truncating, matching {@code
+   * BlockchainReferenceTestCaseSpec.SpecConfig}: a silently wrapped value would build a blob
+   * schedule that does not match the fixture, which is far harder to diagnose than a parse failure.
+   */
   private static int asInt(final JsonNode node) {
     if (node == null || node.isNull()) {
       return 0;
     }
-    return node.isNumber() ? node.asInt() : Long.decode(node.asText().trim()).intValue();
+    return Math.toIntExact(node.isNumber() ? node.asLong() : Long.decode(node.asText().trim()));
   }
 
   public String getNetwork() {

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
-import org.hyperledger.besu.ethereum.core.ConsensusContextFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.provider.BonsaiWorldStateProvider;
@@ -145,9 +144,9 @@ public class EngineTestCaseSpec {
       if (!value.isObject()) {
         continue;
       }
-      // Besu's BlobSchedule reads numeric, all-lowercase keys (target/max/basefeeupdatefraction),
-      // but EELS fixtures encode the values as hex strings (e.g. "0x0e") under a camelCase
-      // baseFeeUpdateFraction; convert to lowercase numeric nodes.
+
+      // BlobSchedule reads numeric, all-lowercase keys (target/max/basefeeupdatefraction),
+      // but the fixtures encode the values as hex strings (e.g. "0x0e") under a camelCase
       final ObjectNode entry = root.objectNode();
       entry.put("target", asInt(value.get("target")));
       entry.put("max", asInt(value.get("max")));
@@ -197,14 +196,6 @@ public class EngineTestCaseSpec {
   public MutableBlockchain buildBlockchain() {
     final Block genesisBlock = new Block(genesisBlockHeader, BlockBody.empty());
     return InMemoryKeyValueStorageProvider.createInMemoryBlockchain(genesisBlock);
-  }
-
-  public ProtocolContext buildProtocolContext(final MutableBlockchain blockchain) {
-    return new ProtocolContext.Builder()
-        .withBlockchain(blockchain)
-        .withWorldStateArchive(buildWorldStateArchive(blockchain))
-        .withConsensusContext(new ConsensusContextFixture())
-        .build();
   }
 
   /**

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EngineTestCaseSpec.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.referencetests;
+
+import org.hyperledger.besu.config.BlobScheduleOptions;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.ConsensusContextFixture;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.provider.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.accumulator.preload.NoOpBonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.pathbased.common.code.PathBasedCodeCache;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.ImmutablePathBasedExtraStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.ServiceManager;
+import org.hyperledger.besu.plugin.services.BesuService;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Represents an engine test fixture (blockchain_test_engine format) containing engine API payloads
+ * to be executed against the client.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EngineTestCaseSpec {
+
+  // Shared no-op ServiceManager — avoids anonymous class allocation per test
+  private static final ServiceManager SHARED_SERVICE_MANAGER =
+      new ServiceManager() {
+        @Override
+        public <T extends BesuService> void addService(
+            final Class<T> serviceType, final T service) {}
+
+        @Override
+        public <T extends BesuService> Optional<T> getService(final Class<T> serviceType) {
+          return Optional.empty();
+        }
+      };
+
+  // Shared no-op trie loader — stateless, safe to reuse
+  private static final NoOpBonsaiCachedMerkleTrieLoader SHARED_TRIE_LOADER =
+      new NoOpBonsaiCachedMerkleTrieLoader();
+
+  // Shared PostMergeContext singleton for engine tests — always post-merge, never syncing
+  private static final org.hyperledger.besu.consensus.merge.PostMergeContext SHARED_MERGE_CONTEXT;
+
+  static {
+    SHARED_MERGE_CONTEXT =
+        new org.hyperledger.besu.consensus.merge.PostMergeContext() {
+          @Override
+          public boolean isSyncing() {
+            return false;
+          }
+        };
+    SHARED_MERGE_CONTEXT.setIsPostMerge(Difficulty.ZERO);
+  }
+
+  private final String network;
+  private final BlockchainReferenceTestCaseSpec.ReferenceTestBlockHeader genesisBlockHeader;
+  private final Map<String, ReferenceTestWorldState.AccountMock> pre;
+  private final Map<String, ReferenceTestWorldState.AccountMock> postState;
+  private final Hash lastBlockHash;
+  private final EngineNewPayload[] engineNewPayloads;
+  private final JsonNode config;
+
+  @JsonCreator
+  public EngineTestCaseSpec(
+      @JsonProperty("network") final String network,
+      @JsonProperty("genesisBlockHeader")
+          final BlockchainReferenceTestCaseSpec.ReferenceTestBlockHeader genesisBlockHeader,
+      @JsonProperty("pre") final Map<String, ReferenceTestWorldState.AccountMock> pre,
+      @JsonProperty("postState") final Map<String, ReferenceTestWorldState.AccountMock> postState,
+      @JsonProperty("lastblockhash") final String lastBlockHash,
+      @JsonProperty("engineNewPayloads") final EngineNewPayload[] engineNewPayloads,
+      @JsonProperty("config") final JsonNode config) {
+    this.network = network;
+    this.genesisBlockHeader = genesisBlockHeader;
+    this.pre = pre;
+    this.postState = postState;
+    this.lastBlockHash = Hash.fromHexString(lastBlockHash);
+    this.engineNewPayloads = engineNewPayloads;
+    this.config = config;
+  }
+
+  /**
+   * The raw JSON of the fixture's {@code config.blobSchedule}, or {@code null} if absent. Used as a
+   * cache key so a protocol schedule is built once per distinct blob schedule.
+   *
+   * @return the blob schedule node as a string, or "" when absent
+   */
+  public String getBlobScheduleKey() {
+    final JsonNode blobSchedule = config == null ? null : config.get("blobSchedule");
+    return blobSchedule == null ? "" : blobSchedule.toString();
+  }
+
+  /**
+   * Builds {@link BlobScheduleOptions} from the fixture's {@code config.blobSchedule}. Fork keys
+   * are lower-cased because Besu reads them as {@code cancun}/{@code prague}/{@code bpo1}..{@code
+   * bpo5} whereas fixtures use {@code Cancun}/{@code BPO1} etc.
+   *
+   * @return the blob schedule options, or empty when the fixture carries no blob schedule
+   */
+  public Optional<BlobScheduleOptions> getBlobScheduleOptions() {
+    final JsonNode blobSchedule = config == null ? null : config.get("blobSchedule");
+    if (blobSchedule == null || !blobSchedule.isObject()) {
+      return Optional.empty();
+    }
+    final ObjectNode root = ((ObjectNode) blobSchedule).objectNode();
+    final Iterator<Map.Entry<String, JsonNode>> forks = blobSchedule.fields();
+    while (forks.hasNext()) {
+      final Map.Entry<String, JsonNode> fork = forks.next();
+      final JsonNode value = fork.getValue();
+      if (!value.isObject()) {
+        continue;
+      }
+      // Besu's BlobSchedule reads numeric, all-lowercase keys (target/max/basefeeupdatefraction),
+      // but EELS fixtures encode the values as hex strings (e.g. "0x0e") under a camelCase
+      // baseFeeUpdateFraction; convert to lowercase numeric nodes.
+      final ObjectNode entry = root.objectNode();
+      entry.put("target", asInt(value.get("target")));
+      entry.put("max", asInt(value.get("max")));
+      entry.put("basefeeupdatefraction", asInt(value.get("baseFeeUpdateFraction")));
+      root.set(fork.getKey().toLowerCase(Locale.ROOT), entry);
+    }
+    return Optional.of(new BlobScheduleOptions(root));
+  }
+
+  private static int asInt(final JsonNode node) {
+    if (node == null || node.isNull()) {
+      return 0;
+    }
+    return node.isNumber() ? node.asInt() : Long.decode(node.asText().trim()).intValue();
+  }
+
+  public String getNetwork() {
+    return network;
+  }
+
+  public BlockchainReferenceTestCaseSpec.ReferenceTestBlockHeader getGenesisBlockHeader() {
+    return genesisBlockHeader;
+  }
+
+  public Map<String, ReferenceTestWorldState.AccountMock> getPre() {
+    return pre;
+  }
+
+  public Map<String, ReferenceTestWorldState.AccountMock> getPostState() {
+    return postState;
+  }
+
+  public Hash getLastBlockHash() {
+    return lastBlockHash;
+  }
+
+  public EngineNewPayload[] getEngineNewPayloads() {
+    return engineNewPayloads;
+  }
+
+  public MutableBlockchain buildBlockchain() {
+    final Block genesisBlock = new Block(genesisBlockHeader, BlockBody.empty());
+    return InMemoryKeyValueStorageProvider.createInMemoryBlockchain(genesisBlock);
+  }
+
+  public ProtocolContext buildProtocolContext(final MutableBlockchain blockchain) {
+    return new ProtocolContext.Builder()
+        .withBlockchain(blockchain)
+        .withWorldStateArchive(buildWorldStateArchive(blockchain))
+        .withConsensusContext(new ConsensusContextFixture())
+        .build();
+  }
+
+  /**
+   * Build a ProtocolContext with MergeContext for engine tests. The MergeContext is required by
+   * AbstractEngineNewPayload to determine terminal total difficulty and merge status.
+   */
+  public ProtocolContext buildProtocolContextForEngine(final MutableBlockchain blockchain) {
+    return new ProtocolContext.Builder()
+        .withBlockchain(blockchain)
+        .withWorldStateArchive(buildWorldStateArchive(blockchain))
+        .withConsensusContext(SHARED_MERGE_CONTEXT)
+        .build();
+  }
+
+  private WorldStateArchive buildWorldStateArchive(
+      final org.hyperledger.besu.ethereum.chain.Blockchain blockchain) {
+    final InMemoryKeyValueStorageProvider inMemoryKeyValueStorageProvider =
+        new InMemoryKeyValueStorageProvider();
+    final WorldStateArchive worldStateArchive =
+        new BonsaiWorldStateProvider(
+            (BonsaiWorldStateKeyValueStorage)
+                inMemoryKeyValueStorageProvider.createWorldStateStorage(
+                    DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
+            blockchain,
+            ImmutablePathBasedExtraStorageConfiguration.builder()
+                .maxLayersToLoad(engineNewPayloads != null ? (long) engineNewPayloads.length : 0L)
+                .build(),
+            SHARED_TRIE_LOADER,
+            SHARED_SERVICE_MANAGER,
+            EvmConfiguration.DEFAULT,
+            () -> (__, ___) -> {},
+            new PathBasedCodeCache());
+
+    final MutableWorldState worldState = worldStateArchive.getWorldState();
+    final WorldUpdater updater = worldState.updater();
+
+    if (pre != null) {
+      for (final Map.Entry<String, ReferenceTestWorldState.AccountMock> entry : pre.entrySet()) {
+        ReferenceTestWorldState.insertAccount(
+            updater, Address.fromHexString(entry.getKey()), entry.getValue());
+      }
+    }
+
+    updater.commit();
+    worldState.persist(null);
+
+    worldStateArchive.resetArchiveStateTo(genesisBlockHeader);
+    return worldStateArchive;
+  }
+
+  /** Represents a single engine_newPayload call from the fixture. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class EngineNewPayload {
+    private final JsonNode[] params;
+    private final String newPayloadVersion;
+    private final String forkchoiceUpdatedVersion;
+    private final String validationError;
+    private final String errorCode;
+
+    @JsonCreator
+    public EngineNewPayload(
+        @JsonProperty("params") final JsonNode[] params,
+        @JsonProperty("newPayloadVersion") final String newPayloadVersion,
+        @JsonProperty("forkchoiceUpdatedVersion") final String forkchoiceUpdatedVersion,
+        @JsonProperty("validationError") final String validationError,
+        @JsonProperty("errorCode") final String errorCode) {
+      this.params = params;
+      this.newPayloadVersion = newPayloadVersion;
+      this.forkchoiceUpdatedVersion = forkchoiceUpdatedVersion;
+      this.validationError = validationError;
+      this.errorCode = errorCode;
+    }
+
+    public JsonNode[] getParams() {
+      return params;
+    }
+
+    public int getNewPayloadVersion() {
+      return Integer.parseInt(newPayloadVersion != null ? newPayloadVersion : "1");
+    }
+
+    public int getForkchoiceUpdatedVersion() {
+      return Integer.parseInt(forkchoiceUpdatedVersion != null ? forkchoiceUpdatedVersion : "1");
+    }
+
+    public String getValidationError() {
+      return validationError;
+    }
+
+    public String getErrorCode() {
+      return errorCode;
+    }
+
+    /** Returns true if this payload is expected to be valid. */
+    public boolean expectsValid() {
+      return validationError == null && errorCode == null;
+    }
+
+    /** Returns the versioned hashes from params[1] (V3+), or null. */
+    public List<String> getVersionedHashes() {
+      if (params != null && params.length > 1 && params[1].isArray()) {
+        var result = new java.util.ArrayList<String>();
+        params[1].forEach(node -> result.add(node.asText()));
+        return result;
+      }
+      return null;
+    }
+
+    /** Returns the parent beacon block root from params[2] (V3+), or null. */
+    public String getBeaconRoot() {
+      if (params != null && params.length > 2 && params[2].isTextual()) {
+        return params[2].asText();
+      }
+      return null;
+    }
+
+    /** Returns the execution requests from params[3] (V4+), or null. */
+    public List<String> getExecutionRequests() {
+      if (params != null && params.length > 3 && params[3].isArray()) {
+        var result = new java.util.ArrayList<String>();
+        params[3].forEach(node -> result.add(node.asText()));
+        return result;
+      }
+      return null;
+    }
+  }
+}

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.referencetests;
 
+import org.hyperledger.besu.config.BlobScheduleOptions;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
@@ -68,6 +69,23 @@ public class ReferenceTestProtocolSchedules {
 
   public static ReferenceTestProtocolSchedules create(final EvmConfiguration evmConfiguration) {
     return create(new StubGenesisConfigOptions(), evmConfiguration);
+  }
+
+  /**
+   * Creates the reference-test schedules with a fixture-supplied blob schedule applied to every
+   * fork (used by engine/blockchain tests on devnets whose blob target/max differ from defaults).
+   *
+   * @param evmConfiguration the EVM configuration
+   * @param blobScheduleOptions the blob schedule from the fixture config, or null for defaults
+   * @return the schedules
+   */
+  public static ReferenceTestProtocolSchedules create(
+      final EvmConfiguration evmConfiguration, final BlobScheduleOptions blobScheduleOptions) {
+    final StubGenesisConfigOptions genesisStub = new StubGenesisConfigOptions();
+    if (blobScheduleOptions != null) {
+      genesisStub.blobScheduleOptions(blobScheduleOptions);
+    }
+    return create(genesisStub, evmConfiguration);
   }
 
   public static ReferenceTestProtocolSchedules create(
@@ -138,6 +156,11 @@ public class ReferenceTestProtocolSchedules {
                     "Paris",
                     createSchedule(genesisStub.clone().mergeNetSplitBlock(0), evmConfiguration)),
                 Map.entry(
+                    "ParisToShanghaiAtTime15k",
+                    createSchedule(
+                        genesisStub.clone().mergeNetSplitBlock(0).shanghaiTime(15000),
+                        evmConfiguration)),
+                Map.entry(
                     "Shanghai",
                     createSchedule(genesisStub.clone().shanghaiTime(0), evmConfiguration)),
                 Map.entry(
@@ -153,10 +176,69 @@ public class ReferenceTestProtocolSchedules {
                 Map.entry(
                     "Prague", createSchedule(genesisStub.clone().pragueTime(0), evmConfiguration)),
                 Map.entry(
-                    "Osaka", createSchedule(genesisStub.clone().osakaTime(0), evmConfiguration)),
+                    "PragueToOsakaAtTime15k",
+                    createSchedule(
+                        genesisStub.clone().pragueTime(0).osakaTime(15000), evmConfiguration)),
+                Map.entry(
+                    "Osaka",
+                    createSchedule(
+                        genesisStub.clone().pragueTime(0).osakaTime(0), evmConfiguration)),
+                Map.entry(
+                    "OsakaToBPO1AtTime15k",
+                    createSchedule(
+                        genesisStub.clone().pragueTime(0).osakaTime(0).bpo1Time(15000),
+                        evmConfiguration)),
+                Map.entry(
+                    "BPO1ToBPO2AtTime15k",
+                    createSchedule(
+                        genesisStub.clone().pragueTime(0).osakaTime(0).bpo1Time(0).bpo2Time(15000),
+                        evmConfiguration)),
+                Map.entry(
+                    "BPO2ToBPO3AtTime15k",
+                    createSchedule(
+                        genesisStub
+                            .clone()
+                            .pragueTime(0)
+                            .osakaTime(0)
+                            .bpo1Time(0)
+                            .bpo2Time(0)
+                            .bpo3Time(15000),
+                        evmConfiguration)),
+                Map.entry(
+                    "BPO3ToBPO4AtTime15k",
+                    createSchedule(
+                        genesisStub
+                            .clone()
+                            .pragueTime(0)
+                            .osakaTime(0)
+                            .bpo1Time(0)
+                            .bpo2Time(0)
+                            .bpo3Time(0)
+                            .bpo4Time(15000),
+                        evmConfiguration)),
                 Map.entry(
                     "Amsterdam",
-                    createSchedule(genesisStub.clone().amsterdamTime(0), evmConfiguration)),
+                    createSchedule(
+                        genesisStub
+                            .clone()
+                            .cancunTime(0)
+                            .pragueTime(0)
+                            .osakaTime(0)
+                            .bpo1Time(0)
+                            .bpo2Time(0)
+                            .amsterdamTime(0),
+                        evmConfiguration)),
+                Map.entry(
+                    "BPO2ToAmsterdamAtTime15k",
+                    createSchedule(
+                        genesisStub
+                            .clone()
+                            .pragueTime(0)
+                            .osakaTime(0)
+                            .bpo1Time(0)
+                            .bpo2Time(0)
+                            .amsterdamTime(15000),
+                        evmConfiguration)),
                 Map.entry(
                     "Bogota",
                     createSchedule(genesisStub.clone().futureEipsTime(0), evmConfiguration)),

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
@@ -175,6 +175,9 @@ public class ReferenceTestProtocolSchedules {
                         genesisStub.clone().cancunTime(0).pragueTime(15000), evmConfiguration)),
                 Map.entry(
                     "Prague", createSchedule(genesisStub.clone().pragueTime(0), evmConfiguration)),
+                // Forks left without an activation time are folded into the first configured
+                // milestone, so each entry only needs to give times to the forks that have to be
+                // told apart (the fork under test and, for transitions, the one it starts from).
                 Map.entry(
                     "PragueToOsakaAtTime15k",
                     createSchedule(
@@ -221,7 +224,6 @@ public class ReferenceTestProtocolSchedules {
                     createSchedule(
                         genesisStub
                             .clone()
-                            .cancunTime(0)
                             .pragueTime(0)
                             .osakaTime(0)
                             .bpo1Time(0)


### PR DESCRIPTION
## PR description

Adds `EngineTestCaseSpec` — the `blockchain_tests_engine` fixture model (payload sequence, expected JSON-RPC error codes, validation errors, per-fixture blob schedule) together with the blockchain and merge-aware protocol context those fixtures need in order to be replayed through the Engine API.

`ReferenceTestProtocolSchedules` gains:

- **The devnet transition networks** — `ParisToShanghai`, `PragueToOsaka`, `OsakaToBPO1`, `BPO1ToBPO2`, `BPO2ToBPO3`, `BPO3ToBPO4` and `BPO2ToAmsterdam`, all at time 15k. `getByName` is a plain lookup, so a fixture naming one of these previously resolved to `null` and was reported as an unsupported fork.
- **A `create(evmConfiguration, BlobScheduleOptions)` overload**, so a fixture's `config.blobSchedule` can be applied to every fork in the schedule instead of the harness falling back to mainnet blob defaults.
- **The full predecessor chain on the `Osaka` and `Amsterdam` entries.** Milestones are not implied by a later fork time: `EngineNewPayloadV4` requires `PRAGUE` to be present, and Amsterdam inherits its blob parameters from `bpo2`, so an entry that sets only its own fork time builds a schedule that does not match the devnet it claims to be.

## Testing

The transition entries and the predecessor chains apply to the existing JUnit `referenceTestsDevnet` gate too, since it reads the same map — so the shared-entry change is the thing worth checking here:

- `./gradlew :ethereum:referencetests:referenceTests --tests "*osaka*" --tests "*amsterdam*"` → **4407 tests, 0 failures**.
- `:ethereum:referencetests:compileJava` and `spotlessCheck` green.

## Notes

Part 2 of 3, splitting up #10184 (closed in favour of this stack). Stacked on #11028. `EngineTestCaseSpec` has no consumer until part 3.

Original work by @spencer-tb, preserved as commit author.
