### PR TITLE
Remove deprecated BFT genesis flag xemptyblockperiodseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
 - The genesis file `v5Bootnodes` key is removed; ENR bootnodes must now be listed in the unified `bootnodes` array alongside enode URLs. Besu's bundled network genesis files were migrated automatically - this only affects custom/downstream genesis files that still use the old `v5Bootnodes` key, whose ENR entries will otherwise be silently dropped.
 - Removed the legacy `PANTHEON_` environment variable prefix for configuration options, everyone should already use the `BESU_` prefix at this time.
 - Removed `--min-block-occupancy-ratio` option. The flag has been a silent no-op since 26.4.0. [#11017](https://github.com/besu-eth/besu/pull/11017)
+- Removed BFT genesis config key `xemptyblockperiodseconds` (deprecated since 26.5.0). Use `emptyblockperiodseconds` instead.
 - Removed the custom `engine_preparePayload_debug` RPC methods, use the standard `testing_buildBlockV1` instead. [#11011](https://github.com/besu-eth/besu/pull/11011)
 
 ### Upcoming Breaking Changes
 - Plugin API
   - `PluginTransactionSelectorFactory.create(final SelectorsStateManager selectorsStateManager)` is deprecated for removal
-- BFT option `xemptyblockperiodseconds` has been taken out of experimental and been renamed `emptyblockperiodseconds`. The old config option is deprecated and will be removed in a future release.
 - `--Xbft-legacy-protocol-encoding` will be removed once Besu 25.x is no longer supported. [#10499](https://github.com/besu-eth/besu/pull/10499)
 - `--Xsnapsync-synchronizer-pivot-block-distance-before-caching` is deprecated and will be removed in a future release; the flag is now a silent no-op.
 - `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` is deprecated and will be removed in a future release; the flag is now a silent no-op.

--- a/config/src/main/java/org/hyperledger/besu/config/BftFork.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BftFork.java
@@ -22,20 +22,15 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** The Bft fork. */
 public class BftFork implements Fork {
-
-  private static final Logger LOG = LoggerFactory.getLogger(BftFork.class);
 
   /** The constant FORK_BLOCK_KEY. */
   public static final String FORK_BLOCK_KEY = "block";
@@ -45,13 +40,6 @@ public class BftFork implements Fork {
 
   /** The constant BLOCK_PERIOD_SECONDS_KEY. */
   public static final String BLOCK_PERIOD_SECONDS_KEY = "blockperiodseconds";
-
-  /**
-   * The deprecated config key for the empty block period (replaced by {@link
-   * #EMPTY_BLOCK_PERIOD_SECONDS_KEY}).
-   */
-  @Deprecated
-  public static final String X_EMPTY_BLOCK_PERIOD_SECONDS_KEY = "xemptyblockperiodseconds";
 
   /** The constant EMPTY_BLOCK_PERIOD_SECONDS_KEY. */
   public static final String EMPTY_BLOCK_PERIOD_SECONDS_KEY = "emptyblockperiodseconds";
@@ -70,10 +58,6 @@ public class BftFork implements Fork {
 
   /** The Fork config root. */
   protected final ObjectNode forkConfigRoot;
-
-  // Ensures the deprecation warning for xemptyblockperiodseconds is emitted at most once
-  // per BftFork instance.
-  private final AtomicBoolean emptyBlockPeriodDeprecationWarned = new AtomicBoolean(false);
 
   /**
    * Instantiates a new Bft fork.
@@ -111,44 +95,11 @@ public class BftFork implements Fork {
   /**
    * Gets empty block period seconds.
    *
-   * <p>If both the new and deprecated keys are set in this fork config, the new key wins and a
-   * deprecation warning is emitted. If only the deprecated key is set, it is used and a deprecation
-   * warning is emitted.
-   *
    * @return the empty block period seconds
    */
   public OptionalInt getEmptyBlockPeriodSeconds() {
     // It can be 0 to disable custom empty block periods
-    final OptionalInt newValue = JsonUtil.getInt(forkConfigRoot, EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    final OptionalInt deprecatedValue =
-        JsonUtil.getInt(forkConfigRoot, X_EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    if (deprecatedValue.isPresent()) {
-      maybeLogEmptyBlockPeriodDeprecationWarning(newValue.isPresent());
-    }
-    return newValue.isPresent() ? newValue : deprecatedValue;
-  }
-
-  private void maybeLogEmptyBlockPeriodDeprecationWarning(final boolean newKeyAlsoSet) {
-    if (!emptyBlockPeriodDeprecationWarned.compareAndSet(false, true)) {
-      return;
-    }
-    final long forkBlock = JsonUtil.getLong(forkConfigRoot, FORK_BLOCK_KEY).orElse(-1L);
-    if (newKeyAlsoSet) {
-      LOG.warn(
-          "Transition fork at block {} specifies both '{}' (deprecated) and '{}'. "
-              + "The deprecated '{}' is being ignored; please remove it from the transition config.",
-          forkBlock,
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    } else {
-      LOG.warn(
-          "Transition fork at block {} uses deprecated option '{}'. "
-              + "Please rename it to '{}'. The deprecated name will be removed in a future release.",
-          forkBlock,
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    }
+    return JsonUtil.getInt(forkConfigRoot, EMPTY_BLOCK_PERIOD_SECONDS_KEY);
   }
 
   /**

--- a/config/src/main/java/org/hyperledger/besu/config/JsonBftConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonBftConfigOptions.java
@@ -21,18 +21,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** The Json Bft config options. */
 public class JsonBftConfigOptions implements BftConfigOptions {
-
-  private static final Logger LOG = LoggerFactory.getLogger(JsonBftConfigOptions.class);
 
   /** The constant DEFAULT. */
   public static final JsonBftConfigOptions DEFAULT =
@@ -40,13 +35,6 @@ public class JsonBftConfigOptions implements BftConfigOptions {
 
   /** The constant EMPTY_BLOCK_PERIOD_SECONDS_KEY. */
   public static final String EMPTY_BLOCK_PERIOD_SECONDS_KEY = "emptyblockperiodseconds";
-
-  /**
-   * The deprecated config key for the empty block period (replaced by {@link
-   * #EMPTY_BLOCK_PERIOD_SECONDS_KEY}).
-   */
-  @Deprecated
-  public static final String X_EMPTY_BLOCK_PERIOD_SECONDS_KEY = "xemptyblockperiodseconds";
 
   private static final long DEFAULT_EPOCH_LENGTH = 30_000;
   private static final int DEFAULT_BLOCK_PERIOD_SECONDS = 1;
@@ -67,10 +55,6 @@ public class JsonBftConfigOptions implements BftConfigOptions {
 
   /** The Bft config root. */
   protected final ObjectNode bftConfigRoot;
-
-  // Ensures the deprecation warning for xemptyblockperiodseconds is emitted at most once
-  // per JsonBftConfigOptions instance.
-  private final AtomicBoolean emptyBlockPeriodDeprecationWarned = new AtomicBoolean(false);
 
   /**
    * Instantiates a new Json bft config options.
@@ -94,37 +78,8 @@ public class JsonBftConfigOptions implements BftConfigOptions {
 
   @Override
   public int getEmptyBlockPeriodSeconds() {
-    final boolean hasNewKey = bftConfigRoot.has(EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    final boolean hasDeprecatedKey = bftConfigRoot.has(X_EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    if (hasDeprecatedKey) {
-      maybeLogEmptyBlockPeriodDeprecationWarning(hasNewKey);
-    }
-    if (hasNewKey) {
-      return JsonUtil.getInt(
-          bftConfigRoot, EMPTY_BLOCK_PERIOD_SECONDS_KEY, DEFAULT_EMPTY_BLOCK_PERIOD_SECONDS);
-    }
     return JsonUtil.getInt(
-        bftConfigRoot, X_EMPTY_BLOCK_PERIOD_SECONDS_KEY, DEFAULT_EMPTY_BLOCK_PERIOD_SECONDS);
-  }
-
-  private void maybeLogEmptyBlockPeriodDeprecationWarning(final boolean newKeyAlsoSet) {
-    if (!emptyBlockPeriodDeprecationWarned.compareAndSet(false, true)) {
-      return;
-    }
-    if (newKeyAlsoSet) {
-      LOG.warn(
-          "Genesis BFT config specifies both '{}' (deprecated) and '{}'. "
-              + "The deprecated '{}' is being ignored; please remove it from the genesis file.",
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    } else {
-      LOG.warn(
-          "Genesis BFT config uses deprecated option '{}'. "
-              + "Please rename it to '{}'. The deprecated name will be removed in a future release.",
-          X_EMPTY_BLOCK_PERIOD_SECONDS_KEY,
-          EMPTY_BLOCK_PERIOD_SECONDS_KEY);
-    }
+        bftConfigRoot, EMPTY_BLOCK_PERIOD_SECONDS_KEY, DEFAULT_EMPTY_BLOCK_PERIOD_SECONDS);
   }
 
   @Override

--- a/config/src/test/java/org/hyperledger/besu/config/BFTForkTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/BFTForkTest.java
@@ -18,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -139,29 +138,6 @@ public class BFTForkTest {
                 BftFork.EMPTY_BLOCK_PERIOD_SECONDS_KEY, 60));
 
     final BftFork bftFork = new BftFork(config);
-    assertThat(bftFork.getEmptyBlockPeriodSeconds()).hasValue(60);
-  }
-
-  @Test
-  public void getEmptyBlockPeriodSeconds_fromDeprecatedKey() {
-    final ObjectNode config =
-        JsonUtil.objectNodeFromMap(
-            Map.of(
-                BftFork.FORK_BLOCK_KEY, 10,
-                BftFork.X_EMPTY_BLOCK_PERIOD_SECONDS_KEY, 45));
-
-    final BftFork bftFork = new BftFork(config);
-    assertThat(bftFork.getEmptyBlockPeriodSeconds()).hasValue(45);
-  }
-
-  @Test
-  public void getEmptyBlockPeriodSeconds_newKeyWinsOverDeprecatedWhenBothSet() {
-    final Map<String, Object> raw = new HashMap<>();
-    raw.put(BftFork.FORK_BLOCK_KEY, 10);
-    raw.put(BftFork.EMPTY_BLOCK_PERIOD_SECONDS_KEY, 60);
-    raw.put(BftFork.X_EMPTY_BLOCK_PERIOD_SECONDS_KEY, 30);
-
-    final BftFork bftFork = new BftFork(JsonUtil.objectNodeFromMap(raw));
     assertThat(bftFork.getEmptyBlockPeriodSeconds()).hasValue(60);
   }
 

--- a/config/src/test/java/org/hyperledger/besu/config/JsonBftConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonBftConfigOptionsTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.datatypes.Address;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -71,21 +70,6 @@ public class JsonBftConfigOptionsTest {
   }
 
   @Test
-  public void shouldGetEmptyBlockPeriodFromDeprecatedConfigKey() {
-    final BftConfigOptions config = fromConfigOptions(singletonMap("xemptyblockperiodseconds", 60));
-    assertThat(config.getEmptyBlockPeriodSeconds()).isEqualTo(60);
-  }
-
-  @Test
-  public void shouldPreferNewEmptyBlockPeriodOverDeprecatedWhenBothSet() {
-    final Map<String, Object> options = new HashMap<>();
-    options.put("emptyblockperiodseconds", 60);
-    options.put("xemptyblockperiodseconds", 30);
-    final BftConfigOptions config = fromConfigOptions(options);
-    assertThat(config.getEmptyBlockPeriodSeconds()).isEqualTo(60);
-  }
-
-  @Test
   public void shouldFallbackToDefaultBlockPeriod() {
     final BftConfigOptions config = fromConfigOptions(emptyMap());
     assertThat(config.getBlockPeriodSeconds()).isEqualTo(EXPECTED_DEFAULT_BLOCK_PERIOD);
@@ -121,13 +105,6 @@ public class JsonBftConfigOptionsTest {
   public void shouldNotThrowOnNonPositiveEmptyBlockPeriod() {
     // can be 0 to be compatible with older versions
     final BftConfigOptions config = fromConfigOptions(singletonMap("emptyblockperiodseconds", 0));
-    assertThatCode(() -> config.getEmptyBlockPeriodSeconds()).doesNotThrowAnyException();
-  }
-
-  @Test
-  public void shouldNotThrowOnNonPositiveEmptyBlockPeriodForDeprecatedKey() {
-    // can be 0 to be compatible with older versions
-    final BftConfigOptions config = fromConfigOptions(singletonMap("xemptyblockperiodseconds", 0));
     assertThatCode(() -> config.getEmptyBlockPeriodSeconds()).doesNotThrowAnyException();
   }
 


### PR DESCRIPTION
The xemptyblockperiodseconds key has been deprecated since 26.5.0 with emptyblockperiodseconds as the replacement. Remove the fallback logic, deprecation warnings, and associated tests.
