### PR TITLE
Fix genesis slotNumber parsing and require the header field from Amsterdam

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfig.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfig.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /** The Genesis config file. */
@@ -271,7 +272,13 @@ public class GenesisConfig {
    * @return the slot number
    */
   public String getSlotNumber() {
-    return JsonUtil.getValueAsString(genesisRoot, "slotnumber", "0x0");
+    final JsonNode node = genesisRoot.get("slotnumber");
+    if (node == null) {
+      return "0x0";
+    }
+    // JSON numbers are decimal; hex-encode so callers parse hex like
+    // every other genesis field.
+    return node.isNumber() ? "0x" + Long.toHexString(node.asLong()) : node.asText();
   }
 
   /**

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigTest.java
@@ -295,6 +295,11 @@ class GenesisConfigTest {
   }
 
   @Test
+  void shouldGetSlotNumberFromJsonNumber() {
+    assertThat(fromConfig("{\"slotNumber\":999}").getSlotNumber()).isEqualTo("0x3e7");
+  }
+
+  @Test
   void shouldDefaultSlotNumberToZero() {
     assertThat(EMPTY_CONFIG.getSlotNumber()).isEqualTo("0x0");
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoBlobRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoDifficultyRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoNonceRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.RequestsHashPresentValidationRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.SlotNumberPresentValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMoreRecentThanParent;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -147,5 +148,13 @@ public final class MainnetBlockHeaderValidator {
       final GasLimitCalculator gasLimitCalculator) {
     return blobAwareBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
         .addRule(new RequestsHashPresentValidationRule());
+  }
+
+  public static BlockHeaderValidator.Builder amsterdamBlockHeaderValidator(
+      final FeeMarket feeMarket,
+      final GasCalculator gasCalculator,
+      final GasLimitCalculator gasLimitCalculator) {
+    return requestsAwareBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
+        .addRule(new SlotNumberPresentValidationRule());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -1291,6 +1291,9 @@ public abstract class MainnetProtocolSpecs {
             // Amsterdam: Validator uses pre-refund gas_metered = max(regular, state) from
             // processing
             .blockGasUsedValidator(BlockGasUsedValidator.AMSTERDAM)
+            // EIP-7843: slotNumber header field is mandatory from Amsterdam onwards
+            .blockHeaderValidatorBuilder(
+                MainnetBlockHeaderValidator::amsterdamBlockHeaderValidator)
             .hardforkId(AMSTERDAM);
 
     // EIP-8282 introduces the builder deposit (0x03) and builder exit (0x04) system-contract

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ensures that a block header carries the {@code slotNumber} field once EIP-7843 is active. From
+ * Amsterdam onwards every block header must include {@code slotNumber}, including slot zero. A
+ * header that omits the field entirely is malformed regardless of its block body, so this presence
+ * check is intentionally independent of the parent header.
+ */
+public class SlotNumberPresentValidationRule implements DetachedBlockHeaderValidationRule {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SlotNumberPresentValidationRule.class);
+
+  @Override
+  public boolean validate(final BlockHeader header, final BlockHeader parent) {
+    if (header.getOptionalSlotNumber().isEmpty()) {
+      LOG.info(
+          "Invalid block header: slotNumber field is required from Amsterdam onwards but is missing");
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "SlotNumberPresent";
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRuleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRuleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+
+import org.junit.jupiter.api.Test;
+
+class SlotNumberPresentValidationRuleTest {
+
+  private final SlotNumberPresentValidationRule rule = new SlotNumberPresentValidationRule();
+
+  @Test
+  void rejectsHeaderWithMissingSlotNumber() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().slotNumber(null).buildHeader();
+
+    assertThat(header.getOptionalSlotNumber()).isEmpty();
+    assertThat(rule.validate(header, parent)).isFalse();
+  }
+
+  @Test
+  void acceptsHeaderWithSlotNumberZero() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().slotNumber(0L).buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void acceptsHeaderWithPopulatedSlotNumber() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().slotNumber(999L).buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void includedInLightValidation() {
+    // slotNumber presence is a detached header property and must be enforced even on the
+    // light-validation sync path.
+    assertThat(rule.includeInLightValidation()).isTrue();
+  }
+}


### PR DESCRIPTION
Two EIP-7843 `slotNumber` fixes, covering all three besu `eip7843_slotnum` failures on hive glamsterdam-quick (fixtures `tests-glamsterdam-devnet@v8.1.0`).

Example run: https://hive.ethpandaops.io/#/test/glamsterdam-quick/1786549384-264b0fb999b2d081299a3f589120dd18

**1. Parse genesis slotNumber from JSON numbers as decimal** (`test_slotnum_genesis`)

geth's de-facto genesis format types `slotNumber` as `HexOrDecimal64`, so a raw JSON number is decimal. `GenesisConfig.getSlotNumber()` returned the node's `asText()` (`"999"`) and `GenesisState.parseUnsignedLong` always parses base-16, yielding `0x999` = 2457: consume-rlp reports `slot_number: expected 0x03e7, got 0x0999`; consume-engine shows the genesis forkchoice update stuck `SYNCING`. Fix: hex-encode numeric nodes in `getSlotNumber()` so the existing hex parsing downstream is correct; string values are handled as before. (A companion execution-specs PR switches the simulator to emit hex strings, which also unblocks current besu; this hardens besu against decimal-number genesis files, which remain valid in the geth format.)

**2. Require slotNumber header field from Amsterdam onwards** (`test_invalid_post_fork_block_without_slot_number`)

Block import accepted an Amsterdam block whose header omits `slotNumber`: the count-based header RLP decode leaves the field null and no validation rule checked its presence, so the invalid block was imported (consume-rlp: client's head advanced to the bad block; the engine path already rejects it as a missing `engine_newPayloadV5` parameter, which masked the gap). Fix: `SlotNumberPresentValidationRule`, wired into a new `amsterdamBlockHeaderValidator` on top of the inherited requests-aware validator, mirroring how `RequestsHashPresentValidationRule` enforces `requestsHash` from Prague.
