### PR TITLE
snap/2 - add metrics

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/BalStats.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/BalStats.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync;
+
+public record BalStats(long blocksApplied, long accounts, long storageSlots, long storageRoots) {
+  public static final BalStats EMPTY = new BalStats(0, 0, 0, 0);
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncMetricsManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncMetricsManager.java
@@ -74,6 +74,18 @@ public class SnapSyncMetricsManager {
   /** Represents the number of trie nodes healed during the healing process. */
   private final AtomicLong nbTrieNodesHealed;
 
+  private final AtomicLong nbPivotCatchups;
+
+  private final AtomicLong nbReorgRecoveries;
+
+  private final AtomicLong nbBalBlocksApplied;
+
+  private final AtomicLong nbBalAccountsApplied;
+
+  private final AtomicLong nbBalStorageSlotsApplied;
+
+  private final AtomicLong nbBalStorageRootsApplied;
+
   private long startSyncTime;
 
   private final Map<Bytes32, BigInteger> lastRangeIndex = new HashMap<>();
@@ -91,6 +103,12 @@ public class SnapSyncMetricsManager {
     nbFlatAccountsHealed = new AtomicLong(0);
     nbFlatSlotsHealed = new AtomicLong(0);
     nbTrieNodesHealed = new AtomicLong(0);
+    nbPivotCatchups = new AtomicLong(0);
+    nbReorgRecoveries = new AtomicLong(0);
+    nbBalBlocksApplied = new AtomicLong(0);
+    nbBalAccountsApplied = new AtomicLong(0);
+    nbBalStorageSlotsApplied = new AtomicLong(0);
+    nbBalStorageRootsApplied = new AtomicLong(0);
     metricsSystem.createCounter(
         BesuMetricCategory.SYNCHRONIZER,
         "snap_world_state_generated_nodes_total",
@@ -126,6 +144,36 @@ public class SnapSyncMetricsManager {
         "snap_world_state_codes_total",
         "Total number of codes downloaded as part of snap sync world state",
         nbCodes::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_pivot_catchups_total",
+        "Total number of snap/2 pivot catch-up cycles completed without a reorg",
+        nbPivotCatchups::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_reorg_recoveries_total",
+        "Total number of snap/2 pivot catch-up cycles that triggered reorg recovery",
+        nbReorgRecoveries::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_bal_blocks_applied_total",
+        "Total number of non-empty BALs applied during snap/2 catch-up",
+        nbBalBlocksApplied::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_bal_accounts_applied_total",
+        "Total number of accounts applied from BALs during snap/2 catch-up",
+        nbBalAccountsApplied::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_bal_storage_slots_applied_total",
+        "Total number of storage slots applied from BALs during snap/2 catch-up",
+        nbBalStorageSlotsApplied::get);
+    metricsSystem.createCounter(
+        BesuMetricCategory.SYNCHRONIZER,
+        "snap_v2_bal_storage_roots_applied_total",
+        "Total number of storage roots updated from BALs during snap/2 catch-up",
+        nbBalStorageRootsApplied::get);
   }
 
   public void initRange(final Map<Bytes32, Bytes32> ranges) {
@@ -173,6 +221,21 @@ public class SnapSyncMetricsManager {
   public void notifyTrieNodesHealed(final long nbNodes) {
     this.nbTrieNodesHealed.getAndAdd(nbNodes);
     print(HEAL_TRIE);
+  }
+
+  public void incrementPivotCatchups() {
+    this.nbPivotCatchups.incrementAndGet();
+  }
+
+  public void incrementReorgRecoveries() {
+    this.nbReorgRecoveries.incrementAndGet();
+  }
+
+  public void addBalStats(final BalStats stats) {
+    this.nbBalBlocksApplied.getAndAdd(stats.blocksApplied());
+    this.nbBalAccountsApplied.getAndAdd(stats.accounts());
+    this.nbBalStorageSlotsApplied.getAndAdd(stats.storageSlots());
+    this.nbBalStorageRootsApplied.getAndAdd(stats.storageRoots());
   }
 
   private void print(final Step step) {
@@ -226,6 +289,17 @@ public class SnapSyncMetricsManager {
         duration.toMinutesPart(),
         duration.toSecondsPart(),
         duration.toMillisPart());
+    if (nbPivotCatchups.get() > 0 || nbReorgRecoveries.get() > 0) {
+      LOG.info(
+          "snap/2 catch-up summary: pivot catch-ups={}, reorg recoveries={}, BAL blocks applied={}, "
+              + "accounts applied={}, storage slots applied={}, storage roots updated={}",
+          nbPivotCatchups.get(),
+          nbReorgRecoveries.get(),
+          nbBalBlocksApplied.get(),
+          nbBalAccountsApplied.get(),
+          nbBalStorageSlotsApplied.get(),
+          nbBalStorageRootsApplied.get());
+    }
   }
 
   public MetricsSystem getMetricsSystem() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplier.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.BalStats;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStateDownloaderException;
@@ -89,32 +90,38 @@ public class SnapV2BlockAccessListApplier {
     final WorldStateKeyValueStorage.Updater updater = worldStateStorageCoordinator.updater();
     final MerkleTrie<Bytes, Bytes> accountTrie = openAccountTrie();
 
-    final Map<Hash, PerAccountChanges> changes =
+    final CollectedChanges collected =
         collectAccountChanges(fromBlock, toBlock, accountRangeTracker);
-    if (changes.isEmpty()) {
+    if (collected.changes().isEmpty()) {
       LOG.info("No persisted accounts affected by BALs in blocks [{}, {}]", fromBlock, toBlock);
-      return new BatchState(accountTrie, updater);
+      return new BatchState(accountTrie, updater, new BalStats(collected.blocksApplied(), 0, 0, 0));
     }
 
     final BalApplicationStats stats =
         stageAccountChanges(
-            changes, accountTrie, updater, storageRangeTracker, accountRangeTracker);
+            collected.changes(), accountTrie, updater, storageRangeTracker, accountRangeTracker);
 
     LOG.info(
-        "Applied snap/2 BALs: {} accounts, {} storage slots, {} storage roots updated",
+        "Applied snap/2 BALs: {} blocks, {} accounts, {} storage slots, {} storage roots updated",
+        collected.blocksApplied(),
         stats.accounts,
         stats.storageSlots,
         stats.storageRoots);
 
-    return new BatchState(accountTrie, updater);
+    return new BatchState(
+        accountTrie,
+        updater,
+        new BalStats(
+            collected.blocksApplied(), stats.accounts, stats.storageSlots, stats.storageRoots));
   }
 
-  private Map<Hash, PerAccountChanges> collectAccountChanges(
+  private CollectedChanges collectAccountChanges(
       final long fromBlock,
       final long toBlock,
       final DownloadedAccountRangeTracker accountRangeTracker) {
 
     final Map<Hash, PerAccountChanges> changesByHash = new LinkedHashMap<>();
+    int blocksApplied = 0;
 
     for (long blockNumber = fromBlock; blockNumber <= toBlock; blockNumber++) {
       final BlockHeader blockHeader = loadBlockHeader(blockNumber);
@@ -131,6 +138,8 @@ public class SnapV2BlockAccessListApplier {
         continue;
       }
 
+      blocksApplied++;
+
       for (final BlockAccessListChanges.AccountFinalChanges afc :
           BlockAccessListChanges.latestChanges(bal)) {
         final Hash accountHash = afc.address().addressHash();
@@ -144,7 +153,7 @@ public class SnapV2BlockAccessListApplier {
       }
     }
 
-    return changesByHash;
+    return new CollectedChanges(changesByHash, blocksApplied);
   }
 
   public Set<Hash> collectPendingStorageAffected(
@@ -740,8 +749,12 @@ public class SnapV2BlockAccessListApplier {
 
   private record BalApplicationStats(int accounts, int storageSlots, int storageRoots) {}
 
+  private record CollectedChanges(Map<Hash, PerAccountChanges> changes, int blocksApplied) {}
+
   record BatchState(
-      MerkleTrie<Bytes, Bytes> accountTrie, WorldStateKeyValueStorage.Updater updater) {
+      MerkleTrie<Bytes, Bytes> accountTrie,
+      WorldStateKeyValueStorage.Updater updater,
+      BalStats stats) {
     void commit() {
       stageAccountTrieChanges(accountTrie, updater);
       updater.commit();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadState.java
@@ -518,6 +518,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
           pendingCodeRequests.outstandingTaskCount());
       pivotCatchupFuture = new CompletableFuture<>();
       pivotCatchupStartMillis = System.currentTimeMillis();
+      syncDurationMetrics.startTimer(SyncDurationMetrics.Labels.SNAP_V2_PIVOT_CATCHUP_DURATION);
       maybeCompleteInFlightTasks(); // handle case of 0 in-flight tasks when catchup starts
     }
 
@@ -550,6 +551,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
   }
 
   private synchronized void failPivotCatchup(final Throwable error) {
+    syncDurationMetrics.stopTimer(SyncDurationMetrics.Labels.SNAP_V2_PIVOT_CATCHUP_DURATION);
     pivotCatchupStartMillis = 0;
     pivotCatchupFuture = null;
     chainCatchupFuture = null;
@@ -561,6 +563,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
       final BlockHeader currentPivotBlockHeader, final BlockHeader newPivotBlockHeader) {
     synchronized (this) {
       if (isStateDownloadFinished()) {
+        syncDurationMetrics.stopTimer(SyncDurationMetrics.Labels.SNAP_V2_PIVOT_CATCHUP_DURATION);
         return;
       }
       // Drain in-flight tasks started when dequeue was allowed while the chain catch-up ran.
@@ -599,6 +602,8 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
           correctRoots = rootsFuture.join();
           final int patched = blockAccessListApplier.patchStorageRoots(batch, correctRoots);
           batch.commit();
+          metricsManager.incrementPivotCatchups();
+          metricsManager.addBalStats(batch.stats());
           LOG.debug(
               "snap/2 pivot catch-up ({} -> {}): {} storage roots patched",
               currentPivotBlockHeader.getNumber(),
@@ -630,6 +635,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
               newPivotBlockHeader.getNumber(),
               recovery.deletedAccounts().size(),
               purged);
+          metricsManager.incrementReorgRecoveries();
           correctRoots = recovery.correctedStorageRoots();
         }
         retargetQueuedRequests(newPivotBlockHeader, correctRoots);
@@ -643,6 +649,7 @@ public class SnapV2WorldDownloadState extends WorldDownloadState<SnapDataRequest
         failPivotCatchup(e);
         return;
       }
+      syncDurationMetrics.stopTimer(SyncDurationMetrics.Labels.SNAP_V2_PIVOT_CATCHUP_DURATION);
       pivotCatchupFuture = null;
       chainCatchupFuture = null;
       pivotCatchupStartMillis = 0;

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/SyncDurationMetrics.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/SyncDurationMetrics.java
@@ -87,6 +87,8 @@ public class SyncDurationMetrics {
     /** Time taken to heal the world state, after the initial download. */
     SNAP_WORLD_STATE_HEALING_DURATION,
     /** Time taken to do the flat database heal. */
-    FLAT_DB_HEAL;
+    FLAT_DB_HEAL,
+    /** Time taken by a snap/2 pivot catch-up cycle. Multiple catch-ups may occur during a sync. */
+    SNAP_V2_PIVOT_CATCHUP_DURATION;
   }
 }


### PR DESCRIPTION
Improves snap/2 observability.

**New counters**
- `snap_v2_pivot_catchups_total` - catch-up cycles completed without reorg
- `snap_v2_reorg_recoveries_total` - catch-up cycles that triggered reorg recovery
- `snap_v2_bal_blocks_applied_total` / `..._accounts_...` / `..._storage_slots_...` / `..._storage_roots_...` - BAL application throughput

**New timer**
- `SNAP_V2_PIVOT_CATCHUP_DURATION` - catch-up duration