### PR TITLE
Deprecate PoaQueryService and BftQueryService for removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Upcoming Breaking Changes
 - Plugin API
   - `PluginTransactionSelectorFactory.create(final SelectorsStateManager selectorsStateManager)` is deprecated for removal
+  - `PoaQueryService` and `BftQueryService` are deprecated and will be removed in a future release, with no replacement. They have no known usage
 - `--Xbft-legacy-protocol-encoding` will be removed once Besu 25.x is no longer supported. [#10499](https://github.com/besu-eth/besu/pull/10499)
 - `--Xsnapsync-synchronizer-pivot-block-distance-before-caching` is deprecated and will be removed in a future release; the flag is now a silent no-op.
 - `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` is deprecated and will be removed in a future release; the flag is now a silent no-op.

--- a/app/src/main/java/org/hyperledger/besu/controller/BftQueryPluginServiceFactory.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BftQueryPluginServiceFactory.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.plugin.services.query.PoaQueryService;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
 
 /** Bft query plugin service factory which is a concrete implementation of PluginServiceFactory. */
+@SuppressWarnings("removal")
 public class BftQueryPluginServiceFactory implements PluginServiceFactory {
 
   private final Blockchain blockchain;

--- a/app/src/main/java/org/hyperledger/besu/controller/IbftQueryPluginServiceFactory.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/IbftQueryPluginServiceFactory.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.plugin.services.query.PoaQueryService;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
 
 /** The IBFT query plugin service factory. */
+@SuppressWarnings("removal")
 public class IbftQueryPluginServiceFactory implements PluginServiceFactory {
 
   private final Blockchain blockchain;

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/PoaQueryServiceImpl.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/PoaQueryServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 /** The Poa query service. */
+@SuppressWarnings("removal")
 public class PoaQueryServiceImpl implements PoaQueryService {
 
   private final BlockInterface blockInterface;

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/queries/BftQueryServiceImpl.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/queries/BftQueryServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import org.apache.tuweni.bytes.Bytes32;
 
 /** The Bft query service. */
+@SuppressWarnings("removal")
 public class BftQueryServiceImpl extends PoaQueryServiceImpl implements BftQueryService {
 
   private final ValidatorProvider validatorProvider;

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/queries/BftQueryServiceImplTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/queries/BftQueryServiceImplTest.java
@@ -49,6 +49,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("removal")
 public class BftQueryServiceImplTest {
 
   @Mock private Blockchain blockchain;

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImpl.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImpl.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import org.apache.tuweni.bytes.Bytes32;
 
 /** The Ibft query service. */
+@SuppressWarnings("removal")
 public class IbftQueryServiceImpl extends PoaQueryServiceImpl implements BftQueryService {
 
   private final BftBlockInterface blockInterface;

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/query/BftQueryService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/query/BftQueryService.java
@@ -19,7 +19,14 @@ import org.hyperledger.besu.plugin.data.BlockHeader;
 
 import java.util.Collection;
 
-/** Allows for the BFT specific aspects of the block chain to be queried. */
+/**
+ * Allows for the BFT specific aspects of the block chain to be queried.
+ *
+ * @deprecated This service is scheduled for removal in a future release, with no replacement, as it
+ *     has no known usage.
+ */
+@Deprecated(forRemoval = true)
+@SuppressWarnings("removal")
 public interface BftQueryService extends PoaQueryService {
 
   /**

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/query/PoaQueryService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/query/PoaQueryService.java
@@ -20,7 +20,13 @@ import org.hyperledger.besu.plugin.services.BesuService;
 
 import java.util.Collection;
 
-/** Provides methods to query the status of a Proof of Authority (PoA) network. */
+/**
+ * Provides methods to query the status of a Proof of Authority (PoA) network.
+ *
+ * @deprecated This service is scheduled for removal in a future release, with no replacement, as it
+ *     has no known usage.
+ */
+@Deprecated(forRemoval = true)
 public interface PoaQueryService extends BesuService {
 
   /**


### PR DESCRIPTION
## Fixed Issue(s)
fixes #11035

## Description

Following the discussion on #11035, `PoaQueryService` and `BftQueryService` are deprecated for removal instead of being extracted into their own module. Both services have no known usage inside Besu, in the ConsenSys plugin repos or in any public repository.

Both interfaces are annotated `@Deprecated(forRemoval = true)` with a javadoc note, so plugin authors see the warning in their IDE and at compile time. The resulting removal warnings at the internal reference sites (the three implementations, the two registration factories and one test) are suppressed, since that machinery keeps the services working until the removal. The annotation is additive, so the compatibility gate stays green. Removal follows in a future release.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs). The plugin interfaces docs page will need updating when the removal lands.
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests. No database changes in this PR.

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
