### PR TITLE
Execute Engine API methods concurrently except ordered forkchoiceUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Extract the Plugin API chain module. The blockchain query, RLP conversion and block-view contracts (`BlockchainService`, `RlpConverterService` and the `BlockContext`, `AddedBlockContext`, `PropagatedBlockContext`, `BadBlockCause` and `LogWithMetadata` data interfaces) now live in a new `besu-plugin-api-chain` artifact, re-exported by `besu-plugin-api` so existing consumers are unaffected. [#11110](https://github.com/besu-eth/besu/pull/11110)
 - Add `--p2p-discovery-port` and `--p2p-discovery-port-ipv6` flags to configure a separate UDP port for devp2p peer discovery, independent of the TCP p2p port. Specify `0` to request an ephemeral port from the OS. [#10718](https://github.com/besu-eth/besu/pull/10718)
 - Pending peer request iteration: `streamAvailablePeers()` scan replaced with an allocation-free capacity check. Reduces lock contention and GC pressure under a backlog of pending peer requests. [#10900](https://github.com/besu-eth/besu/pull/10900)
-- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` and `engine_newPayload` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout. 
+- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` and `engine_newPayload` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout. [#11053](https://github.com/besu-eth/besu/pull/11053)
 
 ## 26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Extract the Plugin API chain module. The blockchain query, RLP conversion and block-view contracts (`BlockchainService`, `RlpConverterService` and the `BlockContext`, `AddedBlockContext`, `PropagatedBlockContext`, `BadBlockCause` and `LogWithMetadata` data interfaces) now live in a new `besu-plugin-api-chain` artifact, re-exported by `besu-plugin-api` so existing consumers are unaffected. [#11110](https://github.com/besu-eth/besu/pull/11110)
 - Add `--p2p-discovery-port` and `--p2p-discovery-port-ipv6` flags to configure a separate UDP port for devp2p peer discovery, independent of the TCP p2p port. Specify `0` to request an ephemeral port from the OS. [#10718](https://github.com/besu-eth/besu/pull/10718)
 - Pending peer request iteration: `streamAvailablePeers()` scan replaced with an allocation-free capacity check. Reduces lock contention and GC pressure under a backlog of pending peer requests. [#10900](https://github.com/besu-eth/besu/pull/10900)
+- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout. 
 
 ## 26.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Extract the Plugin API chain module. The blockchain query, RLP conversion and block-view contracts (`BlockchainService`, `RlpConverterService` and the `BlockContext`, `AddedBlockContext`, `PropagatedBlockContext`, `BadBlockCause` and `LogWithMetadata` data interfaces) now live in a new `besu-plugin-api-chain` artifact, re-exported by `besu-plugin-api` so existing consumers are unaffected. [#11110](https://github.com/besu-eth/besu/pull/11110)
 - Add `--p2p-discovery-port` and `--p2p-discovery-port-ipv6` flags to configure a separate UDP port for devp2p peer discovery, independent of the TCP p2p port. Specify `0` to request an ephemeral port from the OS. [#10718](https://github.com/besu-eth/besu/pull/10718)
 - Pending peer request iteration: `streamAvailablePeers()` scan replaced with an allocation-free capacity check. Reduces lock contention and GC pressure under a backlog of pending peer requests. [#10900](https://github.com/besu-eth/besu/pull/10900)
-- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout. 
+- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` and `engine_newPayload` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout. 
 
 ## 26.8.0
 

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1378,9 +1378,9 @@ public class RunnerBuilder {
       final TransactionSimulator transactionSimulator,
       final EthScheduler ethScheduler) {
     // vertx for the engine consensus API: engine methods execute concurrently on its worker
-    // pool, except engine_forkchoiceUpdated calls, which the Engine API spec requires to be
-    // processed in the order received — those run on a dedicated single-threaded executor
-    // (see ExecutionEngineJsonRpcMethod#requiresOrderedExecution)
+    // pool, except engine_forkchoiceUpdated and engine_newPayload calls, which the Engine API
+    // spec requires to be processed in the order received — those run on a dedicated
+    // single-threaded executor (see OrderedExecutionJsonRpcMethod)
     final Vertx consensusEngineServer = Vertx.vertx();
 
     final Map<String, JsonRpcMethod> methods =

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -148,7 +148,6 @@ import com.google.common.base.Strings;
 import graphql.GraphQL;
 import inet.ipaddr.IPAddress;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -1378,8 +1377,11 @@ public class RunnerBuilder {
       final RpcEndpointServiceImpl rpcEndpointServiceImpl,
       final TransactionSimulator transactionSimulator,
       final EthScheduler ethScheduler) {
-    // sync vertx for engine consensus API, to process requests in FIFO order;
-    final Vertx consensusEngineServer = Vertx.vertx(new VertxOptions().setWorkerPoolSize(1));
+    // vertx for the engine consensus API: engine methods execute concurrently on its worker
+    // pool, except engine_forkchoiceUpdated calls, which the Engine API spec requires to be
+    // processed in the order received — those run on a dedicated single-threaded executor
+    // (see ExecutionEngineJsonRpcMethod#requiresOrderedExecution)
+    final Vertx consensusEngineServer = Vertx.vertx();
 
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1381,7 +1381,8 @@ public class RunnerBuilder {
     // pool, except engine_forkchoiceUpdated and engine_newPayload calls, which the Engine API
     // spec requires to be processed in the order received — those run on a dedicated
     // single-threaded executor (see OrderedExecutionJsonRpcMethod)
-    final Vertx consensusEngineServer = Vertx.vertx();
+    final Vertx consensusEngineServer =
+        Vertx.vertx(new io.vertx.core.VertxOptions().setWorkerPoolSize(1).setEventLoopPoolSize(1));
 
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -30,18 +30,10 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,15 +64,11 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
-  // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
-  // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
-  private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
-  // Single-threaded executor shared by all methods requiring ordered execution, so that their
-  // calls are processed serially in arrival order regardless of which HTTP connection they
-  // arrive on.
-  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
-  private final Vertx syncVertx;
-  private final WorkerExecutor orderedExecutor;
+  // Shared engine consensus API Vertx instance. Only read by OrderedExecutionJsonRpcMethod
+  // (engine_forkchoiceUpdated / engine_newPayload), which uses it to run calls on a dedicated
+  // single-threaded executor rather than spinning up a Vertx instance just for ordering; every
+  // other engine method computes its response directly on the calling thread.
+  protected final Vertx syncVertx;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
@@ -118,14 +106,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   }
 
   protected ExecutionEngineJsonRpcMethod(
-      final ProtocolSchedule protocolSchedule,
-      final ProtocolContext protocolContext,
-      final Vertx vertx,
-      final EngineCallListener engineCallListener) {
-    this(protocolSchedule, protocolContext, vertx, engineCallListener, null, null);
-  }
-
-  protected ExecutionEngineJsonRpcMethod(
       final ConstructorArguments constructorArguments,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
@@ -146,9 +126,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     this.syncVertx = vertx;
-    // every instance gets its own wrapper, but all of them share the same named
-    // single-threaded pool
-    this.orderedExecutor = vertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
     this.protocolSchedule = protocolSchedule;
     this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;
@@ -168,82 +145,45 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   }
 
   @Override
-  public final JsonRpcResponse response(final JsonRpcRequestContext request) {
-
-    final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
-
-    final Handler<Promise<JsonRpcResponse>> blockingHandler =
-        z -> {
-          logger()
-              .trace(
-                  "execution engine JSON-RPC request {} {}",
-                  this.getName(),
-                  request.getRequest().getParams());
-          z.tryComplete(syncResponse(request));
-        };
-    final Handler<AsyncResult<JsonRpcResponse>> resultHandler =
-        resp ->
-            cf.complete(
-                resp.otherwise(
-                        t -> {
-                          if (logger().isDebugEnabled()) {
-                            logger()
-                                .atDebug()
-                                .setMessage("failed to exec consensus method {}")
-                                .addArgument(this.getName())
-                                .setCause(t)
-                                .log();
-                          } else {
-                            logger()
-                                .atError()
-                                .setMessage("failed to exec consensus method {}, error: {}")
-                                .addArgument(this.getName())
-                                .addArgument(t.getMessage())
-                                .log();
-                          }
-                          return new JsonRpcErrorResponse(
-                              request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
-                        })
-                    .result());
-
-    if (requiresOrderedExecution()) {
-      // ordered=false: the executor's single thread already serializes execution, and unordered
-      // submission preserves global arrival order across HTTP connections, while ordered=true
-      // would only preserve it per calling context.
-      orderedExecutor.executeBlocking(blockingHandler, false, resultHandler);
-    } else {
-      syncVertx.executeBlocking(blockingHandler, false, resultHandler);
-    }
-    try {
-      return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
-      logger()
-          .debug(
-              "Timeout waiting for engine API response for {}, releasing worker thread",
-              this.getName());
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      logger().error("Failed to get execution engine response", e);
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
-    } catch (ExecutionException e) {
-      logger().error("Failed to get execution engine response", e);
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
-    }
+  public JsonRpcResponse response(final JsonRpcRequestContext request) {
+    return computeResponseSafely(request);
   }
 
   /**
-   * Whether calls to this method must be processed serially, in the same order as they have been
-   * received.
+   * Runs {@link #syncResponse}, converting any {@link Throwable} it throws into a {@link
+   * JsonRpcErrorResponse} instead of letting it propagate.
    *
-   * <p>The Engine API specification mandates this only for {@code engine_forkchoiceUpdated}
-   * ("Execution Layer client software MUST process engine_forkchoiceUpdated method calls in the
-   * same order as they have been received"), so by default engine methods execute concurrently on
-   * the engine Vertx worker pool and only the {@code engine_forkchoiceUpdated} hierarchy overrides
-   * this to return {@code true}.
+   * <p>{@link #response} calls this directly; {@link OrderedExecutionJsonRpcMethod} overrides
+   * {@link #response} to instead run this on a dedicated single-threaded executor, for methods the
+   * Engine API spec requires to be processed serially in arrival order (e.g. {@code
+   * engine_forkchoiceUpdated}, {@code engine_newPayload}).
    */
-  protected boolean requiresOrderedExecution() {
-    return false;
+  protected final JsonRpcResponse computeResponseSafely(final JsonRpcRequestContext request) {
+    logger()
+        .trace(
+            "execution engine JSON-RPC request {} {}",
+            this.getName(),
+            request.getRequest().getParams());
+    try {
+      return syncResponse(request);
+    } catch (final Throwable t) {
+      if (logger().isDebugEnabled()) {
+        logger()
+            .atDebug()
+            .setMessage("failed to exec consensus method {}")
+            .addArgument(this.getName())
+            .setCause(t)
+            .log();
+      } else {
+        logger()
+            .atError()
+            .setMessage("failed to exec consensus method {}, error: {}")
+            .addArgument(this.getName())
+            .addArgument(t.getMessage())
+            .log();
+      }
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
+    }
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -37,7 +37,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +75,12 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
   // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
   private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
+  // Single-threaded executor shared by all methods requiring ordered execution, so that their
+  // calls are processed serially in arrival order regardless of which HTTP connection they
+  // arrive on.
+  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
   private final Vertx syncVertx;
+  private final WorkerExecutor orderedExecutor;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
@@ -137,6 +146,9 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     this.syncVertx = vertx;
+    // every instance gets its own wrapper, but all of them share the same named
+    // single-threaded pool
+    this.orderedExecutor = vertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
     this.protocolSchedule = protocolSchedule;
     this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;
@@ -160,7 +172,7 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
     final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
 
-    syncVertx.<JsonRpcResponse>executeBlocking(
+    final Handler<Promise<JsonRpcResponse>> blockingHandler =
         z -> {
           logger()
               .trace(
@@ -168,8 +180,8 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
                   this.getName(),
                   request.getRequest().getParams());
           z.tryComplete(syncResponse(request));
-        },
-        true,
+        };
+    final Handler<AsyncResult<JsonRpcResponse>> resultHandler =
         resp ->
             cf.complete(
                 resp.otherwise(
@@ -192,7 +204,16 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
                           return new JsonRpcErrorResponse(
                               request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
                         })
-                    .result()));
+                    .result());
+
+    if (requiresOrderedExecution()) {
+      // ordered=false: the executor's single thread already serializes execution, and unordered
+      // submission preserves global arrival order across HTTP connections, while ordered=true
+      // would only preserve it per calling context.
+      orderedExecutor.executeBlocking(blockingHandler, false, resultHandler);
+    } else {
+      syncVertx.executeBlocking(blockingHandler, false, resultHandler);
+    }
     try {
       return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
@@ -209,6 +230,20 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       logger().error("Failed to get execution engine response", e);
       return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
     }
+  }
+
+  /**
+   * Whether calls to this method must be processed serially, in the same order as they have been
+   * received.
+   *
+   * <p>The Engine API specification mandates this only for {@code engine_forkchoiceUpdated}
+   * ("Execution Layer client software MUST process engine_forkchoiceUpdated method calls in the
+   * same order as they have been received"), so by default engine methods execute concurrently on
+   * the engine Vertx worker pool and only the {@code engine_forkchoiceUpdated} hierarchy overrides
+   * this to return {@code true}.
+   */
+  protected boolean requiresOrderedExecution() {
+    return false;
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
@@ -65,7 +65,17 @@ public abstract class OrderedExecutionJsonRpcMethod extends ExecutionEngineJsonR
     orderedExecutor.<JsonRpcResponse>executeBlocking(
         promise -> promise.complete(computeResponseSafely(request)),
         false,
-        result -> cf.complete(result.result()));
+        result -> {
+          // computeResponseSafely never throws, so a failure here means the executor could not
+          // run the task at all (e.g. rejected because it is closing during shutdown); complete
+          // exceptionally so the ExecutionException branch below returns INTERNAL_ERROR instead
+          // of a null response
+          if (result.succeeded()) {
+            cf.complete(result.result());
+          } else {
+            cf.completeExceptionally(result.cause());
+          }
+        });
 
     try {
       return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.HardforkId;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.vertx.core.WorkerExecutor;
+
+/**
+ * Base class for engine methods the Engine API spec requires to be processed serially, in the same
+ * order as they were received (currently the {@code engine_forkchoiceUpdated} and {@code
+ * engine_newPayload} series — see the respective V1 classes).
+ *
+ * <p>All instances share one single-threaded {@link WorkerExecutor} created from the engine
+ * consensus API's existing Vertx instance (the same one backing {@code EngineQosTimer}), so calls
+ * are serialized globally in arrival order regardless of which HTTP connection they arrive on,
+ * without spinning up a dedicated Vertx instance just for ordering.
+ */
+public abstract class OrderedExecutionJsonRpcMethod extends ExecutionEngineJsonRpcMethod {
+
+  // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
+  // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
+  private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
+  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
+
+  // every instance gets its own wrapper, but all of them share the same named single-threaded pool
+  private final WorkerExecutor orderedExecutor;
+
+  protected OrderedExecutionJsonRpcMethod(
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.orderedExecutor = syncVertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
+  }
+
+  @Override
+  public final JsonRpcResponse response(final JsonRpcRequestContext request) {
+    final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
+
+    // ordered=false: the executor's single thread already serializes execution, and unordered
+    // submission preserves global arrival order across HTTP connections, while ordered=true
+    // would only preserve it per calling context.
+    orderedExecutor.<JsonRpcResponse>executeBlocking(
+        promise -> promise.complete(computeResponseSafely(request)),
+        false,
+        result -> cf.complete(result.result()));
+
+    try {
+      return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (final TimeoutException e) {
+      logger()
+          .debug(
+              "Timeout waiting for engine API response for {}, releasing worker thread",
+              this.getName());
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger().error("Failed to get execution engine response", e);
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
+    } catch (final ExecutionException e) {
+      logger().error("Failed to get execution engine response", e);
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
+    }
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.OrderedExecutionJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceStateV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV1;
@@ -55,10 +55,14 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Parameterized so that V2 can extend this class while narrowing the payload type.
  *
+ * <p>Extends {@link OrderedExecutionJsonRpcMethod} because the Engine API spec mandates that
+ * forkchoiceUpdated calls are processed in the order they have been received; this applies to the
+ * whole sealed V1-V4 hierarchy.
+ *
  * @param <PA> the payload-attributes type this version accepts
  */
 public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
-    extends ExecutionEngineJsonRpcMethod permits EngineForkchoiceUpdatedV2 {
+    extends OrderedExecutionJsonRpcMethod permits EngineForkchoiceUpdatedV2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV1.class);
 
@@ -80,13 +84,6 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
   @Override
   public String getName() {
     return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V1.getMethodName();
-  }
-
-  // The Engine API spec mandates that forkchoiceUpdated calls are processed in the order they
-  // have been received; applies to the whole sealed V1-V4 hierarchy.
-  @Override
-  protected final boolean requiresOrderedExecution() {
-    return true;
   }
 
   @SuppressWarnings("unchecked")

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -82,6 +82,13 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
     return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V1.getMethodName();
   }
 
+  // The Engine API spec mandates that forkchoiceUpdated calls are processed in the order they
+  // have been received; applies to the whole sealed V1-V4 hierarchy.
+  @Override
+  protected final boolean requiresOrderedExecution() {
+    return true;
+  }
+
   @SuppressWarnings("unchecked")
   protected Class<PA> getPayloadAttributesClass() {
     return (Class<PA>) PayloadAttributesV1.class;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.OrderedExecutionJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ExecutionPayloadV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.NewPayloadRequestParametersV1;
@@ -67,9 +67,16 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Extends {@link OrderedExecutionJsonRpcMethod} so that {@code engine_newPayload} calls (and those
+ * of the whole sealed V1-V5 hierarchy) are processed in the order they have been received,
+ * consistent with {@code engine_forkchoiceUpdated}: both affect canonical chain state and a
+ * newPayload racing ahead of (or behind) an FCU for the same or a related block could otherwise be
+ * observed out of order.
+ */
 public sealed class EngineNewPayloadV1<
         EP extends ExecutionPayloadV1, NPRP extends NewPayloadRequestParametersV1<? extends EP>>
-    extends ExecutionEngineJsonRpcMethod permits EngineNewPayloadV2 {
+    extends OrderedExecutionJsonRpcMethod permits EngineNewPayloadV2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineNewPayloadV1.class);
   private static final Hash OMMERS_HASH_CONSTANT = Hash.EMPTY_LIST_HASH;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -40,6 +40,15 @@ version adds or changes.
 - All versions extend `ExecutionEngineJsonRpcMethod`, which owns the fork-window validation
   (`minSupportedFork` / `firstUnsupportedFork` constructor arguments, `validateForkSupported`,
   see also `ForkSupportHelper`). Concrete versions never check fork timestamps themselves.
+- Engine methods execute concurrently by default. The `engine_forkchoiceUpdatedV*` and
+  `engine_newPayloadV*` series are the exception: the Engine API spec requires them to be
+  processed in the order they were received, so `EngineForkchoiceUpdatedV1` and
+  `EngineNewPayloadV1` extend `OrderedExecutionJsonRpcMethod` instead of
+  `ExecutionEngineJsonRpcMethod` directly — a compile-time choice, not a runtime flag, so a new
+  ordered series must extend `OrderedExecutionJsonRpcMethod` from its V1 class onward.
+  `OrderedExecutionJsonRpcMethod` runs calls through a single-threaded `WorkerExecutor` created
+  from the engine consensus API's existing Vertx instance (`ConstructorArguments.vertx()` — the
+  same one backing `EngineQosTimer`), rather than a dedicated Vertx instance just for ordering.
 - Migrated series take a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built
   via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -40,15 +40,9 @@ version adds or changes.
 - All versions extend `ExecutionEngineJsonRpcMethod`, which owns the fork-window validation
   (`minSupportedFork` / `firstUnsupportedFork` constructor arguments, `validateForkSupported`,
   see also `ForkSupportHelper`). Concrete versions never check fork timestamps themselves.
-- Engine methods execute concurrently by default. The `engine_forkchoiceUpdatedV*` and
-  `engine_newPayloadV*` series are the exception: the Engine API spec requires them to be
-  processed in the order they were received, so `EngineForkchoiceUpdatedV1` and
-  `EngineNewPayloadV1` extend `OrderedExecutionJsonRpcMethod` instead of
-  `ExecutionEngineJsonRpcMethod` directly — a compile-time choice, not a runtime flag, so a new
-  ordered series must extend `OrderedExecutionJsonRpcMethod` from its V1 class onward.
-  `OrderedExecutionJsonRpcMethod` runs calls through a single-threaded `WorkerExecutor` created
-  from the engine consensus API's existing Vertx instance (`ConstructorArguments.vertx()` — the
-  same one backing `EngineQosTimer`), rather than a dedicated Vertx instance just for ordering.
+- Engine methods execute concurrently by default. Engine methods that require ordering (FIFO)
+  must extend `OrderedExecutionJsonRpcMethod`. Examples being `EngineNewPayloadV1` and `EngineForkchoiceUpdatedV1`
+- and associated sealed version hierarchies.
 - Migrated series take a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built
   via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.ArrayList;
@@ -49,6 +53,12 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
 
   @Mock private EngineCallListener engineCallListener;
 
+  @Mock private ProtocolSchedule protocolSchedule;
+
+  @Mock private MergeMiningCoordinator mergeCoordinator;
+
+  @Mock private EthPeers ethPeers;
+
   @AfterAll
   public static void tearDown() {
     vertx.close();
@@ -59,11 +69,10 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     // each call blocks until the other one has started executing, so the test only
     // completes if the two calls run in parallel
     final CyclicBarrier bothStarted = new CyclicBarrier(2);
-    final StubEngineMethod method =
-        new StubEngineMethod(
+    final UnorderedStubEngineMethod method =
+        new UnorderedStubEngineMethod(
             protocolContext,
             engineCallListener,
-            false,
             req -> {
               try {
                 bothStarted.await(10, TimeUnit.SECONDS);
@@ -82,11 +91,13 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
   public void orderedMethodCallsNeverExecuteConcurrently() throws Exception {
     final AtomicInteger active = new AtomicInteger();
     final AtomicInteger maxActive = new AtomicInteger();
-    final StubEngineMethod method =
-        new StubEngineMethod(
+    final OrderedStubEngineMethod method =
+        new OrderedStubEngineMethod(
+            protocolSchedule,
             protocolContext,
             engineCallListener,
-            true,
+            mergeCoordinator,
+            ethPeers,
             req -> {
               maxActive.accumulateAndGet(active.incrementAndGet(), Math::max);
               try {
@@ -104,7 +115,7 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     assertThat(maxActive.get()).isEqualTo(1);
   }
 
-  private List<JsonRpcResponse> callConcurrently(final StubEngineMethod method, final int callers)
+  private List<JsonRpcResponse> callConcurrently(final JsonRpcMethod method, final int callers)
       throws Exception {
     final ExecutorService pool = Executors.newFixedThreadPool(callers);
     try {
@@ -127,28 +138,57 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     }
   }
 
-  private static class StubEngineMethod extends ExecutionEngineJsonRpcMethod {
-    private final boolean ordered;
+  private static class UnorderedStubEngineMethod extends ExecutionEngineJsonRpcMethod {
     private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
 
-    StubEngineMethod(
+    UnorderedStubEngineMethod(
         final ProtocolContext protocolContext,
         final EngineCallListener engineCallListener,
-        final boolean ordered,
         final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
       super(vertx, protocolContext, engineCallListener);
-      this.ordered = ordered;
       this.body = body;
     }
 
     @Override
     public String getName() {
-      return "engine_stub";
+      return "engine_stub_unordered";
     }
 
     @Override
-    protected boolean requiresOrderedExecution() {
-      return ordered;
+    public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
+      return body.apply(request);
+    }
+  }
+
+  private static class OrderedStubEngineMethod extends OrderedExecutionJsonRpcMethod {
+    private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
+
+    OrderedStubEngineMethod(
+        final ProtocolSchedule protocolSchedule,
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final MergeMiningCoordinator mergeCoordinator,
+        final EthPeers ethPeers,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      super(
+          new ConstructorArgumentsBuilder()
+              .protocolSchedule(protocolSchedule)
+              .protocolContext(protocolContext)
+              .vertx(vertx)
+              .engineCallListener(engineCallListener)
+              .mergeCoordinator(mergeCoordinator)
+              .ethPeers(ethPeers)
+              .metricsSystem(new NoOpMetricsSystem())
+              .maxRequestBlocks(0)
+              .build(),
+          null,
+          null);
+      this.body = body;
+    }
+
+    @Override
+    public String getName() {
+      return "engine_stub_ordered";
     }
 
     @Override

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -61,7 +61,7 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
 
   @AfterAll
   public static void tearDown() {
-    vertx.close();
+    vertx.close().toCompletionStage().toCompletableFuture().join();
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionEngineJsonRpcMethodExecutionTest {
+  private static final Vertx vertx = Vertx.vertx();
+
+  @Mock private ProtocolContext protocolContext;
+
+  @Mock private EngineCallListener engineCallListener;
+
+  @AfterAll
+  public static void tearDown() {
+    vertx.close();
+  }
+
+  @Test
+  public void unorderedMethodCallsExecuteConcurrently() throws Exception {
+    // each call blocks until the other one has started executing, so the test only
+    // completes if the two calls run in parallel
+    final CyclicBarrier bothStarted = new CyclicBarrier(2);
+    final StubEngineMethod method =
+        new StubEngineMethod(
+            protocolContext,
+            engineCallListener,
+            false,
+            req -> {
+              try {
+                bothStarted.await(10, TimeUnit.SECONDS);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return new JsonRpcSuccessResponse(req.getRequest().getId());
+            });
+
+    final List<JsonRpcResponse> responses = callConcurrently(method, 2);
+
+    assertThat(responses).allMatch(resp -> resp.getType() == RpcResponseType.SUCCESS);
+  }
+
+  @Test
+  public void orderedMethodCallsNeverExecuteConcurrently() throws Exception {
+    final AtomicInteger active = new AtomicInteger();
+    final AtomicInteger maxActive = new AtomicInteger();
+    final StubEngineMethod method =
+        new StubEngineMethod(
+            protocolContext,
+            engineCallListener,
+            true,
+            req -> {
+              maxActive.accumulateAndGet(active.incrementAndGet(), Math::max);
+              try {
+                Thread.sleep(50);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              active.decrementAndGet();
+              return new JsonRpcSuccessResponse(req.getRequest().getId());
+            });
+
+    final List<JsonRpcResponse> responses = callConcurrently(method, 4);
+
+    assertThat(responses).allMatch(resp -> resp.getType() == RpcResponseType.SUCCESS);
+    assertThat(maxActive.get()).isEqualTo(1);
+  }
+
+  private List<JsonRpcResponse> callConcurrently(final StubEngineMethod method, final int callers)
+      throws Exception {
+    final ExecutorService pool = Executors.newFixedThreadPool(callers);
+    try {
+      final List<Future<JsonRpcResponse>> futures = new ArrayList<>();
+      for (int i = 0; i < callers; i++) {
+        futures.add(
+            pool.submit(
+                () ->
+                    method.response(
+                        new JsonRpcRequestContext(
+                            new JsonRpcRequest("2.0", method.getName(), new Object[0])))));
+      }
+      final List<JsonRpcResponse> responses = new ArrayList<>(callers);
+      for (final Future<JsonRpcResponse> future : futures) {
+        responses.add(future.get(30, TimeUnit.SECONDS));
+      }
+      return responses;
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  private static class StubEngineMethod extends ExecutionEngineJsonRpcMethod {
+    private final boolean ordered;
+    private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
+
+    StubEngineMethod(
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final boolean ordered,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      super(vertx, protocolContext, engineCallListener);
+      this.ordered = ordered;
+      this.body = body;
+    }
+
+    @Override
+    public String getName() {
+      return "engine_stub";
+    }
+
+    @Override
+    protected boolean requiresOrderedExecution() {
+      return ordered;
+    }
+
+    @Override
+    public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
+      return body.apply(request);
+    }
+  }
+}


### PR DESCRIPTION
The Engine API spec mandates ordered processing only for
engine_forkchoiceUpdated ("Execution Layer client software MUST process
engine_forkchoiceUpdated method calls in the same order as they have
been received"). Besu instead serialized every engine call on a
single-threaded Vertx worker pool, so light read-only requests like
engine_getBlobsV2 could queue behind a long newPayload import and miss
the consensus client's deadline (e.g. Nimbus cancels getBlobs after 1s
and closes the connection, leaving noisy write errors in the logs).

Engine methods now run concurrently on the engine Vertx worker pool,
while engine_forkchoiceUpdated V1-V4 run on a dedicated shared
single-threaded executor that preserves global arrival order across
HTTP connections.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>
