### PR TITLE
HTTP RPC: Demote timeout and closed connection exception to WARN

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
@@ -49,7 +49,7 @@ public class JsonRpcExecutorHandler {
                   timeoutMillis,
                   id -> {
                     final String requestBodyAsJson = getRequestBodyAsString(ctx);
-                    LOG.error(
+                    LOG.warn(
                         "Timeout ({} ms) occurred in JSON-RPC executor for method {}",
                         timeoutMillis,
                         getShortLogString(requestBodyAsJson));
@@ -74,7 +74,7 @@ public class JsonRpcExecutorHandler {
                     if (e instanceof ClosedChannelException) {
                       // The remote end closed the connection before we finished writing.
                       // No point trying to send an error response on a closed channel.
-                      LOG.error(
+                      LOG.warn(
                           "{} - Connection closed before JSON-RPC response could be written",
                           method);
                     } else {


### PR DESCRIPTION
## PR description

Follow-up to https://github.com/besu-eth/besu/pull/10626, closed connections and timeouts could normally occur and are recoverable, so logging at error does not seem to match the actual severity, while logging at WARN surface them for further review in case there is a burst.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


