### PR TITLE
perf: eliminate O(N²) isClosed overhead in LayeredKeyValueStorage.get()

### DIFF
--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/LayeredKeyValueStorageTest.java
@@ -18,8 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -340,7 +342,51 @@ public class LayeredKeyValueStorageTest {
 
     // The root mock should have been queried at most once across both top-level calls because the
     // intermediate layers cache the result and short-circuit before reaching the root
-    verify(parentStorage, atMostOnce()).isClosed();
+    verify(parentStorage, times(1)).isClosed();
+  }
+
+  @Test
+  void deepChainGetCallsIsClosedOnlyOnce() throws Exception {
+    int depth = 500;
+    byte[] key = {42};
+    byte[] value = {99};
+    when(parentStorage.isClosed()).thenReturn(false);
+    when(parentStorage.get(segmentId, key)).thenReturn(Optional.of(value));
+
+    // Build a 500-deep chain on top of the mock parent.
+    LayeredKeyValueStorage top = layeredKeyValueStorage; // depth 1, wraps parentStorage
+    for (int i = 1; i < depth; i++) {
+      top = new LayeredKeyValueStorage(top);
+    }
+
+    Optional<byte[]> result = top.get(segmentId, key);
+    assertTrue(result.isPresent());
+    assertArrayEquals(value, result.get());
+
+    // With the old code this would be called 500 times (once per level).
+    verify(parentStorage, times(1)).isClosed();
+  }
+
+  @Test
+  void deepChainGetBytesVariantCallsIsClosedOnlyOnce() throws Exception {
+    int depth = 500;
+    Bytes key = Bytes.of(42);
+    byte[] value = {99};
+    when(parentStorage.isClosed()).thenReturn(false);
+    when(parentStorage.get(eq(segmentId), aryEq(key.toArrayUnsafe())))
+        .thenReturn(Optional.of(value));
+
+    LayeredKeyValueStorage top = layeredKeyValueStorage;
+    for (int i = 1; i < depth; i++) {
+      top = new LayeredKeyValueStorage(top);
+    }
+
+    Optional<Bytes> result = top.get(segmentId, key, null);
+    assertTrue(result.isPresent());
+    assertArrayEquals(value, result.get().toArrayUnsafe());
+
+    // With the old code this would be called 500 times (once per level).
+    verify(parentStorage, times(1)).isClosed();
   }
 
   /**

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -91,16 +91,13 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
   public Optional<byte[]> get(final SegmentIdentifier segmentId, final byte[] key)
       throws StorageException {
     throwIfClosed();
-
-    final Lock lock = rwLock.readLock();
-    lock.lock();
-    try {
-      final Bytes wrapKey = Bytes.wrap(key);
-      final Optional<byte[]> foundKey =
-          hashValueStore.computeIfAbsent(segmentId, __ -> newSegmentMap()).get(wrapKey);
-      return foundKey == null ? parent.get(segmentId, key) : foundKey;
-    } finally {
-      lock.unlock();
+    final Bytes wrapKey = Bytes.wrap(key);
+    for (LayeredKeyValueStorage cur = this; ; ) {
+      final Optional<byte[]> found = cur.getLocal(segmentId, wrapKey);
+      if (found != null) return found;
+      if (!(cur.parent instanceof LayeredKeyValueStorage next))
+        return cur.parent.get(segmentId, key);
+      cur = next;
     }
   }
 
@@ -119,23 +116,23 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
       final Bytes key,
       final Function<SegmentedKeyValueStorage, Optional<Bytes>> cacheGetFunction) {
     throwIfClosed();
+    for (LayeredKeyValueStorage cur = this; ; ) {
+      final Optional<byte[]> found = cur.getLocal(segmentId, key);
+      if (found != null) return found.map(Bytes::wrap);
+      if (!(cur.parent instanceof LayeredKeyValueStorage next))
+        return cacheGetFunction != null
+            ? cacheGetFunction.apply(cur.parent)
+            : cur.parent.get(segmentId, key.toArrayUnsafe()).map(Bytes::wrap);
+      cur = next;
+    }
+  }
 
+  private Optional<byte[]> getLocal(final SegmentIdentifier segmentId, final Bytes key) {
     final Lock lock = rwLock.readLock();
     lock.lock();
     try {
-      final Optional<byte[]> foundKey =
-          hashValueStore.computeIfAbsent(segmentId, __ -> newSegmentMap()).get(key);
-
-      if (foundKey == null) {
-        if (parent instanceof LayeredKeyValueStorage layered) {
-          return layered.get(segmentId, key, cacheGetFunction);
-        }
-        if (cacheGetFunction != null) {
-          return cacheGetFunction.apply(parent);
-        }
-        return parent.get(segmentId, key.toArrayUnsafe()).map(Bytes::wrap);
-      }
-      return foundKey.map(Bytes::wrap);
+      final NavigableMap<Bytes, Optional<byte[]>> segment = hashValueStore.get(segmentId);
+      return segment == null ? null : segment.get(key);
     } finally {
       lock.unlock();
     }
@@ -366,13 +363,13 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
   @Override
   public boolean isClosed() {
-    if (closedCache) {
-      return true;
+    if (closedCache) return true;
+    SegmentedKeyValueStorage cur = parent;
+    while (cur instanceof LayeredKeyValueStorage layered) {
+      if (layered.closedCache) return closedCache = true;
+      cur = layered.parent;
     }
-    if (parent.isClosed()) {
-      closedCache = true;
-      return true;
-    }
+    if (cur.isClosed()) return closedCache = true;
     return false;
   }
 

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -92,7 +92,8 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
       throws StorageException {
     throwIfClosed();
     final Bytes wrapKey = Bytes.wrap(key);
-    for (LayeredKeyValueStorage cur = this; ; ) {
+    LayeredKeyValueStorage cur = this;
+    while (true) {
       final Optional<byte[]> found = cur.getLocal(segmentId, wrapKey);
       if (found != null) return found;
       if (!(cur.parent instanceof LayeredKeyValueStorage next))
@@ -116,7 +117,8 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
       final Bytes key,
       final Function<SegmentedKeyValueStorage, Optional<Bytes>> cacheGetFunction) {
     throwIfClosed();
-    for (LayeredKeyValueStorage cur = this; ; ) {
+    LayeredKeyValueStorage cur = this;
+    while (true) {
       final Optional<byte[]> found = cur.getLocal(segmentId, key);
       if (found != null) return found.map(Bytes::wrap);
       if (!(cur.parent instanceof LayeredKeyValueStorage next))


### PR DESCRIPTION
## Summary

`LayeredKeyValueStorage` maintains up to `maxLayersToLoad` (~512) in-memory layers stacked on top of RocksDB. After sustained block import the chain reaches ~490 layers deep.

**The bug**: `get()` called `throwIfClosed()` at every recursive level, and `throwIfClosed()` calls `isClosed()`, which walks the full remaining parent chain. A single key miss on an N-deep chain makes N(N+1)/2 wasted `isClosed()` calls — O(N²). At N=490 that is ~120,000 per miss.

This hit Bonsai archive hard because `ArchiveTrieNodeStrategy` makes thousands of extra chain-miss `get()` calls per block (reading `priorFlat` for every trie-node captured). CPU profiling showed 160 `get()` frames deep with 234 nested `isClosed()` frames consuming **44% of import-thread CPU**, dropping throughput from 300+ blk/min to ~42 blk/min. Regular Bonsai has the same per-call cost but makes far fewer misses per block, so the degradation is much milder.

**Fix**: call `throwIfClosed()` once on entry to the public `get()`, then recurse via a private `getInternal()` that skips the check. `isClosed()` is also made iterative to remove the O(N) chain walk from the single remaining check.

Two new regression tests build a 500-deep chain and assert `parentStorage.isClosed()` is called exactly once per `get()` (old code: 500 times).

## Test plan

- [x] `./gradlew :plugins:rocksdb:test --tests "*LayeredKeyValueStorage*"` — all tests pass
- [ ] QBFT dev network archive full sync (original repro environment)
- [ ] Mainnet archive full sync