### PR TITLE
Backfill missing sources checksums for already-trusted verification-metadata components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -617,6 +617,7 @@ task resolveSourceArtifacts {
   group = 'verification'
   description = 'Resolves source artifacts for all configurations (including the plugin classpath) so they can be included in dependency verification metadata'
   dependsOn getAllprojects().collect { it.tasks.named('resolveProjectSourceArtifacts') }
+  finalizedBy 'backfillLegacySourceChecksums'
   doLast {
     def resolved = new HashSet()
     forEachBuildscriptSourceArtifact { id, source ->
@@ -624,6 +625,62 @@ task resolveSourceArtifacts {
       resolved.add(id)
     }
     logger.lifecycle("Resolved sources for ${resolved.size()} plugin classpath components")
+  }
+}
+
+// Components no longer reachable from any current dependency graph (e.g. an old vertx-core
+// version kept around from before this branch's 4.x -> 5.x upgrade, see 2aa6fd01d1) still get
+// their jar/pom trusted here on purpose. Nothing in resolveSourceArtifacts above can ever
+// re-discover them, since they aren't requested anywhere anymore - but IntelliJ's sync can still
+// probe their sources jar independently of the live graph and fail verification when it's
+// missing. Backfill sources checksums for every such already-trusted component directly from
+// its own artifact, instead of chasing down why the IDE asked for it.
+task backfillLegacySourceChecksums {
+  group = 'verification'
+  description = 'Resolves -sources.jar for every already-trusted (jar+pom) component in verification-metadata.xml that is missing a sources entry'
+  doLast {
+    def metadataFile = rootProject.file('gradle/verification-metadata.xml')
+    def slurper = new groovy.xml.XmlSlurper()
+    slurper.setFeature('http://xml.org/sax/features/namespaces', false)
+    def metadata = slurper.parse(metadataFile)
+
+    def missing = []
+    metadata.components.component.each { comp ->
+      def group = comp.@group.text()
+      def name = comp.@name.text()
+      def version = comp.@version.text()
+      def hasJar = comp.artifact.any { it.@name.text() == "${name}-${version}.jar".toString() }
+      def hasSources = comp.artifact.any { it.@name.text() == "${name}-${version}-sources.jar".toString() }
+      if (hasJar && !hasSources) {
+        missing << [group: group, name: name, version: version]
+      }
+    }
+
+    if (missing.isEmpty()) {
+      logger.lifecycle('No legacy components are missing a -sources.jar verification entry.')
+      return
+    }
+
+    logger.lifecycle("Probing sources for ${missing.size()} already-trusted component(s) with no sources entry:")
+    def resolvedCount = 0
+    missing.each { m ->
+      def coordinate = "${m.group}:${m.name}:${m.version}"
+      try {
+        def dep = project.dependencies.create("${coordinate}:sources")
+        def detached = project.configurations.detachedConfiguration(dep)
+        detached.transitive = false
+        // access .files to trigger download and register with verification metadata
+        if (!detached.files.isEmpty()) {
+          resolvedCount++
+          logger.lifecycle("  resolved sources for ${coordinate}")
+        }
+      } catch (Exception e) {
+        // Many older/legacy components never published a sources jar at all - that is expected
+        // and not an error; only unexpected failures (e.g. verification itself) should be loud.
+        logger.info("  no sources available for ${coordinate}: ${e.message}")
+      }
+    }
+    logger.lifecycle("Resolved sources for ${resolvedCount}/${missing.size()} legacy components")
   }
 }
 


### PR DESCRIPTION
## Summary
- `resolveSourceArtifacts` only discovers sources jars for components still reachable from the live dependency graph, so a component kept in `verification-metadata.xml` for historical reasons (e.g. an old `vertx-core` version pinned before a BOM bump, see #11015) never gets its `-sources.jar` checksum recorded, even though IntelliJ's Gradle sync can still probe it independently of the graph and fail dependency verification on refresh.
- Adds `backfillLegacySourceChecksums`, wired as `finalizedBy` on `resolveSourceArtifacts`, which scans `gradle/verification-metadata.xml` for every component already trusted via jar+pom that is missing a sources entry, and resolves/checksums it directly.
- No change to the documented regeneration command in the README - `./gradlew --write-verification-metadata sha256 --refresh-dependencies resolveSourceArtifacts :plugin-api:checkAPICompatibility --rerun-tasks` now also covers this case.

## Test plan
- [x] Ran `./gradlew --write-verification-metadata sha256 backfillLegacySourceChecksums` - found 305 already-trusted components missing a sources entry, resolved 298 (the other 7 have no sources jar published upstream)
- [x] Re-ran the task - idempotent, zero further changes
- [x] Validated `gradle/verification-metadata.xml` stays well-formed XML with only additive changes