### PR TITLE
Policies - fix broken links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -164,4 +164,4 @@ in the event of a misunderstanding.
 This code is based on the
 [W3C’s Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc) with some
 additions from the [Cloud Foundry](https://www.cloudfoundry.org/)‘s Code of Conduct.
-This project also follows the [Hyperledger Project Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct).
+This project also follows the [LFDT Code of Conduct](https://www.lfdecentralizedtrust.org/code-of-conduct).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,5 @@ Besu accepts security bugs at two email addresses:
 When sending information to either of these emails, please include a description of the flaw and any
 related information (for example, reproduction steps, version, and known active use).
 
-The process by which the LF Decentralized Trust Security Team handles security bugs is documented further in
-our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our
-[wiki](https://wiki.hyperledger.org).
+The process by which the Besu and LF Decentralized Trust Security Teams handle security bugs is documented further in
+our [Security Policy](https://github.com/besu-eth/besu/wiki/Security-Policy).


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Fixed 2 broken links - ink to updated versions of: 
* security policy - recently updated in besu-eth/wiki
* code of conduct - link to LFDT Code of conduct
