### PR TITLE
Enforce EIP-7843 slotNumber presence in Amsterdam header validation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoBlobRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoDifficultyRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoNonceRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.RequestsHashPresentValidationRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.SlotNumberPresentValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMoreRecentThanParent;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -147,5 +148,13 @@ public final class MainnetBlockHeaderValidator {
       final GasLimitCalculator gasLimitCalculator) {
     return blobAwareBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
         .addRule(new RequestsHashPresentValidationRule());
+  }
+
+  public static BlockHeaderValidator.Builder slotNumberAwareBlockHeaderValidator(
+      final FeeMarket feeMarket,
+      final GasCalculator gasCalculator,
+      final GasLimitCalculator gasLimitCalculator) {
+    return requestsAwareBlockHeaderValidator(feeMarket, gasCalculator, gasLimitCalculator)
+        .addRule(new SlotNumberPresentValidationRule());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -1291,6 +1291,9 @@ public abstract class MainnetProtocolSpecs {
             // Amsterdam: Validator uses pre-refund gas_metered = max(regular, state) from
             // processing
             .blockGasUsedValidator(BlockGasUsedValidator.AMSTERDAM)
+            // EIP-7843: slotNumber header field is mandatory from Amsterdam onwards
+            .blockHeaderValidatorBuilder(
+                MainnetBlockHeaderValidator::slotNumberAwareBlockHeaderValidator)
             .hardforkId(AMSTERDAM);
 
     // EIP-8282 introduces the builder deposit (0x03) and builder exit (0x04) system-contract

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRule.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ensures that a block header carries the {@code slotNumber} field once EIP-7843 is active. From
+ * Amsterdam onwards every block header must include {@code slotNumber}; a header that omits the
+ * field is malformed regardless of its block body, so this presence check is intentionally
+ * independent of the parent header.
+ */
+public class SlotNumberPresentValidationRule implements DetachedBlockHeaderValidationRule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlotNumberPresentValidationRule.class);
+
+  @Override
+  public boolean validate(final BlockHeader header, final BlockHeader parent) {
+    if (header.getOptionalSlotNumber().isEmpty()) {
+      LOG.info(
+          "Invalid block header: slotNumber field is required from Amsterdam onwards but is missing");
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "SlotNumberPresent";
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRuleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/SlotNumberPresentValidationRuleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+
+import org.junit.jupiter.api.Test;
+
+class SlotNumberPresentValidationRuleTest {
+
+  private final SlotNumberPresentValidationRule rule = new SlotNumberPresentValidationRule();
+
+  @Test
+  void rejectsHeaderWithMissingSlotNumber() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().buildHeader();
+
+    assertThat(header.getOptionalSlotNumber()).isEmpty();
+    assertThat(rule.validate(header, parent)).isFalse();
+  }
+
+  @Test
+  void acceptsHeaderWithZeroSlotNumber() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().slotNumber(0L).buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void acceptsHeaderWithPopulatedSlotNumber() {
+    final BlockHeader parent = new BlockHeaderTestFixture().buildHeader();
+    final BlockHeader header = new BlockHeaderTestFixture().slotNumber(1234L).buildHeader();
+
+    assertThat(rule.validate(header, parent)).isTrue();
+  }
+
+  @Test
+  void includedInLightValidation() {
+    // slotNumber presence is a detached header property and must be enforced even on the
+    // light-validation sync path.
+    assertThat(rule.includeInLightValidation()).isTrue();
+  }
+}


### PR DESCRIPTION
## PR description

EIP-7843's mandatory `slot_number` header field was only enforced on the `engine_newPayloadV5` path. Blocks arriving via RLP import or sync bypassed that check entirely — there was no block header validation rule for it — so an Amsterdam block whose header omits `slotNumber` was accepted.

This adds:
- `SlotNumberPresentValidationRule` — a detached header rule rejecting any header without `slotNumber` (modeled on `RequestsHashPresentValidationRule`, so it also applies on light-validation sync paths)
- `MainnetBlockHeaderValidator.slotNumberAwareBlockHeaderValidator` — stacks the new rule on the Prague requests-aware validator
- wiring in `amsterdamDefinition` so Amsterdam and later forks enforce the field regardless of how the block arrives

Clique/BFT chains install their own header validators and are unaffected.

## Fixed issue(s)

Caught by hive `eels/consume-rlp` on glamsterdam-devnet-8 ([failing test](https://hive.ethpandaops.io/#/test/glamsterdam-quick/1787065709-f6969313c7cb7e1731441af6513c5225?testnumber=3795)):

`tests/amsterdam/eip7843_slotnum/test_fork_transition.py::test_invalid_post_fork_block_without_slot_number[fork_BPO2ToAmsterdamAtTime15k-blockchain_test]`

Besu imported the invalid activation block, so the simulator's `eth_getBlockByNumber("latest")` returned block 1 without `slot_number` and EEST's header validation failed.

## Testing

- New unit test `SlotNumberPresentValidationRuleTest` (4/4 pass)
- `:ethereum:referencetests:referenceTestsDevnet --tests "*eip7843*"` — all 41 EIP-7843 fixtures pass, including the fork-transition ones (pre-fork blocks without `slotNumber` still validate under the pre-fork spec)
