### PR TITLE
Fixes: GHSA-h594-ww62-rcxv fix logging issue with invalid discv4 packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Removed the legacy `PANTHEON_` environment variable prefix for configuration options, everyone should already use the `BESU_` prefix at this time.
 
 ### Bug fixes
+- Improve logging for malformed discv4 UDP packets.
 - Remove `System.out`/`System.err` logging from `P256VerifyPrecompiledContract` and `BlockchainQueries` — these could leak sensitive data to stdout/stderr in production.
 - EIP-1459 DNS discovery now rejoins TXT records split across multiple `<character-string>`s. Records longer than 255 bytes were truncated, so Besu silently discarded most of every tree, resolving 832 of 3000 nodes from the mainnet tree. [#10985](https://github.com/besu-eth/besu/pull/10985)
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializer.java
@@ -85,15 +85,15 @@ public class PacketDeserializer {
           case ENR_REQUEST -> enrRequestPacketDataRlpReader;
           case ENR_RESPONSE -> enrResponsePacketDataRlpReader;
         };
-    final PacketData packetData;
     try {
-      packetData = deserializer.readFrom(RLP.input(message.slice(Packet.PACKET_DATA_INDEX)));
+      final PacketData packetData =
+          deserializer.readFrom(RLP.input(message.slice(Packet.PACKET_DATA_INDEX)));
+      return packetFactory.create(packetType, packetData, message);
     } catch (final RLPException e) {
       throw new PeerDiscoveryPacketDecodingException("Malformed packet of type: " + packetType, e);
     } catch (final IllegalArgumentException e) {
       throw new PeerDiscoveryPacketDecodingException(
           "Failed decoding packet of type: " + packetType, e);
     }
-    return packetFactory.create(packetType, packetData, message);
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializerTest.java
@@ -14,8 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet;
 
+import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.Endpoint;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.PacketType;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.enrrequest.EnrRequestPacketData;
@@ -223,6 +225,52 @@ public class PacketDeserializerTest {
     EnrRequestPacketData actualPacketData =
         packet.getPacketData(EnrRequestPacketData.class).orElseThrow();
     Assertions.assertEquals(456, actualPacketData.getExpiration());
+  }
+
+  @Test
+  public void testDecodeWithOutOfBoundsSignatureThrowsDecodingException() {
+    // Crafted invalid packet with r=0 in the signature (out of the valid SECP256k1 range [1, n)).
+    final Bytes sig =
+        Bytes.concatenate(
+            Bytes.repeat((byte) 0x00, 32), Bytes.repeat((byte) 0x01, 32), Bytes.of(0x00));
+    final Bytes type = Bytes.of(0x05); // ENR_REQUEST
+    final Bytes body = Bytes.of(0xc5, 0x84, 0xff, 0xff, 0xff, 0xff); // RLP [0xFFFFFFFF] expiration
+    final Bytes rest = Bytes.concatenate(sig, type, body);
+    final Bytes packet = Bytes.concatenate(Hash.keccak256(rest), rest);
+
+    Assertions.assertThrows(
+        PeerDiscoveryPacketDecodingException.class, () -> packetDeserializer.decode(packet));
+  }
+
+  @Test
+  public void testDecodeWithInvalidRecIdThrowsDecodingException() {
+    // recId = 0x02 is outside {0, 1} — SECPSignature.create() throws IllegalArgumentException.
+    final Bytes sig =
+        Bytes.concatenate(
+            Bytes.repeat((byte) 0x01, 32), Bytes.repeat((byte) 0x01, 32), Bytes.of(0x02));
+    final Bytes type = Bytes.of(0x05); // ENR_REQUEST
+    final Bytes body = Bytes.of(0xc5, 0x84, 0xff, 0xff, 0xff, 0xff);
+    final Bytes rest = Bytes.concatenate(sig, type, body);
+    final Bytes packet = Bytes.concatenate(Hash.keccak256(rest), rest);
+
+    Assertions.assertThrows(
+        PeerDiscoveryPacketDecodingException.class, () -> packetDeserializer.decode(packet));
+  }
+
+  @Test
+  public void testDecodeWithOutOfBoundsSThrowsDecodingException() {
+    // s=0 is outside the valid SECP256k1 range [1, n) — exercises the same checkInBounds path as
+    // r=0 but via the s field.
+    final Bytes sig =
+        Bytes.concatenate(
+            Bytes.repeat((byte) 0x01, 32), Bytes.repeat((byte) 0x00, 32), Bytes.of(0x00));
+    final Bytes type = Bytes.of(0x05); // ENR_REQUEST
+    final Bytes body = Bytes.of(0xc5, 0x84, 0xff, 0xff, 0xff, 0xff);
+    final Bytes rest = Bytes.concatenate(sig, type, body);
+    final Bytes packet = Bytes.concatenate(Hash.keccak256(rest), rest);
+
+    Assertions.assertThrows(
+        PeerDiscoveryPacketDecodingException.class, () -> packetDeserializer.decode(packet));
   }
 
   @Test


### PR DESCRIPTION
Fix logging for malformed discv4 UDP packets — improves the log message and adds regression test coverage for invalid signature recovery values (out-of-range recId, s=0).