### PR TITLE
Fix CALLCODE state gas refund target

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -354,7 +354,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
     if (childFrame.getState() == State.COMPLETED_SUCCESS) {
       frame.incrementStateGasSpilled(childFrame.getStateGasSpilled());
     } else {
-      refundCallNewAccountStateGas(frame, childFrame.getContractAddress(), childFrame.getValue());
+      refundCallNewAccountStateGas(frame, childFrame.getRecipientAddress(), childFrame.getValue());
     }
 
     frame.popStackItems(getStackItemsConsumed());

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCallOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCallOperationTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.operation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.Code;
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.MainnetEVMs;
+import org.hyperledger.besu.evm.fluent.SimpleWorld;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.AmsterdamGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
+import org.hyperledger.besu.evm.processor.MessageCallProcessor;
+import org.hyperledger.besu.evm.testutils.FakeBlockValues;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class AbstractCallOperationTest {
+
+  private static final Address STATE_CONTEXT =
+      Address.fromHexString("0x00000000000000000000000000ca110b15012381");
+  private static final Address CODE_ADDRESS = Address.BLS12_G1ADD;
+  private static final long INITIAL_GAS = 1_000_000L;
+
+  private final GasCalculator gasCalculator = new AmsterdamGasCalculator();
+  private final EVM evm =
+      MainnetEVMs.amsterdam(gasCalculator, BigInteger.ONE, EvmConfiguration.DEFAULT);
+  private final long newAccountStateGas =
+      gasCalculator.stateGasCostCalculator().newAccountStateGas();
+  private final long initialStateGasReservoir = 2 * newAccountStateGas;
+
+  @Test
+  void failedCallCodeDoesNotRefundStateGasThatWasNotCharged() {
+    assertThat(gasCalculator.stateGasCostCalculator().isActive()).isTrue();
+
+    final SimpleWorld world = worldWithAliveStateContext();
+    final MessageFrame parentFrame = createParentFrame(world);
+    final CallCodeOperation operation = new CallCodeOperation(gasCalculator);
+
+    pushCallArguments(parentFrame);
+    operation.execute(parentFrame, evm);
+
+    assertThat(world.get(STATE_CONTEXT)).isNotNull();
+    assertThat(world.get(STATE_CONTEXT).isEmpty()).isFalse();
+    assertThat(world.get(CODE_ADDRESS)).isNull();
+    assertThat(parentFrame.getStateGasReservoir()).isEqualTo(initialStateGasReservoir);
+    assertThat(parentFrame.getStateGasUsed()).isZero();
+
+    final MessageFrame childFrame = parentFrame.getMessageFrameStack().peek();
+    assertThat(childFrame).isNotSameAs(parentFrame);
+    assertThat(childFrame.getRecipientAddress()).isEqualTo(STATE_CONTEXT);
+    assertThat(childFrame.getContractAddress()).isEqualTo(CODE_ADDRESS);
+    assertThat(childFrame.getValue()).isEqualTo(Wei.ONE);
+    assertThat(childFrame.getApparentValue()).isEqualTo(Wei.ONE);
+
+    failingPrecompileProcessor().process(childFrame, OperationTracer.NO_TRACING);
+
+    assertThat(childFrame.getState()).isEqualTo(MessageFrame.State.COMPLETED_FAILED);
+    assertThat(parentFrame.getStateGasReservoir()).isEqualTo(initialStateGasReservoir);
+    assertThat(parentFrame.getStateGasUsed()).isZero();
+  }
+
+  @Test
+  void failedCallRefundsChargedNewAccountStateGasOnce() {
+    assertThat(gasCalculator.stateGasCostCalculator().isActive()).isTrue();
+
+    final SimpleWorld world = worldWithAliveStateContext();
+    final MessageFrame parentFrame = createParentFrame(world);
+    final CallOperation operation = new CallOperation(gasCalculator);
+
+    pushCallArguments(parentFrame);
+    operation.execute(parentFrame, evm);
+
+    assertThat(world.get(CODE_ADDRESS)).isNull();
+    assertThat(parentFrame.getStateGasReservoir())
+        .isEqualTo(initialStateGasReservoir - newAccountStateGas);
+    assertThat(parentFrame.getStateGasUsed()).isEqualTo(newAccountStateGas);
+
+    final MessageFrame childFrame = parentFrame.getMessageFrameStack().peek();
+    assertThat(childFrame.getRecipientAddress()).isEqualTo(CODE_ADDRESS);
+    assertThat(childFrame.getContractAddress()).isEqualTo(CODE_ADDRESS);
+
+    failingPrecompileProcessor().process(childFrame, OperationTracer.NO_TRACING);
+
+    assertThat(childFrame.getState()).isEqualTo(MessageFrame.State.COMPLETED_FAILED);
+    assertThat(parentFrame.getStateGasReservoir()).isEqualTo(initialStateGasReservoir);
+    assertThat(parentFrame.getStateGasUsed()).isZero();
+  }
+
+  private SimpleWorld worldWithAliveStateContext() {
+    final SimpleWorld world = new SimpleWorld();
+    world.createAccount(STATE_CONTEXT, 1L, Wei.ONE);
+    return world;
+  }
+
+  private MessageFrame createParentFrame(final SimpleWorld world) {
+    return MessageFrame.builder()
+        .type(MessageFrame.Type.MESSAGE_CALL)
+        .contract(STATE_CONTEXT)
+        .inputData(Bytes.EMPTY)
+        .sender(Address.ZERO)
+        .value(Wei.ZERO)
+        .apparentValue(Wei.ZERO)
+        .code(Code.EMPTY_CODE)
+        .completer(__ -> {})
+        .address(STATE_CONTEXT)
+        .blockHashLookup((__, ___) -> Hash.ZERO)
+        .blockValues(new FakeBlockValues(1L))
+        .gasPrice(Wei.ZERO)
+        .miningBeneficiary(Address.ZERO)
+        .originator(Address.ZERO)
+        .initialGas(INITIAL_GAS)
+        .initialStateGasReservoir(initialStateGasReservoir)
+        .worldUpdater(world)
+        .build();
+  }
+
+  private void pushCallArguments(final MessageFrame frame) {
+    frame.pushStackItem(Bytes.EMPTY); // output size
+    frame.pushStackItem(Bytes.EMPTY); // output offset
+    frame.pushStackItem(Bytes.EMPTY); // input size
+    frame.pushStackItem(Bytes.EMPTY); // input offset
+    frame.pushStackItem(Wei.ONE);
+    frame.pushStackItem(CODE_ADDRESS.getBytes());
+    frame.pushStackItem(Bytes.ofUnsignedLong(100_000L));
+  }
+
+  private MessageCallProcessor failingPrecompileProcessor() {
+    final PrecompileContractRegistry precompiles = new PrecompileContractRegistry();
+    precompiles.put(
+        CODE_ADDRESS,
+        new PrecompiledContract() {
+          @Override
+          public String getName() {
+            return "FAILING";
+          }
+
+          @Override
+          public long gasRequirement(final Bytes input) {
+            return 0L;
+          }
+
+          @Override
+          public PrecompileContractResult computePrecompile(
+              final Bytes input, final MessageFrame messageFrame) {
+            return PrecompileContractResult.halt(
+                null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+          }
+        });
+    return new MessageCallProcessor(evm, precompiles);
+  }
+}


### PR DESCRIPTION
## Fixed Issue(s)

No public issue.

## Description

EIP-8037 charges new-account state gas against the recipient/state-context address before entering a CALL-family child frame. Failed-child completion re-tested the refund predicate against the child contract/code address instead.

Those addresses are the same for an ordinary CALL, but CALLCODE executes code from the contract address in the calling account state context. With an alive recipient A, an absent code address B, and nonzero CALLCODE value, no new-account state gas is charged for A. If the child fails, checking B can nevertheless refund a charge that never occurred, increasing the reservoir and decreasing state gas used.

A precompile exposes the otherwise unusual executable-but-state-empty B shape: code execution is selected by the precompile registry even when no state account exists at that address.

This change uses the child recipient address during failed completion, matching the address used by the upfront charge. The regression tests cover both the CALLCODE no-charge/no-refund case and an ordinary failed CALL that genuinely charges creation state gas and refunds it exactly once.

Current mainnet precompile accounts are prefunded. This is therefore a state-test and Amsterdam development-network consensus-correctness fix, not a claim of a practically triggerable current-mainnet exploit.

## Validation

- Focused regression: ./gradlew :evm:test --tests org.hyperledger.besu.evm.operation.AbstractCallOperationTest
  - Before the patch, only the CALLCODE case failed: expected reservoir 367200, actual 550800.
  - After the patch, both tests pass.
- Affected module suite: ./gradlew :evm:test — passed.
- Formatting: ./gradlew :evm:spotlessCheck — passed.
- Original fixture /tmp/00035601-bls-28.json was verified against SHA-256 431a29a2ffecab05b8be16adb15fdab194a4bdc33edc7f1bef63ed3d1e72ee96 and run with the evmtool state-test tracer. At pc 250, unpatched current main reported 16728322 gas and the patch reported 16630402, removing the same 97920 phantom delta as the original cross-client finding. The fixture contains zero placeholder post-state and logs hashes, so the generic runner reports pass:false despite executing successfully.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out the contribution guidelines.
- [x] Considered documentation; no documentation change is required.
- [x] Considered the changelog; no entry is included because this corrects development-fork EIP-8037 behavior rather than released mainnet behavior.
- [x] Database compatibility is not applicable.

### Locally, you can run these tests to catch failures early:

- [x] spotless: affected module Spotless check passed.
- [x] unit tests: focused regression and full evm module suite passed.
- [ ] acceptance tests: not run; no client/RPC behavior changed.
- [ ] integration tests: the supplied state-test fixture was run directly with evmtool as described above.
- [ ] reference tests: not run; focused state-test reproduction and evm suite cover the change.
- [ ] hive tests: not applicable; no Engine API or RPC behavior changed.