### PR TITLE
fix(rpc): omit gasPrice for EIP-1559 transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Omit `gasPrice` from JSON-RPC transaction results for EIP-1559 fee-market transactions instead of populating it from `effectiveGasPrice` or `maxFeePerGas`. [#11058](https://github.com/besu-eth/besu/issues/11058)
 - Fix `debug_getRawTransaction` returning bare RLP payload (missing EIP-2718 type-byte prefix) for typed transactions, causing `keccak256(raw) != txHash`. Fix `debug_getRawReceipts` double-wrapping typed receipts in an outer RLP byte-string instead of returning the raw `type || rlp(payload)` wire encoding. [#11083](https://github.com/besu-eth/besu/pull/11083)
 - Port clash detection during Besu start now treats TCP and UDP ports separately. [#10904](https://github.com/besu-eth/besu/issues/10904)
 - BFT (QBFT/IBFT) networks configured with Paris or a later execution fork no longer use the PoS transaction selection timeout. The protocol spec inherited `isPoS=true` from the mainnet fork definitions, so `--poa-block-txs-selection-max-time` was ignored and transaction selection ran for the full `--block-txs-selection-max-time` (5000 ms by default), inflating block times on short block-period networks. [#11005](https://github.com/besu-eth/besu/issues/11005)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionBaseResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionBaseResult.java
@@ -64,6 +64,8 @@ public class TransactionBaseResult implements TransactionResult {
 
   private final String from;
   private final String gas;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String gasPrice;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -108,15 +110,7 @@ public class TransactionBaseResult implements TransactionResult {
     this.maxFeePerGas = transaction.getMaxFeePerGas().map(Wei::toShortHexString).orElse(null);
     this.maxFeePerBlobGas =
         transaction.getMaxFeePerBlobGas().map(Wei::toShortHexString).orElse(null);
-    this.gasPrice =
-        Quantity.create(
-            transaction
-                .getGasPrice()
-                .orElseGet(
-                    () ->
-                        maybeBaseFee.isPresent()
-                            ? transaction.getEffectiveGasPrice(maybeBaseFee)
-                            : transaction.getMaxFeePerGas().get()));
+    this.gasPrice = transaction.getGasPrice().map(Quantity::create).orElse(null);
     this.hash = transaction.getHash().toString();
     this.input = transaction.getPayload().toString();
     this.nonce = Quantity.create(transaction.getNonce());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionWithMetadataResultTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionWithMetadataResultTest.java
@@ -65,9 +65,11 @@ public class TransactionWithMetadataResultTest {
                 transaction, 0L, Optional.of(Wei.of(7L)), Hash.ZERO, 0, 0L));
     assertThat(tcr.getMaxFeePerGas()).isNotEmpty();
     assertThat(tcr.getMaxPriorityFeePerGas()).isNotEmpty();
-    assertThat(tcr.getGasPrice()).isNotEmpty();
-    assertThat(tcr.getGasPrice())
-        .isEqualTo(Quantity.create(transaction.getEffectiveGasPrice(Optional.of(Wei.of(7L)))));
+    assertThat(tcr.getGasPrice()).isNull();
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final JsonNode transactionCompleteResultJson = objectMapper.valueToTree(tcr);
+    assertThat(transactionCompleteResultJson.has("gasPrice")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## PR description

`TransactionBaseResult` was synthesizing `gasPrice` for EIP-1559 fee-market transactions from `effectiveGasPrice` when a base fee was available, or from `maxFeePerGas` otherwise. That made transaction result objects populate `gasPrice` even though Besu documents that field as non-EIP1559-only.

This change now derives `gasPrice` only from `Transaction#getGasPrice()`, so legacy and access-list transactions keep their existing field while EIP-1559 fee-market transactions omit it. The EIP-1559 regression test also verifies that the serialized JSON does not contain `gasPrice`.

## Fixed Issue(s)

Fixes besu-eth/besu-docs#2115

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew.bat :ethereum:api:spotlessCheck --no-daemon`
- [x] unit tests: `./gradlew.bat :ethereum:api:test --tests "org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionWithMetadataResultTest" --no-daemon`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)

Notes: On this Windows machine the workspace path contains a non-ASCII character, so the Gradle commands were validated from a short ASCII checkout path to avoid path encoding and long-path failures in generated test data.