### PR TITLE
fix: apply serverStepLimit cap to trace_callMany

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceCall.java
@@ -111,7 +111,7 @@ public abstract class AbstractTraceCall extends AbstractTraceByBlock {
    * limit is 0 (operator opt-out), the caller's value is used as-is. If the caller supplies 0
    * (unlimited), the server ceiling is applied. Otherwise the minimum of the two is used.
    */
-  private TraceOptions applyServerStepLimit(final TraceOptions traceOptions) {
+  protected TraceOptions applyServerStepLimit(final TraceOptions traceOptions) {
     if (serverStepLimit <= 0) {
       return traceOptions;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.BLOCK_NOT_FOUND;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INTERNAL_ERROR;
 
+import org.hyperledger.besu.ethereum.api.ApiConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -55,7 +56,15 @@ public class TraceCallMany extends TraceCall implements JsonRpcMethod {
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
       final TransactionSimulator transactionSimulator) {
-    super(blockchainQueries, protocolSchedule, transactionSimulator);
+    this(blockchainQueries, protocolSchedule, transactionSimulator, null);
+  }
+
+  public TraceCallMany(
+      final BlockchainQueries blockchainQueries,
+      final ProtocolSchedule protocolSchedule,
+      final TransactionSimulator transactionSimulator,
+      final ApiConfiguration apiConfiguration) {
+    super(blockchainQueries, protocolSchedule, transactionSimulator, apiConfiguration);
   }
 
   @Override
@@ -156,7 +165,8 @@ public class TraceCallMany extends TraceCall implements JsonRpcMethod {
       final WorldUpdater worldUpdater) {
     final Set<TraceTypeParameter.TraceType> traceTypes = traceTypeParameter.getTraceTypes();
     final DebugOperationTracer tracer =
-        new DebugOperationTracer(buildTraceOptions(traceTypes).opCodeTracerConfig(), false);
+        new DebugOperationTracer(
+            applyServerStepLimit(buildTraceOptions(traceTypes)).opCodeTracerConfig(), false);
     final var miningBeneficiary =
         protocolSchedule
             .getByBlockHeader(header)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -86,7 +86,8 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
         new TraceBlock(protocolSchedule, blockchainQueries, metricsSystem, ethScheduler),
         new TraceCall(blockchainQueries, protocolSchedule, transactionSimulator, apiConfiguration),
-        new TraceCallMany(blockchainQueries, protocolSchedule, transactionSimulator),
+        new TraceCallMany(
+            blockchainQueries, protocolSchedule, transactionSimulator, apiConfiguration),
         new TraceRawTransaction(protocolSchedule, blockchainQueries, transactionSimulator));
   }
 }


### PR DESCRIPTION
Follow up to #11100 
TraceCall was wired to receive ApiConfiguration and clamp EVM steps via applyServerStepLimit(), but TraceCallMany was not. TraceCallMany.getSingleCallResult() constructed DebugOperationTracer directly from buildTraceOptions() without applying the server-side cap, leaving trace_callMany unbounded regardless of --rpc-max-trace-steps.

- Make applyServerStepLimit() protected in AbstractTraceCall so subclasses can call it
- Add ApiConfiguration constructor to TraceCallMany delegating to super
- Apply applyServerStepLimit() in getSingleCallResult() before building the tracer
- Wire apiConfiguration into TraceCallMany in TraceJsonRpcMethods


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


