### PR TITLE
Fix CPU exhaustion from speculative execution after block rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Abandon speculative transaction execution once block processing has finished. The parallel block processor dispatched one task per transaction up front, and nothing stopped the ones still queued when processing aborted early, so an invalid block kept every core busy long after it was rejected. A 4096-transaction block that Besu rejected at transaction 11 kept the process busy for ~18s at ~2600% CPU; it is now ~0.8s.
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)
 - Bonsai world state rolling failures are now logged at `WARN` instead of `INFO`, and a missing block header or trie log during a roll reports which block hash or trie log was missing. [#10859](https://github.com/besu-eth/besu/issues/10859)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -250,6 +250,10 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
             .getBlockAccessListFactory()
             .map(BlockAccessListFactory::newBlockAccessListBuilder);
 
+    // Declared outside the try so that the finally block can abandon any speculative work still
+    // outstanding, on every exit path including the early returns for an invalid block.
+    Optional<PreprocessingContext> preProcessingContext = Optional.empty();
+
     try {
       final Optional<AccessLocationTracker> preExecutionAccessLocationTracker =
           blockAccessListBuilder.map(
@@ -279,7 +283,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
                               calculateExcessBlobGasForParent(protocolSpec, parentHeader)))
               .orElse(Wei.ZERO);
 
-      final Optional<PreprocessingContext> preProcessingContext =
+      preProcessingContext =
           preprocessingBlockFunction.run(
               protocolContext,
               blockHeader,
@@ -567,6 +571,9 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
           parallelizedTxFound ? Optional.of(nbParallelTx) : Optional.empty());
     } finally {
       stateRootCommitter.cancel();
+      // Processing is over, so any speculative execution still queued can no longer contribute a
+      // usable result. Left alone it would keep the CPU busy well past this point.
+      preProcessingContext.ifPresent(ctx -> ctx.processor().abandonPendingExecutions());
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
@@ -36,6 +36,32 @@ public abstract class ParallelBlockTransactionProcessor {
 
   protected CompletableFuture<ParallelizedTransactionContext>[] futures;
 
+  /**
+   * Set once block processing no longer has any use for the speculative results.
+   *
+   * <p>Read from the executor threads, written from the block processing thread, hence volatile.
+   */
+  private volatile boolean abandoned;
+
+  /**
+   * Abandons the speculative executions dispatched by {@link #runAsyncBlock} that have not started
+   * yet.
+   *
+   * <p>Block processing routinely stops before the last transaction: a transaction is invalid, the
+   * block gas budget is exhausted, the state root does not match. Every result still queued at that
+   * point is unusable, but the tasks stay runnable and keep every core busy long after the block
+   * has been rejected. Since a block is rejected on attacker-supplied data, that turns one invalid
+   * block into sustained CPU exhaustion.
+   *
+   * <p>Cancelling the futures would not help: {@link CompletableFuture#cancel} does not interrupt a
+   * task that is already running and does not remove it from the executor queue. Tasks are
+   * therefore made to check this flag and return early instead. Executions already in flight are
+   * left to finish, so at most one transaction per executor thread still runs to completion.
+   */
+  public void abandonPendingExecutions() {
+    abandoned = true;
+  }
+
   protected CompletableFuture<ParallelizedTransactionContext> removeFuture(final int txIndex) {
     final CompletableFuture<ParallelizedTransactionContext> future = futures[txIndex];
     futures[txIndex] = null;
@@ -54,6 +80,7 @@ public abstract class ParallelBlockTransactionProcessor {
       final Optional<BlockAccessListBuilder> blockAccessListBuilder,
       final Optional<BlockHeader> maybeParentHeader) {
 
+    abandoned = false;
     futures = new CompletableFuture[transactions.size()];
 
     for (int i = 0; i < transactions.size(); i++) {
@@ -63,16 +90,20 @@ public abstract class ParallelBlockTransactionProcessor {
       futures[i] =
           CompletableFuture.supplyAsync(
               () ->
-                  runTransaction(
-                      protocolContext,
-                      blockHeader,
-                      txIndex,
-                      transaction,
-                      miningBeneficiary,
-                      blockHashLookup,
-                      blobGasPrice,
-                      blockAccessListBuilder,
-                      maybeParentHeader),
+                  abandoned
+                      // A null context means "no speculative result for this transaction", which
+                      // getProcessingResult already handles by executing it on the block thread.
+                      ? null
+                      : runTransaction(
+                          protocolContext,
+                          blockHeader,
+                          txIndex,
+                          transaction,
+                          miningBeneficiary,
+                          blockHashLookup,
+                          blobGasPrice,
+                          blockAccessListBuilder,
+                          maybeParentHeader),
               executor);
     }
   }


### PR DESCRIPTION
The parallel block processor schedules one task per transaction upfront. If block processing stops early, for example because of an invalid transaction, exhausted gas budget, or a state root mismatch, the remaining queued tasks are not stopped. They keep running and can keep all CPU cores busy even though the block has already been rejected.

This is a DoS risk because an attacker can deliberately create a block that fails early while still causing lots of unnecessary parallel work.

Cancelling the `CompletableFuture`s does not solve this, since `CompletableFuture.cancel` does not interrupt running tasks or reliably remove queued ones from the executor. Instead, the tasks check a shared stop flag and exit early. Returning `null` is already supported as meaning “no speculative result,” in which case the transaction is simply executed normally on the block-processing thread.
