### PR TITLE
Add block creation timing to QBFT block building

### DIFF
--- a/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/bft/qbft/QbftBlockProductionLogAcceptanceTest.java
+++ b/acceptance-tests/tests/src/acceptanceTest/java/org/hyperledger/besu/tests/acceptance/bft/qbft/QbftBlockProductionLogAcceptanceTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.bft.qbft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNodeRunner;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+public class QbftBlockProductionLogAcceptanceTest extends AcceptanceTestBase {
+
+  private static final Pattern PRODUCED_LOG_PATTERN =
+      Pattern.compile(
+          "Produced #.*Timing\\(started at .*duplicateWorldState=\\d+ms.*preTxsSelection=\\d+ms"
+              + ".*selectedTxsEvaluation=\\d+ms.*blockAssembled=\\d+ms.*blockImported=\\d+ms\\)");
+
+  @Test
+  public void producedBlockLogReportsBlockCreationTimings() throws Exception {
+    Assumptions.assumeTrue(
+        BesuNodeRunner.isProcessBesuNodeRunner(),
+        "Console capture is only available when Besu runs as a process");
+
+    final BesuNode minerNode = besu.createQbftNode("miner1");
+    cluster.startConsoleCapture();
+    cluster.start(minerNode);
+
+    cluster.verify(blockchain.reachesHeight(minerNode, 1));
+
+    final Account sender = accounts.createAccount("account1");
+    minerNode.execute(accountTransactions.createTransfer(sender, 50));
+    cluster.verify(sender.balanceEquals(50));
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(PRODUCED_LOG_PATTERN.matcher(cluster.peekConsoleContents()).find())
+                    .as("a 'Produced #...' log line with Timing information")
+                    .isTrue());
+
+    assertThat(cluster.peekConsoleContents()).doesNotContain("Produced block", "Produced empty");
+  }
+}

--- a/app/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -51,6 +51,7 @@ import org.hyperledger.besu.consensus.qbft.QbftForksSchedulesFactory;
 import org.hyperledger.besu.consensus.qbft.QbftProtocolScheduleBuilder;
 import org.hyperledger.besu.consensus.qbft.adaptor.AdaptorUtil;
 import org.hyperledger.besu.consensus.qbft.adaptor.BftEventHandlerAdaptor;
+import org.hyperledger.besu.consensus.qbft.adaptor.QbftBlockAdaptor;
 import org.hyperledger.besu.consensus.qbft.adaptor.QbftBlockCodecAdaptor;
 import org.hyperledger.besu.consensus.qbft.adaptor.QbftBlockCreatorFactoryAdaptor;
 import org.hyperledger.besu.consensus.qbft.adaptor.QbftBlockInterfaceAdaptor;
@@ -83,10 +84,11 @@ import org.hyperledger.besu.consensus.qbft.validator.ValidatorModeTransitionLogg
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreationTiming;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -266,10 +268,7 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
     final Subscribers<QbftMinedBlockObserver> minedBlockObservers = Subscribers.create();
     minedBlockObservers.subscribe(
         qbftBlock -> ethProtocolManager.blockMined(AdaptorUtil.toBesuBlock(qbftBlock)));
-    minedBlockObservers.subscribe(
-        qbftBlock ->
-            blockLogger(transactionPool, localAddress)
-                .blockMined(AdaptorUtil.toBesuBlock(qbftBlock)));
+    minedBlockObservers.subscribe(blockLogger(transactionPool, localAddress));
 
     final EthSynchronizerUpdater synchronizerUpdater =
         new EthSynchronizerUpdater(ethProtocolManager.ethContext().getEthPeers());
@@ -452,9 +451,27 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
     return new BftValidatorOverrides(result);
   }
 
-  private static MinedBlockObserver blockLogger(
+  private static QbftMinedBlockObserver blockLogger(
       final TransactionPool transactionPool, final Address localAddress) {
-    return block ->
+    return qbftBlock -> {
+      final Block block = AdaptorUtil.toBesuBlock(qbftBlock);
+      final Optional<BlockCreationTiming> timing =
+          qbftBlock instanceof QbftBlockAdaptor adaptor
+              ? adaptor.getBlockCreationTiming()
+              : Optional.empty();
+      if (block.getHeader().getCoinbase().equals(localAddress) && timing.isPresent()) {
+        LOG.info(
+            String.format(
+                "Produced #%,d  (%s)| %4d tx | %d pending | %,d (%01.1f%%) gas in %01.3fs | Timing(%s)",
+                block.getHeader().getNumber(),
+                block.getHash().toShortLogString(),
+                block.getBody().getTransactions().size(),
+                transactionPool.count(),
+                block.getHeader().getGasUsed(),
+                (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
+                timing.get().end("blockImported").toMillis() / 1000.0,
+                timing.get()));
+      } else {
         LOG.info(
             String.format(
                 "%s %-11s #%,d / %d tx / %d pending / %,d (%01.1f%%) gas / (%s)",
@@ -466,5 +483,7 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
                 block.getHeader().getGasUsed(),
                 (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
                 block.getHash().getBytes().toHexString()));
+      }
+    };
   }
 }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockAdaptor.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockAdaptor.java
@@ -18,9 +18,11 @@ import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreationTiming;
 import org.hyperledger.besu.ethereum.core.Block;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,7 @@ public class QbftBlockAdaptor implements QbftBlock {
 
   private final Block besuBlock;
   private final QbftBlockHeader qbftBlockHeader;
+  private final Optional<BlockCreationTiming> blockCreationTiming;
 
   /**
    * Constructs a QbftBlock from a Besu Block.
@@ -42,8 +45,20 @@ public class QbftBlockAdaptor implements QbftBlock {
    * @param besuBlock the Besu Block
    */
   public QbftBlockAdaptor(final Block besuBlock) {
+    this(besuBlock, Optional.empty());
+  }
+
+  /**
+   * Constructs a QbftBlock from a Besu Block, keeping the block creation timing.
+   *
+   * @param besuBlock the Besu Block
+   * @param blockCreationTiming the timing of the block creation, when created locally
+   */
+  public QbftBlockAdaptor(
+      final Block besuBlock, final Optional<BlockCreationTiming> blockCreationTiming) {
     this.besuBlock = besuBlock;
     this.qbftBlockHeader = new QbftBlockHeaderAdaptor(besuBlock.getHeader());
+    this.blockCreationTiming = blockCreationTiming;
   }
 
   @Override
@@ -82,6 +97,15 @@ public class QbftBlockAdaptor implements QbftBlock {
    */
   public Block getBesuBlock() {
     return besuBlock;
+  }
+
+  /**
+   * Returns the block creation timing, only present when the block was created locally.
+   *
+   * @return the block creation timing
+   */
+  public Optional<BlockCreationTiming> getBlockCreationTiming() {
+    return blockCreationTiming;
   }
 
   @Override

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockCreatorAdaptor.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockCreatorAdaptor.java
@@ -21,12 +21,14 @@ import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCreator;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader;
 import org.hyperledger.besu.crypto.SECPSignature;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreationTiming;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /** Adaptor class to allow a {@link BlockCreator} to be used as a {@link QbftBlockCreator}. */
 public class QbftBlockCreatorAdaptor implements QbftBlockCreator {
@@ -53,7 +55,9 @@ public class QbftBlockCreatorAdaptor implements QbftBlockCreator {
         besuBlockCreator.createBlock(
             headerTimeStampSeconds, AdaptorUtil.toBesuBlockHeader(parentHeader));
     return new BlockCreationResult(
-        new QbftBlockAdaptor(blockResult.getBlock()), blockResult.getBlockAccessList());
+        new QbftBlockAdaptor(
+            blockResult.getBlock(), Optional.of(blockResult.getBlockCreationTimings())),
+        blockResult.getBlockAccessList());
   }
 
   @Override
@@ -78,6 +82,10 @@ public class QbftBlockCreatorAdaptor implements QbftBlockCreator {
             .blockHeaderFunctions(BftBlockHeaderFunctions.forOnchainBlock(bftExtraDataCodec))
             .buildBlockHeader();
     final Block sealedBesuBlock = new Block(sealedHeader, besuBlock.getBody());
-    return new QbftBlockAdaptor(sealedBesuBlock);
+    final Optional<BlockCreationTiming> timing =
+        block instanceof QbftBlockAdaptor adaptor
+            ? adaptor.getBlockCreationTiming()
+            : Optional.empty();
+    return new QbftBlockAdaptor(sealedBesuBlock, timing);
   }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockCreatorAdaptorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftBlockCreatorAdaptorTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCreator;
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreationTiming;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -53,8 +54,10 @@ class QbftBlockCreatorAdaptorTest {
     BlockHeader besuParentHeader = new BlockHeaderTestFixture().buildHeader();
     QbftBlockHeader parentHeader = new QbftBlockHeaderAdaptor(besuParentHeader);
 
+    BlockCreationTiming timing = new BlockCreationTiming();
     when(blockCreator.createBlock(10, besuParentHeader))
-        .thenReturn(new BlockCreator.BlockCreationResult(besuBlock, null, null, Optional.empty()));
+        .thenReturn(
+            new BlockCreator.BlockCreationResult(besuBlock, null, timing, Optional.empty()));
 
     QbftBlockCreatorAdaptor qbftBlockCreator =
         new QbftBlockCreatorAdaptor(blockCreator, qbftExtraDataCodec);
@@ -62,6 +65,7 @@ class QbftBlockCreatorAdaptorTest {
         qbftBlockCreator.createBlock(10, parentHeader);
     QbftBlock qbftBlock = qbftBlockCreationResult.block();
     assertThat(((QbftBlockAdaptor) qbftBlock).getBesuBlock()).isEqualTo(besuBlock);
+    assertThat(((QbftBlockAdaptor) qbftBlock).getBlockCreationTiming()).contains(timing);
   }
 
   @Test


### PR DESCRIPTION
## PR description
With this PR, QBFT logs the block production same way as the engine API, using the same BlockCreationTiming object:
```
Produced #4  (42e96.....b4a4f)|    1 tx | 0 pending | 21,000 (0.4%) gas in 0.032s | Timing(started at ..., duplicateWorldState=0ms, preTxsSelection=0ms, txsSelection=19ms, selectedTxsEvaluation=16ms, blockAssembled=3ms, blockImported=9ms)
```

Before, the timing created by AbstractBlockCreator was lost in the QBFT adaptors. Now it is kept on QbftBlockAdaptor until the block import, and the logger finish it with a last step blockImported. For imported blocks the log format stays the same as before.

The explicit call `blockMined(AdaptorUtil.toBesuBlock(qbftBlock))` is removed because it was only there to bridge the QbftBlock observer with a Besu MinedBlockObserver, and this conversion was unwrapping the adaptor so the timing was lost. Now the logger is itself a QbftMinedBlockObserver, subscribed directly, and QbftRound still calls it like before.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


