### PR TITLE
Abort JSON-RPC stream backpressure wait when the peer goes away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Serialize `BftMiningCoordinator` `enable()`/`disable()` with `start()`/`stop()` so the mining state flips and their surrounding checks can no longer interleave with concurrent lifecycle transitions. [#10887](https://github.com/besu-eth/besu/pull/10887)
 - An EIP-7702 transaction with an empty `authorization_list` is now rejected by transaction validation rather than by RLP decoding. Over the Engine API such a transaction made the whole payload report `Failed to decode transactions from block parameter`, hiding both the rule that was broken and any other defect the transaction had. [#11193](https://github.com/besu-eth/besu/pull/11193)
 - `engine_newPayloadV4`+ now returns `-32602` for an `executionRequests` element consisting only of a type byte, as execution-apis requires, including when that type byte is one Besu does not recognize. Such an element was previously answered with an `INVALID` payload status. [#11194](https://github.com/besu-eth/besu/pull/11194)
+- JSON-RPC response streaming no longer parks a Vert.x worker thread for the full backpressure timeout after the client has gone away, so a client that stops reading a large response can no longer starve the worker pool that also serves the Engine API. [#11146](https://github.com/besu-eth/besu/pull/11146)
 
 ### Additions and Improvements
 - Implement native `callTracer` execution tracing, reducing memory use for `debug_trace*`. [#11077](https://github.com/besu-eth/besu/pull/11077)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.buffer.Buffer;
@@ -61,7 +62,7 @@ public class JsonResponseStreamer extends OutputStream {
       chunked = true;
     }
 
-    StreamBackpressure.awaitDrain(response, this::writeAborted);
+    StreamBackpressure.awaitDrain(response, this::stopOnFailureOrClosed);
 
     Buffer buf = Buffer.buffer(len);
     buf.appendBytes(bbuf, off, len);
@@ -81,6 +82,12 @@ public class JsonResponseStreamer extends OutputStream {
     }
   }
 
+  /**
+   * Guards both the next write and a thread blocked on backpressure. The original failure is
+   * rethrown as-is so a write error stays distinguishable from a client that hung up.
+   *
+   * @throws IOException if writing should be abandoned
+   */
   private void stopOnFailureOrClosed() throws IOException {
     if (closed) {
       throw new IOException("Stream closed");
@@ -91,21 +98,16 @@ public class JsonResponseStreamer extends OutputStream {
       LOG.debug("Stop writing to remote address {} due to a failure", remoteAddress, t);
       throw (t instanceof IOException ioException) ? ioException : new IOException(t);
     }
+
+    // The event loop can complete the response - the JSON-RPC timeout handler does - while this
+    // worker thread is between writes. Writing to it afterwards throws IllegalStateException.
+    if (response.closed() || response.ended()) {
+      throw new ClosedChannelException();
+    }
   }
 
   private void handleFailure(final Throwable t) {
     LOG.debug("Write to remote address {} failed", remoteAddress, t);
     failure.set(t);
-  }
-
-  /**
-   * True once this response can no longer be delivered, so a thread waiting for the write queue to
-   * drain should give up rather than wait out the backpressure timeout. {@code ended()} covers the
-   * JSON-RPC timeout handler completing the response from the event loop while we are blocked here.
-   *
-   * @return whether writing should be abandoned
-   */
-  private boolean writeAborted() {
-    return failure.get() != null || response.closed() || response.ended();
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
@@ -61,7 +61,7 @@ public class JsonResponseStreamer extends OutputStream {
       chunked = true;
     }
 
-    StreamBackpressure.awaitDrain(response);
+    StreamBackpressure.awaitDrain(response, this::writeAborted);
 
     Buffer buf = Buffer.buffer(len);
     buf.appendBytes(bbuf, off, len);
@@ -96,5 +96,16 @@ public class JsonResponseStreamer extends OutputStream {
   private void handleFailure(final Throwable t) {
     LOG.debug("Write to remote address {} failed", remoteAddress, t);
     failure.set(t);
+  }
+
+  /**
+   * True once this response can no longer be delivered, so a thread waiting for the write queue to
+   * drain should give up rather than wait out the backpressure timeout. {@code ended()} covers the
+   * JSON-RPC timeout handler completing the response from the event loop while we are blocked here.
+   *
+   * @return whether writing should be abandoned
+   */
+  private boolean writeAborted() {
+    return failure.get() != null || response.closed() || response.ended();
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressure.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressure.java
@@ -15,8 +15,10 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 import io.vertx.core.streams.WriteStream;
 
@@ -30,33 +32,71 @@ import io.vertx.core.streams.WriteStream;
  */
 public final class StreamBackpressure {
 
-  private static final long DRAIN_TIMEOUT_SECONDS = 60;
+  private static final long DRAIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(60);
+
+  /**
+   * How often the wait is broken to re-evaluate the abort condition. A drain still wakes the waiter
+   * immediately via the drain handler, so this only bounds how quickly a dead peer is noticed.
+   */
+  private static final long ABORT_POLL_MILLIS = 50;
 
   private StreamBackpressure() {}
 
   /**
-   * If the write queue is full, blocks until it drains below the low watermark or the timeout
-   * expires.
+   * If the write queue is full, blocks until it drains below the low watermark, the peer goes away,
+   * or the timeout expires.
    *
    * @param stream the Vertx WriteStream to check
+   * @param aborted returns true once the response can no longer be written — the connection was
+   *     closed, the response was already ended (for example by the JSON-RPC timeout handler), or a
+   *     previous write failed. Re-evaluated every 50 ms while waiting.
+   * @throws ClosedChannelException if {@code aborted} becomes true while waiting
    * @throws IOException if the timeout expires or the thread is interrupted
    */
-  public static void awaitDrain(final WriteStream<?> stream) throws IOException {
-    if (stream.writeQueueFull()) {
-      final CountDownLatch latch = new CountDownLatch(1);
-      stream.drainHandler(v -> latch.countDown());
-      // Re-check after setting handler to avoid race where queue drained
+  public static void awaitDrain(final WriteStream<?> stream, final BooleanSupplier aborted)
+      throws IOException {
+    awaitDrain(stream, aborted, DRAIN_TIMEOUT_MILLIS);
+  }
+
+  static void awaitDrain(
+      final WriteStream<?> stream, final BooleanSupplier aborted, final long timeoutMillis)
+      throws IOException {
+    if (!stream.writeQueueFull()) {
+      return;
+    }
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    stream.drainHandler(v -> latch.countDown());
+    try {
+      // Re-check after setting the handler to avoid a race where the queue drained
       // between the full-check and the handler registration
-      if (stream.writeQueueFull()) {
-        try {
-          if (!latch.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            throw new IOException("Timed out waiting for write queue to drain");
-          }
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new IOException("Interrupted waiting for write queue to drain", e);
+      if (!stream.writeQueueFull()) {
+        return;
+      }
+      final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+      while (true) {
+        // Checked before every wait slice: nothing counts the latch down when the peer
+        // disappears, so without this the thread would park for the full timeout even though
+        // the response can never be delivered.
+        if (aborted.getAsBoolean()) {
+          throw new ClosedChannelException();
+        }
+        final long remainingNanos = deadline - System.nanoTime();
+        if (remainingNanos <= 0) {
+          throw new IOException("Timed out waiting for write queue to drain");
+        }
+        final long waitMillis =
+            Math.min(ABORT_POLL_MILLIS, TimeUnit.NANOSECONDS.toMillis(remainingNanos) + 1);
+        if (latch.await(waitMillis, TimeUnit.MILLISECONDS)) {
+          return;
         }
       }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted waiting for write queue to drain", e);
+    } finally {
+      // Do not leave a handler pointing at a latch nobody is waiting on any more.
+      stream.drainHandler(null);
     }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressure.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressure.java
@@ -18,8 +18,8 @@ import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
 
+import io.vertx.core.Handler;
 import io.vertx.core.streams.WriteStream;
 
 /**
@@ -34,53 +34,62 @@ public final class StreamBackpressure {
 
   private static final long DRAIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(60);
 
-  /**
-   * How often the wait is broken to re-evaluate the abort condition. A drain still wakes the waiter
-   * immediately via the drain handler, so this only bounds how quickly a dead peer is noticed.
-   */
+  /** Bounds how long a waiter can stay parked after the peer has gone away. */
   private static final long ABORT_POLL_MILLIS = 50;
 
   private StreamBackpressure() {}
+
+  /** Signals that a response can no longer be delivered. */
+  @FunctionalInterface
+  public interface AbortCheck {
+
+    /**
+     * Implementations should throw {@link ClosedChannelException} for a lost peer and the
+     * underlying failure for a write error, so the two stay distinguishable in the logs.
+     *
+     * @throws IOException if the response can no longer be delivered
+     */
+    void checkNotAborted() throws IOException;
+  }
 
   /**
    * If the write queue is full, blocks until it drains below the low watermark, the peer goes away,
    * or the timeout expires.
    *
    * @param stream the Vertx WriteStream to check
-   * @param aborted returns true once the response can no longer be written — the connection was
-   *     closed, the response was already ended (for example by the JSON-RPC timeout handler), or a
-   *     previous write failed. Re-evaluated every 50 ms while waiting.
-   * @throws ClosedChannelException if {@code aborted} becomes true while waiting
-   * @throws IOException if the timeout expires or the thread is interrupted
+   * @param abortCheck throws once the response can no longer be written
+   * @throws IOException if {@code abortCheck} throws while waiting, if the timeout expires, or if
+   *     the thread is interrupted
    */
-  public static void awaitDrain(final WriteStream<?> stream, final BooleanSupplier aborted)
+  public static void awaitDrain(final WriteStream<?> stream, final AbortCheck abortCheck)
       throws IOException {
-    awaitDrain(stream, aborted, DRAIN_TIMEOUT_MILLIS);
+    awaitDrain(stream, abortCheck, DRAIN_TIMEOUT_MILLIS);
   }
 
   static void awaitDrain(
-      final WriteStream<?> stream, final BooleanSupplier aborted, final long timeoutMillis)
+      final WriteStream<?> stream, final AbortCheck abortCheck, final long timeoutMillis)
       throws IOException {
-    if (!stream.writeQueueFull()) {
+    // A closed ServerWebSocket rejects every query about its write queue, so the abort has to be
+    // detected before the stream is touched.
+    abortCheck.checkNotAborted();
+
+    if (!writeQueueFull(stream)) {
       return;
     }
 
     final CountDownLatch latch = new CountDownLatch(1);
-    stream.drainHandler(v -> latch.countDown());
+    if (!setDrainHandler(stream, v -> latch.countDown())) {
+      throw new ClosedChannelException();
+    }
     try {
-      // Re-check after setting the handler to avoid a race where the queue drained
-      // between the full-check and the handler registration
-      if (!stream.writeQueueFull()) {
+      // Guards against the queue draining between the full-check and the handler registration.
+      if (!writeQueueFull(stream)) {
         return;
       }
       final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
       while (true) {
-        // Checked before every wait slice: nothing counts the latch down when the peer
-        // disappears, so without this the thread would park for the full timeout even though
-        // the response can never be delivered.
-        if (aborted.getAsBoolean()) {
-          throw new ClosedChannelException();
-        }
+        // Nothing counts the latch down when the peer disappears, so the abort has to be polled.
+        abortCheck.checkNotAborted();
         final long remainingNanos = deadline - System.nanoTime();
         if (remainingNanos <= 0) {
           throw new IOException("Timed out waiting for write queue to drain");
@@ -95,8 +104,34 @@ public final class StreamBackpressure {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted waiting for write queue to drain", e);
     } finally {
-      // Do not leave a handler pointing at a latch nobody is waiting on any more.
-      stream.drainHandler(null);
+      // Do not leave a handler pointing at a latch nobody waits on any more.
+      setDrainHandler(stream, null);
+    }
+  }
+
+  private static boolean writeQueueFull(final WriteStream<?> stream) throws IOException {
+    try {
+      return stream.writeQueueFull();
+    } catch (final IllegalStateException e) {
+      // ServerWebSocket throws instead of answering once the socket is closed
+      final ClosedChannelException closed = new ClosedChannelException();
+      closed.initCause(e);
+      throw closed;
+    }
+  }
+
+  /**
+   * @return false if the stream refused the handler because it is already closed
+   */
+  private static boolean setDrainHandler(
+      final WriteStream<?> stream, final Handler<Void> drainHandler) {
+    try {
+      stream.drainHandler(drainHandler);
+      return true;
+    } catch (final IllegalStateException e) {
+      // ServerWebSocket.drainHandler() throws once the socket is closed, even when clearing the
+      // handler with null. Swallowed so it cannot mask the abort the caller reports.
+      return false;
     }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
@@ -58,7 +58,7 @@ class JsonResponseStreamer extends OutputStream {
     stopOnFailureOrClosed();
 
     if (buffer != EMPTY_BUFFER) {
-      StreamBackpressure.awaitDrain(response);
+      StreamBackpressure.awaitDrain(response, this::writeAborted);
       writeFrame(buffer, false);
     }
     Buffer buf = Buffer.buffer(len);
@@ -103,5 +103,15 @@ class JsonResponseStreamer extends OutputStream {
   private void handleFailure(final Throwable t) {
     LOG.debug("Write to remote address {} failed", response.remoteAddress(), t);
     failure.set(t);
+  }
+
+  /**
+   * True once this response can no longer be delivered, so a thread waiting for the write queue to
+   * drain should give up rather than wait out the backpressure timeout.
+   *
+   * @return whether writing should be abandoned
+   */
+  private boolean writeAborted() {
+    return failure.get() != null || response.isClosed();
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.StreamBackpressure;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.buffer.Buffer;
@@ -58,7 +59,7 @@ class JsonResponseStreamer extends OutputStream {
     stopOnFailureOrClosed();
 
     if (buffer != EMPTY_BUFFER) {
-      StreamBackpressure.awaitDrain(response, this::writeAborted);
+      StreamBackpressure.awaitDrain(response, this::stopOnFailureOrClosed);
       writeFrame(buffer, false);
     }
     Buffer buf = Buffer.buffer(len);
@@ -88,6 +89,12 @@ class JsonResponseStreamer extends OutputStream {
     }
   }
 
+  /**
+   * Guards both the next write and a thread blocked on backpressure. The original failure is
+   * rethrown as-is so a write error stays distinguishable from a client that hung up.
+   *
+   * @throws IOException if writing should be abandoned
+   */
   private void stopOnFailureOrClosed() throws IOException {
     if (closed) {
       throw new IOException("Stream closed");
@@ -98,20 +105,14 @@ class JsonResponseStreamer extends OutputStream {
       LOG.debug("Stop writing to remote address {} due to a failure", response.remoteAddress(), t);
       throw (t instanceof IOException ioException) ? ioException : new IOException(t);
     }
+
+    if (response.isClosed()) {
+      throw new ClosedChannelException();
+    }
   }
 
   private void handleFailure(final Throwable t) {
     LOG.debug("Write to remote address {} failed", response.remoteAddress(), t);
     failure.set(t);
-  }
-
-  /**
-   * True once this response can no longer be delivered, so a thread waiting for the write queue to
-   * drain should give up rather than wait out the backpressure timeout.
-   *
-   * @return whether writing should be abandoned
-   */
-  private boolean writeAborted() {
-    return failure.get() != null || response.isClosed();
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
@@ -136,8 +136,7 @@ public class JsonResponseStreamerTest {
 
   @Test
   public void writeAbortsWhenResponseAlreadyEndedWhileQueueIsFull() {
-    // the JSON-RPC timeout handler ends the response from the event loop while a worker
-    // thread is blocked on backpressure
+    // the timeout handler ends the response while a worker thread is blocked on backpressure
     when(httpResponse.writeQueueFull()).thenReturn(true);
     when(httpResponse.ended()).thenReturn(true);
 
@@ -146,6 +145,33 @@ public class JsonResponseStreamerTest {
     assertThatThrownBy(() -> streamer.write("xyz".getBytes(StandardCharsets.UTF_8)))
         .isInstanceOf(ClosedChannelException.class);
     verify(httpResponse, never()).write(any(Buffer.class));
+  }
+
+  @Test
+  public void writeAbortsWhenResponseAlreadyEndedAndQueueIsNotFull() {
+    // the timeout handler ends the response while the worker thread is between writes, so there is
+    // no backpressure wait to abort
+    when(httpResponse.writeQueueFull()).thenReturn(false);
+    when(httpResponse.ended()).thenReturn(true);
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(httpResponse, testAddress);
+
+    assertThatThrownBy(() -> streamer.write("xyz".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(ClosedChannelException.class);
+    verify(httpResponse, never()).write(any(Buffer.class));
+  }
+
+  @Test
+  public void writeKeepsTheOriginalFailureRatherThanReportingAClosedChannel() throws IOException {
+    final IOException cause = new IOException("SSL write failed");
+    when(failedResponse.write(any(Buffer.class))).thenReturn(new FailedFuture<>(cause));
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(failedResponse, testAddress);
+    streamer.write("xyz".getBytes(StandardCharsets.UTF_8));
+
+    // a genuine write error must stay distinguishable from a peer that simply hung up
+    assertThatThrownBy(() -> streamer.write("abc".getBytes(StandardCharsets.UTF_8)))
+        .isSameAs(cause);
   }
 
   private ArgumentMatcher<Buffer> bufferContains(final String text) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 
 import io.vertx.core.buffer.Buffer;
@@ -119,6 +120,32 @@ public class JsonResponseStreamerTest {
     verify(failedResponse).write(argThat(bufferContains("xyz")));
     verify(failedResponse, never()).write(argThat(bufferContains("abc")));
     verify(failedResponse).end();
+  }
+
+  @Test
+  public void writeAbortsWhenConnectionClosesWhileQueueIsFull() {
+    when(httpResponse.writeQueueFull()).thenReturn(true);
+    when(httpResponse.closed()).thenReturn(true);
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(httpResponse, testAddress);
+
+    assertThatThrownBy(() -> streamer.write("xyz".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(ClosedChannelException.class);
+    verify(httpResponse, never()).write(any(Buffer.class));
+  }
+
+  @Test
+  public void writeAbortsWhenResponseAlreadyEndedWhileQueueIsFull() {
+    // the JSON-RPC timeout handler ends the response from the event loop while a worker
+    // thread is blocked on backpressure
+    when(httpResponse.writeQueueFull()).thenReturn(true);
+    when(httpResponse.ended()).thenReturn(true);
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(httpResponse, testAddress);
+
+    assertThatThrownBy(() -> streamer.write("xyz".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(ClosedChannelException.class);
+    verify(httpResponse, never()).write(any(Buffer.class));
   }
 
   private ArgumentMatcher<Buffer> bufferContains(final String text) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressureTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressureTest.java
@@ -18,9 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.StreamBackpressure.AbortCheck;
 
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
@@ -44,6 +47,12 @@ class StreamBackpressureTest {
 
   private static final long TIMEOUT_MILLIS = 30_000;
 
+  private static final AbortCheck NEVER_ABORTS = () -> {};
+  private static final AbortCheck ALWAYS_ABORTED =
+      () -> {
+        throw new ClosedChannelException();
+      };
+
   @Mock private WriteStream<Buffer> stream;
 
   private final AtomicReference<Handler<Void>> drainHandler = new AtomicReference<>();
@@ -62,7 +71,7 @@ class StreamBackpressureTest {
   void returnsImmediatelyWhenQueueIsNotFull() throws IOException {
     when(stream.writeQueueFull()).thenReturn(false);
 
-    StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS);
+    StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, TIMEOUT_MILLIS);
 
     verify(stream, never()).drainHandler(any());
   }
@@ -71,14 +80,13 @@ class StreamBackpressureTest {
   void returnsWhenQueueDrainsAfterHandlerRegistration() {
     when(stream.writeQueueFull()).thenReturn(true, false);
 
-    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS))
+    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, TIMEOUT_MILLIS))
         .doesNotThrowAnyException();
   }
 
   @Test
   void returnsWhenDrainHandlerFires() {
     when(stream.writeQueueFull()).thenReturn(true);
-    // Fire the drain callback as soon as it is registered.
     when(stream.drainHandler(any()))
         .thenAnswer(
             invocation -> {
@@ -89,7 +97,7 @@ class StreamBackpressureTest {
               return stream;
             });
 
-    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS))
+    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, TIMEOUT_MILLIS))
         .doesNotThrowAnyException();
   }
 
@@ -97,8 +105,7 @@ class StreamBackpressureTest {
   void abortsPromptlyWhenPeerGoesAwayWhileWaiting() {
     when(stream.writeQueueFull()).thenReturn(true);
     final AtomicBoolean aborted = new AtomicBoolean(false);
-    // The drain callback never fires: this is the dead-peer case, where nothing ever
-    // counts the latch down.
+    // the dead-peer case: the drain callback never fires, so nothing counts the latch down
     new Thread(
             () -> {
               try {
@@ -110,8 +117,15 @@ class StreamBackpressureTest {
             })
         .start();
 
+    final AbortCheck abortCheck =
+        () -> {
+          if (aborted.get()) {
+            throw new ClosedChannelException();
+          }
+        };
+
     final long start = System.nanoTime();
-    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, aborted::get, TIMEOUT_MILLIS))
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, abortCheck, TIMEOUT_MILLIS))
         .isInstanceOf(ClosedChannelException.class);
     final long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
 
@@ -123,15 +137,71 @@ class StreamBackpressureTest {
   void abortsBeforeWaitingWhenPeerIsAlreadyGone() {
     when(stream.writeQueueFull()).thenReturn(true);
 
-    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> true, TIMEOUT_MILLIS))
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, ALWAYS_ABORTED, TIMEOUT_MILLIS))
         .isInstanceOf(ClosedChannelException.class);
+  }
+
+  @Test
+  void abortsWithoutQueryingAClosedStream() {
+    // ServerWebSocket.writeQueueFull() throws rather than answering once the socket is closed
+    when(stream.writeQueueFull()).thenThrow(new IllegalStateException("WebSocket is closed"));
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, ALWAYS_ABORTED, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class);
+
+    verify(stream, never()).writeQueueFull();
+  }
+
+  @Test
+  void reportsAStreamClosedDuringTheFullCheckAsAClosedChannel() {
+    when(stream.writeQueueFull()).thenThrow(new IllegalStateException("WebSocket is closed"));
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class)
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void reportsAStreamThatRefusesTheDrainHandlerAsAClosedChannel() {
+    // the socket closed between the full-check and the handler registration
+    when(stream.writeQueueFull()).thenReturn(true);
+    when(stream.drainHandler(any())).thenThrow(new IllegalStateException("WebSocket is closed"));
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class);
+  }
+
+  @Test
+  void clearingTheDrainHandlerOnAClosedStreamDoesNotMaskTheAbort() {
+    // ServerWebSocket.drainHandler() throws once the socket is closed, even for a null handler
+    when(stream.writeQueueFull()).thenReturn(true);
+    when(stream.drainHandler(isNull())).thenThrow(new IllegalStateException("WebSocket is closed"));
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, abortAfterFirstCheck(), 150))
+        .isInstanceOf(ClosedChannelException.class);
+  }
+
+  @Test
+  void propagatesTheAbortCheckFailureUnchanged() {
+    when(stream.writeQueueFull()).thenReturn(true);
+    final IOException cause = new IOException("SSL write failed");
+
+    assertThatThrownBy(
+            () ->
+                StreamBackpressure.awaitDrain(
+                    stream,
+                    () -> {
+                      throw cause;
+                    },
+                    TIMEOUT_MILLIS))
+        .isSameAs(cause);
   }
 
   @Test
   void throwsOnTimeoutWhenPeerIsAliveButNeverDrains() {
     when(stream.writeQueueFull()).thenReturn(true);
 
-    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> false, 150))
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, NEVER_ABORTS, 150))
         .isInstanceOf(IOException.class)
         .isNotInstanceOf(ClosedChannelException.class)
         .hasMessageContaining("Timed out waiting for write queue to drain");
@@ -141,9 +211,22 @@ class StreamBackpressureTest {
   void clearsDrainHandlerOnAbort() {
     when(stream.writeQueueFull()).thenReturn(true);
 
-    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> true, TIMEOUT_MILLIS))
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, abortAfterFirstCheck(), 150))
         .isInstanceOf(ClosedChannelException.class);
 
     assertThat(drainHandler.get()).isNull();
+  }
+
+  /**
+   * Passes the pre-registration check and aborts on the first in-loop check, so the drain handler
+   * is registered before the abort is reported.
+   */
+  private AbortCheck abortAfterFirstCheck() {
+    final AtomicBoolean firstCheck = new AtomicBoolean(true);
+    return () -> {
+      if (!firstCheck.compareAndSet(true, false)) {
+        throw new ClosedChannelException();
+      }
+    };
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressureTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/StreamBackpressureTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.WriteStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StreamBackpressureTest {
+
+  private static final long TIMEOUT_MILLIS = 30_000;
+
+  @Mock private WriteStream<Buffer> stream;
+
+  private final AtomicReference<Handler<Void>> drainHandler = new AtomicReference<>();
+
+  @BeforeEach
+  void captureDrainHandler() {
+    when(stream.drainHandler(any()))
+        .thenAnswer(
+            invocation -> {
+              drainHandler.set(invocation.getArgument(0));
+              return stream;
+            });
+  }
+
+  @Test
+  void returnsImmediatelyWhenQueueIsNotFull() throws IOException {
+    when(stream.writeQueueFull()).thenReturn(false);
+
+    StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS);
+
+    verify(stream, never()).drainHandler(any());
+  }
+
+  @Test
+  void returnsWhenQueueDrainsAfterHandlerRegistration() {
+    when(stream.writeQueueFull()).thenReturn(true, false);
+
+    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void returnsWhenDrainHandlerFires() {
+    when(stream.writeQueueFull()).thenReturn(true);
+    // Fire the drain callback as soon as it is registered.
+    when(stream.drainHandler(any()))
+        .thenAnswer(
+            invocation -> {
+              final Handler<Void> handler = invocation.getArgument(0);
+              if (handler != null) {
+                handler.handle(null);
+              }
+              return stream;
+            });
+
+    assertThatCode(() -> StreamBackpressure.awaitDrain(stream, () -> false, TIMEOUT_MILLIS))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void abortsPromptlyWhenPeerGoesAwayWhileWaiting() {
+    when(stream.writeQueueFull()).thenReturn(true);
+    final AtomicBoolean aborted = new AtomicBoolean(false);
+    // The drain callback never fires: this is the dead-peer case, where nothing ever
+    // counts the latch down.
+    new Thread(
+            () -> {
+              try {
+                Thread.sleep(200);
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              aborted.set(true);
+            })
+        .start();
+
+    final long start = System.nanoTime();
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, aborted::get, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class);
+    final long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    // Must not wait out the full backpressure timeout.
+    assertThat(elapsedMillis).isLessThan(TIMEOUT_MILLIS / 2);
+  }
+
+  @Test
+  void abortsBeforeWaitingWhenPeerIsAlreadyGone() {
+    when(stream.writeQueueFull()).thenReturn(true);
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> true, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class);
+  }
+
+  @Test
+  void throwsOnTimeoutWhenPeerIsAliveButNeverDrains() {
+    when(stream.writeQueueFull()).thenReturn(true);
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> false, 150))
+        .isInstanceOf(IOException.class)
+        .isNotInstanceOf(ClosedChannelException.class)
+        .hasMessageContaining("Timed out waiting for write queue to drain");
+  }
+
+  @Test
+  void clearsDrainHandlerOnAbort() {
+    when(stream.writeQueueFull()).thenReturn(true);
+
+    assertThatThrownBy(() -> StreamBackpressure.awaitDrain(stream, () -> true, TIMEOUT_MILLIS))
+        .isInstanceOf(ClosedChannelException.class);
+
+    assertThat(drainHandler.get()).isNull();
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 
 import io.vertx.core.http.ServerWebSocket;
@@ -101,6 +102,19 @@ public class JsonResponseStreamerTest {
 
     verify(failedResponse).writeFrame(argThat(frameContains("xyz", false)));
     verify(failedResponse, never()).writeFrame(argThat(frameContains("\n", true)));
+  }
+
+  @Test
+  public void writeAbortsWhenWebSocketClosesWhileQueueIsFull() throws IOException {
+    when(response.writeQueueFull()).thenReturn(true);
+    when(response.isClosed()).thenReturn(true);
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(response);
+    // the first write only buffers; the second is the one that has to wait for the queue
+    streamer.write("xyz".getBytes(StandardCharsets.UTF_8));
+
+    assertThatThrownBy(() -> streamer.write('\n')).isInstanceOf(ClosedChannelException.class);
+    verify(response, never()).writeFrame(any(WebSocketFrame.class));
   }
 
   private ArgumentMatcher<WebSocketFrame> frameContains(final String text, final boolean isFinal) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
@@ -107,13 +108,30 @@ public class JsonResponseStreamerTest {
   @Test
   public void writeAbortsWhenWebSocketClosesWhileQueueIsFull() throws IOException {
     when(response.writeQueueFull()).thenReturn(true);
-    when(response.isClosed()).thenReturn(true);
+    final AtomicBoolean webSocketClosed = new AtomicBoolean(false);
+    when(response.isClosed()).thenAnswer(invocation -> webSocketClosed.get());
 
     JsonResponseStreamer streamer = new JsonResponseStreamer(response);
     // the first write only buffers; the second is the one that has to wait for the queue
     streamer.write("xyz".getBytes(StandardCharsets.UTF_8));
+    webSocketClosed.set(true);
 
     assertThatThrownBy(() -> streamer.write('\n')).isInstanceOf(ClosedChannelException.class);
+    verify(response, never()).writeFrame(any(WebSocketFrame.class));
+  }
+
+  @Test
+  public void writeAbortsWhenWebSocketIsAlreadyClosed() {
+    // a closed ServerWebSocket throws IllegalStateException from writeQueueFull() and
+    // drainHandler(), so the abort has to be detected without touching either
+    when(response.isClosed()).thenReturn(true);
+    when(response.writeQueueFull()).thenThrow(new IllegalStateException("WebSocket is closed"));
+    when(response.drainHandler(any())).thenThrow(new IllegalStateException("WebSocket is closed"));
+
+    JsonResponseStreamer streamer = new JsonResponseStreamer(response);
+
+    assertThatThrownBy(() -> streamer.write("xyz".getBytes(StandardCharsets.UTF_8)))
+        .isInstanceOf(ClosedChannelException.class);
     verify(response, never()).writeFrame(any(WebSocketFrame.class));
   }
 


### PR DESCRIPTION
## PR description

`StreamBackpressure.awaitDrain` parks the calling worker thread on a `CountDownLatch` that is only ever counted down by the Vert.x drain handler. When the client stops reading and the connection is closed — or when the JSON-RPC timeout handler ends the response from the event loop — nothing counts that latch down, so the thread stays parked for the full 60 s backpressure timeout. That is double the default 30 s RPC timeout, and the same Vert.x worker pool serves the Engine API.

Found while going through 23 h of logs from a devnet node. Two blocks were correctly rejected as invalid; from then on the consensus client polled `debug_getBadBlocks` every ~4 minutes and never drained the response. All 365 calls failed (238 "Connection closed", 87 "Broken pipe", 40 × 30 s timeouts), and 105 of them leaked a worker thread for 60–62 s. Every single `BlockedThreadChecker` warning in the whole log is this one stack:

```
WARN  | BlockedThreadChecker | Thread Thread[vert.x-worker-thread-11,5,main] has been blocked for 60644 ms, time limit is 60000 ms
io.vertx.core.VertxException: Thread blocked
	at java.base/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:276)
	at org.hyperledger.besu.ethereum.api.jsonrpc.StreamBackpressure.awaitDrain(StreamBackpressure.java:52)
	at org.hyperledger.besu.ethereum.api.jsonrpc.JsonResponseStreamer.write(JsonResponseStreamer.java:64)
	...
```

The 60 s durations match `DRAIN_TIMEOUT_SECONDS` exactly, and the timeouts confirm the thread outlives the RPC deadline: the executor logs `Timeout (30000 ms) occurred ... debug_getBadBlocks` at 13:39:58 and the `BlockedThreadChecker` warning for that same thread lands at 13:40:29.

### Change

- `awaitDrain` now takes an abort predicate and waits in 50 ms slices, re-evaluating it between slices. A drain still wakes the waiter immediately through the drain handler, so the fast path is unchanged.
- Both `JsonResponseStreamer`s (HTTP and WebSocket) report "cannot be delivered any more" as: a closed connection, an already-ended response, or a previously failed write. `ended()` is what covers the timeout-handler case.
- Aborting throws `ClosedChannelException`, which `JsonRpcExecutorHandler` already reports as a WARN rather than an ERROR with a stack trace. A genuine timeout against a live but slow client still throws a plain `IOException`, so "client is slow" and "client is gone" stay distinguishable in the logs.
- The drain handler is cleared on exit so it no longer points at a latch nobody is waiting on.

The 60 s cap is kept as a backstop. With the abort predicate in place it is now effectively bounded by the RPC timeout, since the timeout handler ends the response.

### Testing

New `StreamBackpressureTest` (7 tests) covers: no-op when the queue is not full, the drain-handler wakeup path, the post-registration re-check race, prompt abort when the peer disappears mid-wait, abort when the peer is already gone, timeout against a live client, and drain-handler cleanup. Added abort cases to both `JsonResponseStreamerTest`s. Full `:ethereum:api:test` passes.

## Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if [updates are required](https://github.com/besu-eth/besu/blob/main/docs/DOC-STYLE-GUIDE.md).
- [x] Considered the changelog and included an [update if required](https://github.com/besu-eth/besu/blob/main/CHANGELOG.md).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

