### PR TITLE
fix jmh profiler and gas calculator issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -953,7 +953,7 @@ subprojects {
       }
       var gasProfiler = _strCmdArg('gasProfiler')
       if (gasProfiler != null && gasProfiler.toBoolean()) {
-        if (asyncProfiler == null) profilers = []
+        if (asyncProfiler == null && profilers == null) profilers = []
         var gasProfilerFork = _strCmdArg('gasProfilerFork')
         profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler' + (gasProfilerFork != null ? ':' + gasProfilerFork : ''))
       }

--- a/build.gradle
+++ b/build.gradle
@@ -939,21 +939,18 @@ subprojects {
       jvmArgs = [
         '-XX:+EnableDynamicAgentLoading'
       ]
+      profilers = []
       if (asyncProfiler != null) {
-        profilers = [
-          'async:libPath=' + asyncProfiler + ';' + asyncProfilerOptions
-        ]
+        profilers.add('async:libPath=' + asyncProfiler + ';' + asyncProfilerOptions)
         // Force debug symbols of stack traces to the profiler
         jvmArgs.addAll("-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints")
       }
       var gcProfiler = _strCmdArg('gcProfiler')
       if (gcProfiler != null && gcProfiler.toBoolean()) {
-        if (asyncProfiler == null) profilers = []
         profilers.add('gc')
       }
       var gasProfiler = _strCmdArg('gasProfiler')
       if (gasProfiler != null && gasProfiler.toBoolean()) {
-        if (asyncProfiler == null && profilers == null) profilers = []
         var gasProfilerFork = _strCmdArg('gasProfilerFork')
         profilers.add('org.hyperledger.besu.ethereum.vm.operations.GasProfiler' + (gasProfilerFork != null ? ':' + gasProfilerFork : ''))
       }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.gascalculator.OsakaGasCalculator;
 import org.hyperledger.besu.evm.operation.CallDataCopyOperation;
 
 import java.util.concurrent.TimeUnit;
@@ -77,7 +77,7 @@ public class CallDataCopyOperationBenchmark implements GasCostBenchmark {
 
   @Setup
   public void setUp() {
-    callDataCopyOperation = new CallDataCopyOperation(new CancunGasCalculator());
+    callDataCopyOperation = new CallDataCopyOperation(new OsakaGasCalculator());
     callData = BenchmarkHelper.createCallData(dataSize, nonZeroData);
     frame = BenchmarkHelper.createMessageCallFrameWithCallData(callData);
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CallDataCopyOperationBenchmark.java
@@ -93,18 +93,7 @@ public class CallDataCopyOperationBenchmark implements GasCostBenchmark {
     index = 0;
   }
 
-  @Benchmark
-  public void baseline() {
-    frame.pushStackItem(sizePool[index]);
-    frame.pushStackItem(srcOffsetPool[index]);
-    frame.pushStackItem(destOffsetPool[index]);
-
-    frame.popStackItem();
-    frame.popStackItem();
-    frame.popStackItem();
-    index = (index + 1) % SAMPLE_SIZE;
-  }
-
+  @Override
   @Benchmark
   public void executeOperation(final Blackhole blackhole) {
     frame.pushStackItem(sizePool[index]);

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
@@ -101,13 +101,4 @@ public class CountLeadingZerosOperationBenchmark {
       frame.popStackItem();
     }
   }
-
-  @Benchmark
-  @OperationsPerInvocation(OPERATIONS_PER_INVOCATION)
-  public void baseline() {
-    for (int i = 0; i < OPERATIONS_PER_INVOCATION; i++) {
-      frame.pushStackItem(bytes);
-      frame.popStackItem();
-    }
-  }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasCostBenchmark.java
@@ -17,7 +17,10 @@ package org.hyperledger.besu.ethereum.vm.operations;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 
 public interface GasCostBenchmark {
   long getGasCost(BenchmarkParams params, GasCalculator calc);
+
+  void executeOperation(Blackhole blackhole);
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasFormulas.java
@@ -26,7 +26,7 @@ public final class GasFormulas {
 
   public static OptionalLong compute(final BenchmarkParams params, final GasCalculator calc) {
     final String fqn = params.getBenchmark();
-    if (fqn.endsWith(".baseline")) {
+    if (!fqn.endsWith("executeOperation")) {
       return OptionalLong.empty();
     }
     final String className = fqn.substring(0, fqn.lastIndexOf('.'));

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -140,7 +140,8 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
             "mgas_per_s",
             1000 * trialGasCost.getAsLong() / nsPerOp,
             "MGas/s",
-            AggregationPolicy.AVG));
+            AggregationPolicy.AVG),
+        new ScalarResult("gas", trialGasCost.getAsLong(), "gas", AggregationPolicy.AVG));
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.EvmSpecVersion;
+import org.hyperledger.besu.evm.gascalculator.AmsterdamGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.BerlinGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.ByzantiumGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
@@ -29,6 +30,7 @@ import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.ShanghaiGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.SpuriousDragonGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.TangerineWhistleGasCalculator;
 
 import java.io.File;
 import java.util.Collection;
@@ -92,6 +94,7 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
     return switch (EvmSpecVersion.valueOf(fork)) {
       case FRONTIER -> new FrontierGasCalculator();
       case HOMESTEAD -> new HomesteadGasCalculator();
+      case TANGERINE_WHISTLE -> new TangerineWhistleGasCalculator();
       case SPURIOUS_DRAGON -> new SpuriousDragonGasCalculator();
       case BYZANTIUM -> new ByzantiumGasCalculator();
       case CONSTANTINOPLE -> new ConstantinopleGasCalculator();
@@ -102,6 +105,8 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
       case SHANGHAI -> new ShanghaiGasCalculator();
       case CANCUN -> new CancunGasCalculator();
       case PRAGUE -> new PragueGasCalculator();
+      case OSAKA -> new OsakaGasCalculator();
+      case AMSTERDAM -> new AmsterdamGasCalculator();
       default -> new OsakaGasCalculator();
     };
   }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GasProfiler.java
@@ -141,7 +141,7 @@ public class GasProfiler implements InternalProfiler, ExternalProfiler {
             1000 * trialGasCost.getAsLong() / nsPerOp,
             "MGas/s",
             AggregationPolicy.AVG),
-        new ScalarResult("gas", trialGasCost.getAsLong(), "gas", AggregationPolicy.AVG));
+        new ScalarResult("gas", trialGasCost.getAsLong(), "gas", AggregationPolicy.MAX));
   }
 
   @Override

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/Keccak256Benchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -62,8 +63,9 @@ public class Keccak256Benchmark implements GasCostBenchmark {
     bytes = Bytes.wrap(byteArray);
   }
 
+  @Override
   @Benchmark
-  public void executeOperation() {
-    Hash.keccak256(bytes);
+  public void executeOperation(final Blackhole blackhole) {
+    blackhole.consume(Hash.keccak256(bytes));
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SHA256Benchmark.java
@@ -21,7 +21,6 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Measurement;
@@ -33,6 +32,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -60,8 +60,9 @@ public class SHA256Benchmark implements GasCostBenchmark {
     bytes = Bytes.wrap(byteArray);
   }
 
+  @Override
   @Benchmark
-  public Bytes32 sha256() {
-    return Hash.sha256(bytes);
+  public void executeOperation(final Blackhole blackhole) {
+    blackhole.consume(Hash.sha256(bytes));
   }
 }


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
Fix JMH issues on build.gradle profiler reset that silently dropped gc when combined with gasProfiler, missing TangerineWhistle and Amsterdam cases in the GasProfiler fork switch, and CallDataCopyOperationBenchmark using CancunGasCalculator instead of Osaka.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


