### PR TITLE
Size the engine API worker pool for concurrent engine calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- The engine API worker pool is no longer limited to a single thread, so a long-running `engine_newPayload` can no longer head-of-line block the `engine_getPayload` a proposer is waiting for. Engine methods were already intended to run concurrently, but the pool they are dispatched on had room for exactly one call at a time. [#11148](https://github.com/besu-eth/besu/pull/11148)
 - `admin_generateLogBloomCache` now clamps both block bounds to the chain head. [#11135](https://github.com/besu-eth/besu/pull/11135)
 - `eth_getTransactionByBlockHashAndIndex` reported a malformed block hash at parameter 0 as `Invalid transaction hash params`; it now reports `Invalid block hash params`. [#11119](https://github.com/besu-eth/besu/pull/11119)
 - Fix `debug_getRawTransaction` returning bare RLP payload (missing EIP-2718 type-byte prefix) for typed transactions, causing `keccak256(raw) != txHash`. Fix `debug_getRawReceipts` double-wrapping typed receipts in an outer RLP byte-string instead of returning the raw `type || rlp(payload)` wire encoding. [#11083](https://github.com/besu-eth/besu/pull/11083)

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1379,11 +1379,10 @@ public class RunnerBuilder {
       final TransactionSimulator transactionSimulator,
       final EthScheduler ethScheduler) {
     // vertx for the engine consensus API: engine methods execute concurrently on its worker
-    // pool, except engine_forkchoiceUpdated and engine_newPayload calls, which the Engine API
-    // spec requires to be processed in the order received — those run on a dedicated
-    // single-threaded executor (see OrderedExecutionJsonRpcMethod)
-    final Vertx consensusEngineServer =
-        Vertx.vertx(new io.vertx.core.VertxOptions().setWorkerPoolSize(1).setEventLoopPoolSize(1));
+    // pool (sized in EngineJsonRpcService), except engine_forkchoiceUpdated and engine_newPayload
+    // calls, which the Engine API spec requires to be processed in the order received — those run
+    // on a dedicated single-threaded executor (see OrderedExecutionJsonRpcMethod)
+    final Vertx consensusEngineServer = EngineJsonRpcService.createEngineVertx();
 
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -76,6 +76,7 @@ import io.opentelemetry.extension.trace.propagation.JaegerPropagator;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpConnection;
@@ -106,6 +107,27 @@ public class EngineJsonRpcService {
   private static final String SPAN_CONTEXT = "span_context";
   private static final InetSocketAddress EMPTY_SOCKET_ADDRESS = new InetSocketAddress("0.0.0.0", 0);
   private static final String APPLICATION_JSON = "application/json";
+
+  /**
+   * A single event loop, so every engine request is read on the same thread and therefore observed
+   * in a well-defined arrival order.
+   */
+  private static final int ENGINE_EVENT_LOOP_POOL_SIZE = 1;
+
+  /**
+   * Engine requests are dispatched to this pool by {@code blockingHandler}, so its size is the
+   * number of engine calls that can be in flight at once.
+   *
+   * <p>It must be greater than one. A single {@code engine_newPayload} can occupy its thread for
+   * seconds — importing a large block, or rejecting a deliberately expensive invalid one — and with
+   * a pool of one that head-of-line blocks every other engine call, including the {@code
+   * engine_getPayload} the consensus client has to receive inside its slot deadline to propose.
+   * {@link
+   * org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.OrderedExecutionJsonRpcMethod} hands
+   * the work to its own single-threaded executor but keeps blocking the dispatching thread until it
+   * finishes, so an in-flight ordered call costs a slot here for its whole duration.
+   */
+  private static final int ENGINE_WORKER_POOL_SIZE = 10;
 
   private static final TextMapPropagator traceFormats =
       TextMapPropagator.composite(
@@ -151,6 +173,22 @@ public class EngineJsonRpcService {
   private final HealthService readinessService;
 
   private final MetricsSystem metricsSystem;
+
+  /**
+   * Creates the Vertx instance that backs the engine consensus API.
+   *
+   * <p>The engine API gets its own Vertx rather than sharing the main JSON-RPC one so that public
+   * RPC traffic can never delay consensus calls. See {@link #ENGINE_EVENT_LOOP_POOL_SIZE} and
+   * {@link #ENGINE_WORKER_POOL_SIZE} for why those pools are sized the way they are.
+   *
+   * @return a new Vertx instance configured for the engine consensus API
+   */
+  public static Vertx createEngineVertx() {
+    return Vertx.vertx(
+        new VertxOptions()
+            .setEventLoopPoolSize(ENGINE_EVENT_LOOP_POOL_SIZE)
+            .setWorkerPoolSize(ENGINE_WORKER_POOL_SIZE));
+  }
 
   /**
    * Construct a EngineJsonRpcService to handle either http or websocket clients

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.EngineJsonRpcService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
@@ -31,14 +32,15 @@ import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -119,11 +121,80 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     assertThat(maxActive.get()).isEqualTo(1);
   }
 
+  @Test
+  public void slowOrderedCallDoesNotBlockUnorderedCallOnTheEngineWorkerPool() throws Exception {
+    // The other tests in this class invoke response() from their own thread pool, which bypasses
+    // the Vertx worker pool the engine HTTP route actually dispatches on. This one goes through
+    // that pool, on a Vertx configured exactly as the running node configures it, because the
+    // pool's size is what decides whether a long engine_newPayload can hold up the
+    // engine_getPayload a proposer is waiting for.
+    final Vertx engineVertx = EngineJsonRpcService.createEngineVertx();
+    try {
+      final CountDownLatch orderedStarted = new CountDownLatch(1);
+      final CountDownLatch releaseOrdered = new CountDownLatch(1);
+
+      final OrderedStubEngineMethod slowOrderedMethod =
+          new OrderedStubEngineMethod(
+              engineVertx,
+              protocolSchedule,
+              protocolContext,
+              engineCallListener,
+              mergeCoordinator,
+              ethPeers,
+              transactionPool,
+              req -> {
+                orderedStarted.countDown();
+                try {
+                  releaseOrdered.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+                return new JsonRpcSuccessResponse(req.getRequest().getId());
+              });
+      final UnorderedStubEngineMethod lightMethod =
+          new UnorderedStubEngineMethod(
+              engineVertx,
+              protocolContext,
+              engineCallListener,
+              req -> new JsonRpcSuccessResponse(req.getRequest().getId()));
+
+      final Future<JsonRpcResponse> slowCall = dispatchOnWorkerPool(engineVertx, slowOrderedMethod);
+      assertThat(orderedStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+      // the slow call is still in flight and holding a worker thread; the light one must not
+      // have to wait for it
+      final JsonRpcResponse lightResponse =
+          dispatchOnWorkerPool(engineVertx, lightMethod)
+              .toCompletionStage()
+              .toCompletableFuture()
+              .get(10, TimeUnit.SECONDS);
+      assertThat(lightResponse.getType()).isEqualTo(RpcResponseType.SUCCESS);
+
+      releaseOrdered.countDown();
+      assertThat(slowCall.toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS))
+          .matches(resp -> resp.getType() == RpcResponseType.SUCCESS);
+    } finally {
+      engineVertx.close().toCompletionStage().toCompletableFuture().join();
+    }
+  }
+
+  /** Mirrors how the engine HTTP route dispatches a request: an unordered blocking handler. */
+  private Future<JsonRpcResponse> dispatchOnWorkerPool(
+      final Vertx engineVertx, final JsonRpcMethod method) {
+    return engineVertx.executeBlocking(
+        promise ->
+            promise.complete(
+                method.response(
+                    new JsonRpcRequestContext(
+                        new JsonRpcRequest("2.0", method.getName(), new Object[0])))),
+        false);
+  }
+
   private List<JsonRpcResponse> callConcurrently(final JsonRpcMethod method, final int callers)
       throws Exception {
     final ExecutorService pool = Executors.newFixedThreadPool(callers);
     try {
-      final List<Future<JsonRpcResponse>> futures = new ArrayList<>();
+      final List<java.util.concurrent.Future<JsonRpcResponse>> futures = new ArrayList<>();
       for (int i = 0; i < callers; i++) {
         futures.add(
             pool.submit(
@@ -133,7 +204,7 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
                             new JsonRpcRequest("2.0", method.getName(), new Object[0])))));
       }
       final List<JsonRpcResponse> responses = new ArrayList<>(callers);
-      for (final Future<JsonRpcResponse> future : futures) {
+      for (final java.util.concurrent.Future<JsonRpcResponse> future : futures) {
         responses.add(future.get(30, TimeUnit.SECONDS));
       }
       return responses;
@@ -146,6 +217,14 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
 
     UnorderedStubEngineMethod(
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      this(vertx, protocolContext, engineCallListener, body);
+    }
+
+    UnorderedStubEngineMethod(
+        final Vertx vertx,
         final ProtocolContext protocolContext,
         final EngineCallListener engineCallListener,
         final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
@@ -168,6 +247,26 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
 
     OrderedStubEngineMethod(
+        final ProtocolSchedule protocolSchedule,
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final MergeMiningCoordinator mergeCoordinator,
+        final EthPeers ethPeers,
+        final TransactionPool transactionPool,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      this(
+          vertx,
+          protocolSchedule,
+          protocolContext,
+          engineCallListener,
+          mergeCoordinator,
+          ethPeers,
+          transactionPool,
+          body);
+    }
+
+    OrderedStubEngineMethod(
+        final Vertx vertx,
         final ProtocolSchedule protocolSchedule,
         final ProtocolContext protocolContext,
         final EngineCallListener engineCallListener,


### PR DESCRIPTION
## PR description

The engine consensus API Vertx is created with `setWorkerPoolSize(1)`. That pool is what `blockingHandler` dispatches every engine request on, so exactly one engine call can be in flight at a time and a slow one head-of-line blocks the rest.

This is not theoretical. On glamsterdam-devnet-8, `nero_eth` deliberately submitted a heavy invalid payload (~185M gas of real execution before the tx that busts the EIP-8037 block budget). A teku-besu node was the next-slot proposer and missed its slot:

```
12:53:48.723  MergeCoordinator     Start building proposals for block 77262 (payloadId 0x585082cc88a560e6)
~12:53:59     engine_newPayloadV5(0x2326a40c…) arrives
12:54:02.134  AbstractBlockProcessor  tx gas limit 16777216 exceeds available block budget
                                      (regular=184549376, state=0, limit=199803547)
12:54:10.670  EngineNewPayloadV5   INVALID: provided gas insufficient
12:54:10.670  AbstractEngineGetPayload  Produced #77,262 | awaitingRetrieval=10278ms
12:54:10.677  JsonRpcExecutorHandler    engine_getPayloadV6 - Connection closed before JSON-RPC response could be written
```

Besu's own payload had been ready since ~12:54:00.4. `engine_getPayload` then waited **10,278 ms** and finally ran in the same millisecond `newPayload` released the thread — by which point Teku had hung up. Every one of the 21,107 engine log lines in that 23h log is on `vert.x-worker-thread-0`.

### Why #11053 did not already fix this

#11053 moved `engine_newPayload` and `engine_forkchoiceUpdated` onto a dedicated single-threaded executor precisely so the remaining engine methods could run concurrently, but two things kept that from happening:

- the dispatch pool stayed at `setWorkerPoolSize(1)`, and
- `OrderedExecutionJsonRpcMethod.response()` submits to the ordered executor and then blocks the dispatching thread on `cf.get(30s)` until the call completes.

So an in-flight ordered call still occupies the single dispatch slot for its whole duration, and nothing overlaps. This PR makes that concurrency actually reachable.

### Changes

- Move the engine Vertx construction into `EngineJsonRpcService.createEngineVertx()`, next to the code whose behaviour depends on it, and document why each pool is sized as it is.
- Raise the worker pool to 10. The number is not load-bearing beyond being greater than one — it just needs headroom for the handful of concurrent calls a consensus client makes.
- The event loop pool stays at 1, so every engine request is still read on one thread and observed in a well-defined arrival order.

### Testing

`ExecutionEngineJsonRpcMethodExecutionTest` already had `unorderedMethodCallsExecuteConcurrently` and `orderedMethodCallsNeverExecuteConcurrently`, but both call `response()` from their own `Executors.newFixedThreadPool`, which never touches the Vertx worker pool the HTTP route actually dispatches on. That is why the pool size went unnoticed.

The added `slowOrderedCallDoesNotBlockUnorderedCallOnTheEngineWorkerPool` dispatches through `EngineJsonRpcService.createEngineVertx()`'s worker pool the way `blockingHandler` does: it starts a slow ordered call, waits for it to be running, then asserts a light unordered call still completes. With the old `setWorkerPoolSize(1)` it fails with `TimeoutException`; with the new size it passes. I verified both directions.

`:ethereum:api:test`, `:ethereum:api:spotlessCheck`, `:app:compileJava` and `:app:spotlessCheck` are green.

### One thing worth a second opinion

@fab-10 @garyschulte — with more than one dispatch thread, two engine calls that are genuinely in flight *at the same time* can now reach the ordered executor's queue in a different order than they arrived, because the worker threads race between dequeue and `executeBlocking`. With a pool of 1 that could not happen, so today's cross-connection ordering is partly an accident of the pool size rather than something the ordered executor guarantees.

I think this is fine in practice: consensus clients issue `newPayload` → response → `forkchoiceUpdated` sequentially, so two ordered calls are rarely concurrent, and when they genuinely are (separate connections) their relative arrival order is not meaningful anyway. The spec's ordering requirement is about a client's sequential stream, which stays ordered.

If you want the guarantee to be structural rather than probabilistic, the clean way is to dispatch on the event loop — where arrival order is authoritative — sending ordered methods straight to the single-threaded executor with `ordered=true` and everything else to the worker pool. That also drops the wasted blocked thread. It means reworking `OrderedExecutionJsonRpcMethod`, so I kept it out of this PR rather than redoing yours; happy to do it as a follow-up if you'd prefer that shape.

### Related

There is a second, independent contributor to that missed slot which I'll raise separately: `MainnetParallelBlockProcessor` falls back to a full serial re-execution on *any* processing failure, so the deterministic `provided gas insufficient` rejection above was computed twice — 2.2s in parallel, then 8.5s again serially.
