### PR TITLE
fix(parallel): abort speculative futures on block-budget abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- Abort pending speculative transaction futures when the block-budget is exhausted in parallel block production.
 - Queue backward-sync targets received before peer readiness and retry when a peer connects. [#10843](https://github.com/besu-eth/besu/pull/10843)
 - Return `BLOCK_NOT_FOUND` for unknown block hashes and `GENESIS_BLOCK_NOT_TRACEABLE` for genesis blocks from `debug_traceBlockByHash`. [#10701](https://github.com/besu-eth/besu/pull/10701)
 - Bonsai world state rolling failures are now logged at `WARN` instead of `INFO`, and a missing block header or trie log during a roll reports which block hash or trie log was missing. [#10859](https://github.com/besu-eth/besu/issues/10859)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -250,6 +250,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
             .getBlockAccessListFactory()
             .map(BlockAccessListFactory::newBlockAccessListBuilder);
 
+    Optional<PreprocessingContext> preProcessingContext = Optional.empty();
     try {
       final Optional<AccessLocationTracker> preExecutionAccessLocationTracker =
           blockAccessListBuilder.map(
@@ -279,7 +280,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
                               calculateExcessBlobGasForParent(protocolSpec, parentHeader)))
               .orElse(Wei.ZERO);
 
-      final Optional<PreprocessingContext> preProcessingContext =
+      preProcessingContext =
           preprocessingBlockFunction.run(
               protocolContext,
               blockHeader,
@@ -567,6 +568,15 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
           parallelizedTxFound ? Optional.of(nbParallelTx) : Optional.empty());
     } finally {
       stateRootCommitter.cancel();
+      preProcessingContext.ifPresent(
+          ctx -> {
+            try {
+              // Cancel any speculative futures not yet consumed by the main loop.
+              ctx.processor().abort();
+            } catch (final Exception e) {
+              LOG.debug("Error aborting parallel transaction preprocessing futures", e);
+            }
+          });
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelBlockTransactionProcessor.java
@@ -77,6 +77,23 @@ public abstract class ParallelBlockTransactionProcessor {
     }
   }
 
+  /**
+   * Cancels every still-pending speculative future and nulls its slot. Already-consumed slots are
+   * null, so on the success path this is a no-op.
+   */
+  public void abort() {
+    if (futures == null) {
+      return;
+    }
+    for (int i = 0; i < futures.length; i++) {
+      final CompletableFuture<ParallelizedTransactionContext> future = futures[i];
+      if (future != null) {
+        future.cancel(true);
+        futures[i] = null;
+      }
+    }
+  }
+
   /** World state at the parent block. Call only when the parent header is known to be present. */
   protected Optional<BonsaiWorldState> getWorldState(
       final ProtocolContext protocolContext, final BlockHeader parentHeader) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticTransactionProcessorUnitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/OptimisticTransactionProcessorUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.mainnet.parallelization;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.WorldStateConfig.createStatefulConfigWithTrie;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,6 +59,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -620,6 +622,59 @@ class OptimisticTransactionProcessorUnitTest {
       assertTrue(
           maybeResult.get().getPartialBlockAccessView().isPresent(),
           "Expected BAL view to be present");
+    }
+  }
+
+  @Nested
+  @DisplayName("abort() cleanup of speculative futures")
+  @MockitoSettings(strictness = Strictness.LENIENT)
+  class AbortTests {
+
+    @Test
+    @DisplayName("abort() before runAsyncBlock is a no-op")
+    void abortBeforeRunIsNoOp() {
+      processor.abort();
+      processor.abort();
+      assertThat(processor.futures).isNull();
+    }
+
+    @Test
+    @DisplayName("abort() cancels and nulls all pending futures")
+    void abortCancelsAndNullsFutures() {
+      final Transaction tx1 = mockTransaction();
+      final Transaction tx2 = mockTransaction();
+      stubSuccessfulTransaction(Optional.empty());
+
+      // An executor that never runs submitted tasks, so the futures stay pending and abort()'s
+      // cancel(true) is observable (cancel on an already-completed future is a no-op).
+      final Executor noOpExecutor = runnable -> {};
+
+      processor.runAsyncBlock(
+          env.protocolContext(),
+          env.blockHeader(),
+          List.of(tx1, tx2),
+          MINING_BENEFICIARY,
+          EMPTY_BLOCK_HASH_LOOKUP,
+          BLOB_GAS_PRICE,
+          noOpExecutor,
+          Optional.empty(),
+          env.maybeParentHeader());
+
+      // Capture the futures before abort() nulls the slots, then verify they were actually
+      // cancelled
+      final CompletableFuture<ParallelizedTransactionContext> future0 = processor.futures[0];
+      final CompletableFuture<ParallelizedTransactionContext> future1 = processor.futures[1];
+      assertThat(future0).isNotNull().isNotDone();
+      assertThat(future1).isNotNull().isNotDone();
+
+      processor.abort();
+
+      assertThat(processor.futures[0]).isNull();
+      assertThat(processor.futures[1]).isNull();
+      assertThat(future0).isCancelled();
+      assertThat(future1).isCancelled();
+
+      processor.abort();
     }
   }
 }


### PR DESCRIPTION
## Summary
- Port of https://github.com/besu-eth/besu/pull/11104 onto `glamsterdam-devnet-8`
- Abort pending speculative transaction futures when the block-budget is exhausted in parallel block production, preventing leaked futures when block processing exits early

## Changes
- Add `abort()` to `ParallelBlockTransactionProcessor` to cancel and null pending speculative futures
- Call `abort()` from `AbstractBlockProcessor` finally block after block processing completes or aborts
- Add unit tests for `abort()` cleanup behavior

## Test plan
- [ ] `OptimisticTransactionProcessorUnitTest.AbortTests` passes
- [ ] Parallel block processing integration tests pass on glamsterdam-devnet-8
