### PR TITLE
fix: testing_buildBlockV1 gas limit one-step decrement when no targetGasLimit supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- `testing_buildBlockV1` now uses the genesis gas limit as the effective target when no `targetGasLimit` is specified, so the gas limit calculator applies a one-step decrement rather than holding the parent value. [#11166](https://github.com/besu-eth/besu/pull/11166)
 - `admin_generateLogBloomCache` now clamps both block bounds to the chain head. [#11135](https://github.com/besu-eth/besu/pull/11135)
 - `eth_getTransactionByBlockHashAndIndex` reported a malformed block hash at parameter 0 as `Invalid transaction hash params`; it now reports `Invalid block hash params`. [#11119](https://github.com/besu-eth/besu/pull/11119)
 - Fix `debug_getRawTransaction` returning bare RLP payload (missing EIP-2718 type-byte prefix) for typed transactions, causing `keccak256(raw) != txHash`. Fix `debug_getRawReceipts` double-wrapping typed receipts in an outer RLP byte-string instead of returning the raw `type || rlp(payload)` wire encoding. [#11083](https://github.com/besu-eth/besu/pull/11083)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -233,10 +233,15 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               protocolSchedule,
               ethScheduler);
 
-      // When no targetGasLimit is provided, default to the parent's gas limit so that the
-      // node's mining configuration target does not cause an unexpected adjustment.
+      // When no targetGasLimit is provided, default to the genesis gas limit. This causes the
+      // gas limit calculator to apply its normal clamping logic (adjust toward genesis) rather
+      // than locking the gas limit at the parent value. Matches go-ethereum behaviour, which
+      // targets its configured GasCeil (default 45 M) — any target below the parent's current
+      // gas limit produces the same one-step decrement.
+      final long genesisGasLimit =
+          protocolContext.getBlockchain().getGenesisBlock().getHeader().getGasLimit();
       final long effectiveTargetGasLimit =
-          targetGasLimit != null ? targetGasLimit : parentHeader.getGasLimit();
+          targetGasLimit != null ? targetGasLimit : genesisGasLimit;
 
       final BlockCreationResult result =
           blockCreator.createBlock(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -233,6 +233,11 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               protocolSchedule,
               ethScheduler);
 
+      // When no targetGasLimit is provided, default to the parent's gas limit so that the
+      // node's mining configuration target does not cause an unexpected adjustment.
+      final long effectiveTargetGasLimit =
+          targetGasLimit != null ? targetGasLimit : parentHeader.getGasLimit();
+
       final BlockCreationResult result =
           blockCreator.createBlock(
               maybeTransactions,
@@ -241,7 +246,7 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               Optional.of(withdrawals),
               Optional.ofNullable(parentBeaconBlockRoot),
               Optional.ofNullable(slotNumber),
-              Optional.ofNullable(targetGasLimit),
+              Optional.of(effectiveTargetGasLimit),
               parentHeader);
 
       // When transactions are explicitly provided, return an error if any were not applied.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The testing_buildBlockV1 RPC method is a debugging and testing tool that simplifies the block
- * production process into a single call. It is intended to replace the multi-step workflow of
+ * production process into a single call. It is intended to replace the multistep workflow of
  * sending transactions, calling engine_forkchoiceUpdated with payloadAttributes, and then calling
  * engine_getPayload.
  *
@@ -234,10 +234,7 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               ethScheduler);
 
       // When no targetGasLimit is provided, default to the genesis gas limit. This causes the
-      // gas limit calculator to apply its normal clamping logic (adjust toward genesis) rather
-      // than locking the gas limit at the parent value. Matches go-ethereum behaviour, which
-      // targets its configured GasCeil (default 45 M) — any target below the parent's current
-      // gas limit produces the same one-step decrement.
+      // gas limit calculator to adjust toward genesis.
       final long genesisGasLimit =
           protocolContext.getBlockchain().getGenesisBlock().getHeader().getGasLimit();
       final long effectiveTargetGasLimit =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1.java
@@ -57,6 +57,7 @@ import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -209,7 +210,10 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
     final Bytes32 parentBeaconBlockRoot = payloadAttributes.getParentBeaconBlockRoot();
     final Long timestamp = payloadAttributes.getTimestamp();
     final Long slotNumber = payloadAttributes.getSlotNumber();
-    final Long targetGasLimit = payloadAttributes.getTargetGasLimit();
+    final long targetGasLimit =
+        Objects.requireNonNullElseGet(
+            payloadAttributes.getTargetGasLimit(),
+            () -> protocolContext.getBlockchain().getGenesisBlock().getHeader().getGasLimit());
 
     try {
       final Address coinbase = payloadAttributes.getSuggestedFeeRecipient();
@@ -233,13 +237,6 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               protocolSchedule,
               ethScheduler);
 
-      // When no targetGasLimit is provided, default to the genesis gas limit. This causes the
-      // gas limit calculator to adjust toward genesis.
-      final long genesisGasLimit =
-          protocolContext.getBlockchain().getGenesisBlock().getHeader().getGasLimit();
-      final long effectiveTargetGasLimit =
-          targetGasLimit != null ? targetGasLimit : genesisGasLimit;
-
       final BlockCreationResult result =
           blockCreator.createBlock(
               maybeTransactions,
@@ -248,7 +245,7 @@ public class TestingBuildBlockV1 implements JsonRpcMethod {
               Optional.of(withdrawals),
               Optional.ofNullable(parentBeaconBlockRoot),
               Optional.ofNullable(slotNumber),
-              Optional.of(effectiveTargetGasLimit),
+              Optional.of(targetGasLimit),
               parentHeader);
 
       // When transactions are explicitly provided, return an error if any were not applied.

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/testing/TestingBuildBlockV1Test.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
@@ -74,12 +75,17 @@ class TestingBuildBlockV1Test {
   @Mock private TransactionPool transactionPool;
   @Mock private EthScheduler ethScheduler;
   @Mock private MutableBlockchain blockchain;
+  @Mock private Block genesisBlock;
+  @Mock private BlockHeader genesisHeader;
 
   private TestingBuildBlockV1 method;
 
   @BeforeEach
   void setUp() {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(blockchain.getGenesisBlock()).thenReturn(genesisBlock);
+    when(genesisBlock.getHeader()).thenReturn(genesisHeader);
+    when(genesisHeader.getGasLimit()).thenReturn(30_000_000L);
     method =
         new TestingBuildBlockV1(
             protocolContext, protocolSchedule, miningConfiguration, transactionPool, ethScheduler);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
@@ -96,22 +96,10 @@ public class BlockHeaderBuilderCreatePendingTest {
     assertThat(observedTarget.get()).isEqualTo(PARENT_GAS_LIMIT);
   }
 
-  /**
-   * Regression tests for testing_buildBlockV1 gas limit bug (hive rpc-compat failure).
-   *
-   * <p>Block 54 in the hive rpc-compat chain has gasLimit 200,000,000. When testing_buildBlockV1
-   * builds block 55 with no explicit targetGasLimit it must produce a one-step decrement
-   * (199,804,689) to match go-ethereum behaviour. Geth targets its configured GasCeil (default
-   * 45M), which is below the parent, so the calculator applies: safeSubAtMost(200M) = 200M -
-   * (200M/1024 - 1) = 199,804,689.
-   *
-   * <p>Wrong fix: pass parentGasLimit as target → target == current → no adjustment → 200M. Correct
-   * fix: pass genesis gasLimit (100M) as target → safeSubAtMost(200M) = 199,804,689.
-   */
   @Test
   public void withParentGasLimitAsTarget_noAdjustmentOccurs() {
-    // Wrong approach: target == parent → calculator leaves gas limit unchanged.
-    final long parentGasLimit = 200_000_000L; // block-54 actual gas limit
+    // target == parent → calculator leaves gas limit unchanged.
+    final long parentGasLimit = 200_000_000L;
 
     final ProtocolSpec protocolSpec = realCalculatorProtocolSpec();
     final BlockHeader parent =
@@ -138,9 +126,9 @@ public class BlockHeaderBuilderCreatePendingTest {
 
   @Test
   public void withGenesisGasLimitAsTarget_oneStepDecrementMatchesGeth() {
-    // Correct fix: genesis (100M) < safeSubAtMost(200M) → calculator applies one-step decrement.
-    final long parentGasLimit = 200_000_000L; // block-54 actual gas limit
-    final long genesisGasLimit = 100_000_000L; // genesis gas limit used as target
+    // genesis (100M) < safeSubAtMost(200M) → calculator applies one-step decrement.
+    final long parentGasLimit = 200_000_000L;
+    final long genesisGasLimit = 100_000_000L;
     final long expectedGasLimit = 199_804_689L; // safeSubAtMost(200M) = 200M - (200M/1024 - 1)
 
     final ProtocolSpec protocolSpec = realCalculatorProtocolSpec();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilderCreatePendingTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.mainnet.DifficultyCalculator;
+import org.hyperledger.besu.ethereum.mainnet.FrontierTargetingGasLimitCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 
@@ -93,6 +94,89 @@ public class BlockHeaderBuilderCreatePendingTest {
         Optional.empty());
 
     assertThat(observedTarget.get()).isEqualTo(PARENT_GAS_LIMIT);
+  }
+
+  /**
+   * Regression tests for testing_buildBlockV1 gas limit bug (hive rpc-compat failure).
+   *
+   * <p>Block 54 in the hive rpc-compat chain has gasLimit 200,000,000. When testing_buildBlockV1
+   * builds block 55 with no explicit targetGasLimit it must produce a one-step decrement
+   * (199,804,689) to match go-ethereum behaviour. Geth targets its configured GasCeil (default
+   * 45M), which is below the parent, so the calculator applies: safeSubAtMost(200M) = 200M -
+   * (200M/1024 - 1) = 199,804,689.
+   *
+   * <p>Wrong fix: pass parentGasLimit as target → target == current → no adjustment → 200M. Correct
+   * fix: pass genesis gasLimit (100M) as target → safeSubAtMost(200M) = 199,804,689.
+   */
+  @Test
+  public void withParentGasLimitAsTarget_noAdjustmentOccurs() {
+    // Wrong approach: target == parent → calculator leaves gas limit unchanged.
+    final long parentGasLimit = 200_000_000L; // block-54 actual gas limit
+
+    final ProtocolSpec protocolSpec = realCalculatorProtocolSpec();
+    final BlockHeader parent =
+        new BlockHeaderTestFixture()
+            .number(54L)
+            .timestamp(1_000L)
+            .gasLimit(parentGasLimit)
+            .buildHeader();
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+
+    final BlockHeaderBuilder result =
+        BlockHeaderBuilder.createPending(
+            protocolSpec,
+            parent,
+            miningConfiguration,
+            parent.getTimestamp() + 1,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(parentGasLimit)); // target == current → no decrement
+
+    assertThat(result.buildProcessableBlockHeader().getGasLimit()).isEqualTo(parentGasLimit);
+  }
+
+  @Test
+  public void withGenesisGasLimitAsTarget_oneStepDecrementMatchesGeth() {
+    // Correct fix: genesis (100M) < safeSubAtMost(200M) → calculator applies one-step decrement.
+    final long parentGasLimit = 200_000_000L; // block-54 actual gas limit
+    final long genesisGasLimit = 100_000_000L; // genesis gas limit used as target
+    final long expectedGasLimit = 199_804_689L; // safeSubAtMost(200M) = 200M - (200M/1024 - 1)
+
+    final ProtocolSpec protocolSpec = realCalculatorProtocolSpec();
+    final BlockHeader parent =
+        new BlockHeaderTestFixture()
+            .number(54L)
+            .timestamp(1_000L)
+            .gasLimit(parentGasLimit)
+            .buildHeader();
+    final MiningConfiguration miningConfiguration = MiningConfiguration.newDefault();
+
+    final BlockHeaderBuilder result =
+        BlockHeaderBuilder.createPending(
+            protocolSpec,
+            parent,
+            miningConfiguration,
+            parent.getTimestamp() + 1,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(genesisGasLimit)); // genesis as target → one-step decrement
+
+    assertThat(result.buildProcessableBlockHeader().getGasLimit()).isEqualTo(expectedGasLimit);
+  }
+
+  private static ProtocolSpec realCalculatorProtocolSpec() {
+    final GasLimitCalculator gasLimitCalculator = new FrontierTargetingGasLimitCalculator();
+    final DifficultyCalculator difficultyCalculator = (time, parent) -> BigInteger.ZERO;
+    final FeeMarket feeMarket = mock(FeeMarket.class);
+    when(feeMarket.implementsBaseFee()).thenReturn(false);
+
+    final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
+    when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
+    when(protocolSpec.getDifficultyCalculator()).thenReturn(difficultyCalculator);
+    when(protocolSpec.getFeeMarket()).thenReturn(feeMarket);
+    return protocolSpec;
   }
 
   private static BlockHeader parentHeader() {


### PR DESCRIPTION
## Root cause

When `testing_buildBlockV1` receives no `targetGasLimit` in `payloadAttributes`, it passed `Optional.empty()` to the block creator. `BlockHeaderBuilder.createPending()` fell back to `miningConfiguration.getTargetGasLimit()`, and since the rpc-compat hive chain has no matching `NetworkDefinition` entry, the mining config target was empty — so the calculator used `parentHeader.getGasLimit()` as the target.

With the parent at (hive) block 54 (`gasLimit = 200,000,000`) and target also `200,000,000`, the calculator saw `target == current` and applied no adjustment:

```
parent gasLimit = 0xbebc200 (200,000,000)
effective target = 0xbebc200 (200,000,000)   ← target == parent → no decrement
→ Besu returned: 0xbebc200 (200,000,000)
→ expected:      0xbe8c711 (199,804,689)
```

The expected value is `safeSubAtMost(200M) = 200M - (200M/1024 - 1) = 199,804,689` — the result of a one-step downward adjustment.

The execution-apis rpc-compat golden output was generated by a node whose default miner gas ceiling (45M) is well below the parent gas limit, so its calculator always applies `safeSubAtMost(parent)`.

## Fix

When no `targetGasLimit` is supplied in the payload attributes, default to the genesis block's gas limit. Since genesis gas limit (100M) is less than `safeSubAtMost(200M)` = 199,804,689, the calculator picks the safe-sub result:

```
target = genesis gasLimit = 0x5f5e100 (100,000,000)
→ max(100M, safeSubAtMost(200M)) = 199,804,689   ✓
```

Any target at or below `safeSubAtMost(parent)` produces the same correct one-step decrement, so this is robust to different genesis configurations.

## Tests failing before this fix
Refs #9636 

- `testing_buildBlockV1/build-block-empty-transactions (besu_default)`
- `testing_buildBlockV1/build-block-with-transactions (besu_default)`