### PR TITLE
Fix incorrect SYNCING response from engine_newPayload after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `eth_simulateV1` no longer applies EIP-7825's transaction gas limit cap to simulation gas, fixing incorrect block/transaction hashes on Osaka [#10885](https://github.com/besu-eth/besu/pull/10885)
 - Move to a new BFT round and select a new proposer for a block if transactions arrive at a non-proposing node after blockperiodseconds but before emptyblockperiodseconds [#11031](https://github.com/besu-eth/besu/pull/11031) 
 - Complete QBFT votes in a reasonable time when `empyblockperiodseconds` is set by treating QBFT votes as "non empty blocks" [#11111](https://github.com/besu-eth/besu/pull/11111)
+- `engine_newPayload` no longer briefly answers `SYNCING` after startup on a peerless node: `PostMergeContext.isSyncing()` now treats an undetermined terminal-difficulty flag as "reached", matching `SyncState.isInSync()`. [#XXXXX](https://github.com/besu-eth/besu/pull/XXXXX)
 
 ### Additions and Improvements
 - Add JMH `GasProfiler` that emits `mgas_per_s` as a secondary metric on each benchmark iteration using Besu's own `GasCalculator`. Enable with `-PgasProfiler=true`; override the EVM fork with `-PgasProfilerFork=<fork>` (defaults to Osaka). [#10807](https://github.com/besu-eth/besu/pull/10807)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - `eth_simulateV1` no longer applies EIP-7825's transaction gas limit cap to simulation gas, fixing incorrect block/transaction hashes on Osaka [#10885](https://github.com/besu-eth/besu/pull/10885)
 - Move to a new BFT round and select a new proposer for a block if transactions arrive at a non-proposing node after blockperiodseconds but before emptyblockperiodseconds [#11031](https://github.com/besu-eth/besu/pull/11031) 
 - Complete QBFT votes in a reasonable time when `empyblockperiodseconds` is set by treating QBFT votes as "non empty blocks" [#11111](https://github.com/besu-eth/besu/pull/11111)
-- `engine_newPayload` no longer briefly answers `SYNCING` after startup on a peerless node: `PostMergeContext.isSyncing()` now treats an undetermined terminal-difficulty flag as "reached", matching `SyncState.isInSync()`. [#XXXXX](https://github.com/besu-eth/besu/pull/XXXXX)
+- `engine_newPayload` no longer briefly answers `SYNCING` after startup on a peerless node: `PostMergeContext.isSyncing()` now treats an undetermined terminal-difficulty flag as "reached", matching `SyncState.isInSync()`. [#11168](https://github.com/besu-eth/besu/pull/11168)
 
 ### Additions and Improvements
 - Add JMH `GasProfiler` that emits `mgas_per_s` as a secondary metric on each benchmark iteration using Besu's own `GasCalculator`. Enable with `-PgasProfiler=true`; override the EVM fork with `-PgasProfilerFork=<fork>` (defaults to Osaka). [#10807](https://github.com/besu-eth/besu/pull/10807)

--- a/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -337,9 +337,8 @@ public class MergeBesuControllerBuilderTest {
   }
 
   @Test
-  public void reportSyncingWhenP2pEnabled() {
-    when(synchronizerConfiguration.getSyncMode())
-        .thenReturn(new Random().nextBoolean() ? SyncMode.FULL : SyncMode.SNAP);
+  public void reportSyncingWhenP2pEnabledAndSnapSync() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.SNAP);
 
     final boolean isSyncing =
         visitWithMockConfigs(new MergeBesuControllerBuilder())
@@ -349,7 +348,26 @@ public class MergeBesuControllerBuilderTest {
             .getConsensusContext(MergeContext.class)
             .isSyncing();
 
+    // The initial sync phase has not completed yet.
     assertThat(isSyncing).isTrue();
+  }
+
+  @Test
+  public void reportNotSyncingWhenP2pEnabledAndFullSyncAndNoPeers() {
+    when(synchronizerConfiguration.getSyncMode()).thenReturn(SyncMode.FULL);
+
+    final boolean isSyncing =
+        visitWithMockConfigs(new MergeBesuControllerBuilder())
+            .p2pEnabled(true)
+            .build()
+            .getProtocolContext()
+            .getConsensusContext(MergeContext.class)
+            .isSyncing();
+
+    // Full sync marks the initial sync phase done at startup and leaves terminal difficulty
+    // undetermined until the downloader terminates. That undetermined state now defaults to
+    // "reached", so with no peers ahead of us we are in sync rather than syncing.
+    assertThat(isSyncing).isFalse();
   }
 
   @Test

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -134,10 +134,11 @@ public class PostMergeContext implements MergeContext {
     if (!state.isInitialSyncPhaseDone()) {
       return true;
     }
-    // Pre-TTD: if terminal difficulty hasn't been reached we're still in PoW sync.
-    // When started with --p2p-enabled=false the controller marks TTD reached at startup,
-    // so this branch is skipped and the node can serve the engine API immediately.
-    if (!state.hasReachedTerminalDifficulty().orElse(false)) {
+    // Pre-TTD: if terminal difficulty is known *not* to have been reached we're still in PoW sync.
+    // An empty Optional just means "not determined yet" (normal right after startup), so default to
+    // "reached" as SyncState.isInSync() does; a node genuinely mid-PoW-sync has peers ahead of it
+    // and is still caught by the isInSync() check below.
+    if (!state.hasReachedTerminalDifficulty().orElse(true)) {
       return true;
     }
     // Post-TTD (post-merge): rely solely on peer sync state. This correctly handles full sync on

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
@@ -351,6 +351,31 @@ public class PostMergeContextTest {
   }
 
   @Test
+  public void isSyncingReturnsFalseAtStartupBeforeTerminalDifficultyIsDetermined() {
+    // Regression test: a freshly started node with p2p enabled and no peers yet answered
+    // engine_newPayload with SYNCING for about a second, because reachedTerminalDifficulty is
+    // only set asynchronously once DefaultSynchronizer's downloader terminates. This is the
+    // state hive's consume-engine sims hit on the very first payload after the genesis FCU.
+    when(mockSyncState.isInitialSyncPhaseDone()).thenReturn(Boolean.TRUE);
+    // Not determined yet — the synchronizer has not finished starting up.
+    when(mockSyncState.hasReachedTerminalDifficulty()).thenReturn(Optional.empty());
+    // No peers, so SyncState reports in-sync (both the sync target and best peer are absent).
+    when(mockSyncState.isInSync()).thenReturn(Boolean.TRUE);
+
+    assertThat(postMergeContext.isSyncing()).isFalse();
+  }
+
+  @Test
+  public void isSyncingReturnsTrueWhenTerminalDifficultyIsKnownNotToBeReached() {
+    when(mockSyncState.isInitialSyncPhaseDone()).thenReturn(Boolean.TRUE);
+    when(mockSyncState.hasReachedTerminalDifficulty()).thenReturn(Optional.of(Boolean.FALSE));
+
+    // Short-circuits on the pre-TTD gate, so peer sync state is never consulted.
+    assertThat(postMergeContext.isSyncing()).isTrue();
+    verify(mockSyncState, never()).isInSync();
+  }
+
+  @Test
   public void fireNewPayloadEventDeliversToSubscribedListeners() {
     final List<BlockHeader> received = new ArrayList<>();
     postMergeContext.addNewPayloadListener(received::add);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -203,13 +203,20 @@ public final class DefaultP2PNetworkTest {
     final DefaultP2PNetwork network = network();
     final Peer peer = PeerTestHelper.createPeer();
 
+    // Stubbed before start(), which arms a 2s timer that runs checkMaintainedConnectionPeers() on
+    // the scheduler thread. That background call invokes rlpxAgent too, and Mockito tracks the
+    // invocation being stubbed per mock rather than per thread, so stubbing after start() can have
+    // its when(...)/thenReturn(...) pair torn apart by the timer on a slow enough run.
+    // thenAnswer() rather than thenReturn() because a Stream is single-use and the timer may
+    // consume one before this test does.
+    when(rlpxAgent.streamActiveConnections())
+        .thenAnswer(invocation -> Stream.of(MockPeerConnection.create(peer)));
+
     network.start();
 
     maintainedPeers.add(peer);
 
     // Don't connect to an already connected peer
-    when(rlpxAgent.streamActiveConnections())
-        .thenReturn(Stream.of(MockPeerConnection.create(peer)));
     network.checkMaintainedConnectionPeers();
     verify(rlpxAgent, times(0)).connect(peer, ConnectSource.MAINTAIN);
   }


### PR DESCRIPTION
## PR description

A freshly started node with no peers yet answered `engine_newPayload` with `SYNCING` for roughly a second after startup.

`PostMergeContext.isSyncing()` read `SyncState.hasReachedTerminalDifficulty()` with `orElse(false)`, so an empty `Optional` — which only means "not determined yet", the normal state until `DefaultSynchronizer`'s downloader terminates — was treated as "TTD not reached" and reported as syncing.

The default is now `orElse(true)`, matching `SyncState.isInSync()`, which reads the same field. A node that is genuinely mid-PoW-sync has peers ahead of it and is still caught by the `isInSync()` check further down.

## Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if [updates are required](https://github.com/besu-eth/besu/blob/main/docs/README.md).
- [x] Considered the changelog and included an [update if required](https://github.com/besu-eth/besu/blob/main/docs/README.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests