### PR TITLE
Refactor engine_getBlobsV* into a sealed version hierarchy

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -216,6 +216,15 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     return engineCallListener;
   }
 
+  protected int getNumericVersion() {
+    final String name = getName();
+    final int vIndex = name.lastIndexOf('V');
+    if (vIndex < 0 || vIndex == name.length() - 1) {
+      throw new IllegalStateException("Cannot derive numeric version from method name: " + name);
+    }
+    return Integer.parseInt(name.substring(vIndex + 1));
+  }
+
   // TRANSITIONAL: not 'final' yet (restored in cleanup PR) so not-yet-migrated engine methods can
   // still override it; new methods inherit this implementation.
   protected ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -49,9 +49,9 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     INVALID_BLOCK_HASH;
   }
 
-  // Fields used by migrated series (every engine_* series except engine_getBlobsV* — see the
-  // package README's migration status table). Not-yet-migrated series keep using the
-  // TRANSITIONAL SHIM constructors below instead of this record.
+  // Fields used by migrated series — now every engine_* series, see the package README's
+  // migration status table. The TRANSITIONAL SHIM constructors below have no callers left and are
+  // removed in the cleanup PR that closes this stack.
   @Value.Builder
   public record ConstructorArguments(
       ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -14,12 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -32,17 +29,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV1;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * #### Specification
@@ -66,22 +62,22 @@ import org.jspecify.annotations.Nullable;
  * <p>5. Callers **MUST** consider that execution layer clients may prune old blobs from their pool,
  * and will respond with `null` if a blob has been pruned.
  */
-public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
-
-  private final TransactionPool transactionPool;
-  private final Optional<Long> cancunMilestone;
-  private final Optional<Long> osakaMilestone;
+public sealed class EngineGetBlobsV1<BAP extends BlobAndProofV1>
+    extends ExecutionEngineJsonRpcMethod permits EngineGetBlobsV2 {
+  private static final Logger LOG = LoggerFactory.getLogger(EngineGetBlobsV1.class);
+  public static final int REQUEST_MAX_VERSIONED_HASHES = 128;
+  protected final TransactionPool transactionPool;
+  protected final GetBlobsMetrics getBlobsMetrics;
 
   public EngineGetBlobsV1(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool) {
-    super(vertx, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
-    this.cancunMilestone = protocolSchedule.milestoneFor(CANCUN);
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.transactionPool = constructorArguments.transactionPool();
+    this.getBlobsMetrics =
+        new GetBlobsMetrics(
+            constructorArguments.metricsSystem(), getName().charAt(getName().length() - 1));
   }
 
   @Override
@@ -101,47 +97,99 @@ public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
           e);
     }
 
-    if (versionedHashes.length > 128) {
+    if (versionedHashes.length > REQUEST_MAX_VERSIONED_HASHES) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(),
           RpcErrorType.INVALID_ENGINE_GET_BLOBS_TOO_LARGE_REQUEST);
     }
+
     if (mergeContext.get().isSyncing()) {
-      final List<BlobAndProofV1> emptyResults = Collections.nCopies(versionedHashes.length, null);
-      return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), emptyResults);
+      return new JsonRpcSuccessResponse(
+          requestContext.getRequest().getId(), getEmptyResult(versionedHashes));
     }
-    long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
+
+    final long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
     ValidationResult<RpcErrorType> forkValidationResult = validateForkSupported(timestamp);
     if (!forkValidationResult.isValid()) {
       return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
     }
 
-    final List<BlobAndProofV1> result = getBlobV1Result(versionedHashes);
-
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(), getBlobResult(versionedHashes));
   }
 
-  private @NotNull List<BlobAndProofV1> getBlobV1Result(final VersionedHash[] versionedHashes) {
-    return Arrays.stream(versionedHashes)
-        .map(transactionPool::getBlobProofBundle)
-        .map(this::getBlobAndProofV1)
+  protected List<BlobAndProofV1> getEmptyResult(final VersionedHash[] versionedHashes) {
+    return Collections.nCopies(versionedHashes.length, null);
+  }
+
+  protected List<BAP> getBlobResult(final VersionedHash[] versionedHashes) {
+    return getResultPartialMode(versionedHashes);
+  }
+
+  protected @NotNull List<BAP> getResultPartialMode(final VersionedHash[] versionedHashes) {
+    return fetchedBlobsData(versionedHashes).blobProofBundles().parallelStream()
+        .map(this::getBlobAndProofResult)
         .toList();
   }
 
-  private @Nullable BlobAndProofV1 getBlobAndProofV1(final BlobProofBundle bq) {
-    if (bq == null) {
+  private @Nullable BAP getBlobAndProofResult(final BlobProofBundle blobProofBundle) {
+    if (blobProofBundle == null) {
       return null;
     }
-    if (bq.getBlobType() != BlobType.KZG_PROOF) {
-      return null;
-    }
-    return new BlobAndProofV1(
-        bq.getBlob().getData().toHexString(), bq.getKzgProof().getFirst().getData().toHexString());
+    return getVersionSpecificBlobAndProofResult(blobProofBundle);
   }
 
-  @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(
-        CANCUN, cancunMilestone, OSAKA, osakaMilestone, currentTimestamp);
+  @SuppressWarnings("unchecked")
+  protected BAP getVersionSpecificBlobAndProofResult(final BlobProofBundle blobProofBundle) {
+    return (BAP) new BlobAndProofV1(blobProofBundle);
   }
+
+  protected FetchedBlobsData fetchedBlobsData(final VersionedHash[] versionedHashes) {
+    final ArrayList<BlobProofBundle> validBundles =
+        new ArrayList<>(Collections.nCopies(versionedHashes.length, null));
+    getBlobsMetrics.increaseRequested(versionedHashes.length);
+    int unsupportedBlobs = 0;
+    int missingBlobs = 0;
+    int foundBlobs = 0;
+    for (int i = 0; i < versionedHashes.length; i++) {
+      final VersionedHash hash = versionedHashes[i];
+      final BlobProofBundle bundle = transactionPool.getBlobProofBundle(hash);
+      if (bundle == null) {
+        LOG.trace("No BlobProofBundle found for versioned hash: {}", hash);
+        missingBlobs++;
+        continue;
+      }
+      if (isUnsupportedBlob(bundle)) {
+        LOG.trace("Unsupported blob type {} for versioned hash: {}", bundle.getBlobType(), hash);
+        unsupportedBlobs++;
+        continue;
+      }
+      validBundles.set(i, bundle);
+      foundBlobs++;
+    }
+
+    getBlobsMetrics.increaseAvailable(foundBlobs);
+    getBlobsMetrics.increaseMissing(missingBlobs);
+    getBlobsMetrics.increaseUnsupported(unsupportedBlobs);
+    if (foundBlobs == versionedHashes.length) {
+      getBlobsMetrics.increaseFull();
+    } else if (foundBlobs == 0) {
+      getBlobsMetrics.increasePartial();
+    }
+
+    LOG.debug(
+        "Requested {} bundles, found {} valid bundles, {} missing, {} unsupported",
+        versionedHashes.length,
+        foundBlobs,
+        missingBlobs,
+        unsupportedBlobs);
+
+    return new FetchedBlobsData(validBundles, missingBlobs + unsupportedBlobs > 0);
+  }
+
+  protected boolean isUnsupportedBlob(final BlobProofBundle blobProofBundle) {
+    return blobProofBundle.getBlobType() == BlobType.KZG_CELL_PROOFS;
+  }
+
+  protected record FetchedBlobsData(List<BlobProofBundle> blobProofBundles, boolean partial) {}
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -126,7 +126,7 @@ public sealed class EngineGetBlobsV1<BAP extends BlobAndProofV1>
   }
 
   protected @NotNull List<BAP> getResultPartialMode(final VersionedHash[] versionedHashes) {
-    return fetchedBlobsData(versionedHashes).blobProofBundles().parallelStream()
+    return fetchedBlobsData(versionedHashes).blobProofBundles().stream()
         .map(this::getBlobAndProofResult)
         .toList();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -76,8 +76,7 @@ public sealed class EngineGetBlobsV1<BAP extends BlobAndProofV1>
     super(constructorArguments, minSupportedFork, firstUnsupportedFork);
     this.transactionPool = constructorArguments.transactionPool();
     this.getBlobsMetrics =
-        new GetBlobsMetrics(
-            constructorArguments.metricsSystem(), getName().charAt(getName().length() - 1));
+        new GetBlobsMetrics(constructorArguments.metricsSystem(), getNumericVersion());
   }
 
   @Override
@@ -173,7 +172,7 @@ public sealed class EngineGetBlobsV1<BAP extends BlobAndProofV1>
     getBlobsMetrics.increaseUnsupported(unsupportedBlobs);
     if (foundBlobs == versionedHashes.length) {
       getBlobsMetrics.increaseFull();
-    } else if (foundBlobs == 0) {
+    } else {
       getBlobsMetrics.increasePartial();
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
@@ -14,80 +14,26 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV2;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
-import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.util.HexUtils;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
 
-public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
-  private static final Logger LOG = LoggerFactory.getLogger(EngineGetBlobsV2.class);
-  public static final int REQUEST_MAX_VERSIONED_HASHES = 128;
-
-  private final TransactionPool transactionPool;
-  private final Counter requestedCounter;
-  private final Counter availableCounter;
-  private final Counter hitCounter;
-  private final Counter missCounter;
-  private final Optional<Long> osakaMilestone;
+public sealed class EngineGetBlobsV2<BAP extends BlobAndProofV2> extends EngineGetBlobsV1<BAP>
+    permits EngineGetBlobsV3 {
 
   public EngineGetBlobsV2(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final MetricsSystem metricsSystem) {
-    super(vertx, protocolSchedule, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
-    // create counters
-    this.requestedCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_requested_total",
-            "Number of blobs requested via engine_getBlobsV2");
-    this.availableCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_available_total",
-            "Number of blobs requested via engine_getBlobsV2 that are present in the blob pool");
-    this.hitCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_hit_total",
-            "Number of calls to engine_getBlobsV2 that returned at least one blob");
-    this.missCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_miss_total",
-            "Number of calls to engine_getBlobsV2 that returned zero blobs");
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override
@@ -96,83 +42,33 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
-    final VersionedHash[] versionedHashes = extractVersionedHashes(requestContext);
-    if (versionedHashes.length > REQUEST_MAX_VERSIONED_HASHES) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(),
-          RpcErrorType.INVALID_ENGINE_GET_BLOBS_TOO_LARGE_REQUEST);
-    }
-    if (mergeContext.get().isSyncing()) {
-      return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), null);
-    }
-    long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
-    ValidationResult<RpcErrorType> forkValidationResult = validateForkSupported(timestamp);
-    if (!forkValidationResult.isValid()) {
-      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
-    }
-    requestedCounter.inc(versionedHashes.length);
-    List<BlobProofBundle> validBundles = new ArrayList<>(versionedHashes.length);
-    int missingBlobs = 0;
-    int unsupportedBlobs = 0;
-    for (VersionedHash hash : versionedHashes) {
-      final BlobProofBundle bundle = transactionPool.getBlobProofBundle(hash);
-      if (bundle == null) {
-        LOG.trace("No BlobProofBundle found for versioned hash: {}", hash);
-        missingBlobs++;
-        continue;
-      }
-      if (bundle.getBlobType() == BlobType.KZG_PROOF) {
-        LOG.trace("Unsupported blob type KZG_PROOF for versioned hash: {}", hash);
-        unsupportedBlobs++;
-        continue;
-      }
-      validBundles.add(bundle);
-    }
-    // count how many of the requested blobs are actually available
-    availableCounter.inc(validBundles.size());
-
-    LOG.debug(
-        "Requested {} bundles, found {} valid bundles, {} missing, {} unsupported",
-        versionedHashes.length,
-        validBundles.size(),
-        missingBlobs,
-        unsupportedBlobs);
-
-    // V2 returns null if any requested blobs are missing or unsupported
-    if (missingBlobs > 0 || unsupportedBlobs > 0) {
-      missCounter.inc();
-      return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), null);
-    }
-
-    final List<BlobAndProofV2> results =
-        validBundles.parallelStream().map(this::createBlobAndProofV2).toList();
-
-    hitCounter.inc();
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), results);
-  }
-
-  private VersionedHash[] extractVersionedHashes(final JsonRpcRequestContext requestContext) {
-    try {
-      return requestContext.getRequiredParameter(0, VersionedHash[].class);
-    } catch (JsonRpcParameter.JsonRpcParameterException e) {
-      throw new InvalidJsonRpcParameters(
-          "Invalid versioned hashes parameter (index 0)",
-          RpcErrorType.INVALID_VERSIONED_HASHES_PARAMS,
-          e);
-    }
-  }
-
-  private BlobAndProofV2 createBlobAndProofV2(final BlobProofBundle blobProofBundle) {
-    return new BlobAndProofV2(
-        HexUtils.toFastHex(blobProofBundle.getBlob().getData(), true),
-        blobProofBundle.getKzgProof().parallelStream()
-            .map(proof -> HexUtils.toFastHex(proof.getData(), true))
-            .toList());
+  protected List<BlobAndProofV1> getEmptyResult(final VersionedHash[] versionedHashes) {
+    return null;
   }
 
   @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(OSAKA, osakaMilestone, currentTimestamp);
+  protected List<BAP> getBlobResult(final VersionedHash[] versionedHashes) {
+    return getResultFullMode(versionedHashes);
+  }
+
+  private @Nullable List<BAP> getResultFullMode(final VersionedHash[] versionedHashes) {
+    final FetchedBlobsData fetchedBlobsData = fetchedBlobsData(versionedHashes);
+    if (fetchedBlobsData.partial()) {
+      return null;
+    }
+    return fetchedBlobsData.blobProofBundles().stream()
+        .map(this::getVersionSpecificBlobAndProofResult)
+        .toList();
+  }
+
+  @Override
+  protected boolean isUnsupportedBlob(final BlobProofBundle blobProofBundle) {
+    return blobProofBundle.getBlobType() == BlobType.KZG_PROOF;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected BAP getVersionSpecificBlobAndProofResult(final BlobProofBundle blobProofBundle) {
+    return (BAP) new BlobAndProofV2(blobProofBundle);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
@@ -14,39 +14,14 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
-import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV2;
-import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
-import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.util.HexUtils;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-
-import io.vertx.core.Vertx;
-import jakarta.validation.constraints.NotNull;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of engine_getBlobsV3 API method.
@@ -64,48 +39,13 @@ import org.slf4j.LoggerFactory;
  *   <li>Only supports KZG_CELL_PROOFS blob type (rejects KZG_PROOF)
  * </ul>
  */
-public class EngineGetBlobsV3 extends ExecutionEngineJsonRpcMethod {
-  private static final Logger LOG = LoggerFactory.getLogger(EngineGetBlobsV3.class);
-  public static final int REQUEST_MAX_VERSIONED_HASHES = 128;
-
-  private final TransactionPool transactionPool;
-  private final Counter requestedCounter;
-  private final Counter availableCounter;
-  private final Counter partialResponseCounter;
-  private final Counter fullResponseCounter;
-  private final Optional<Long> osakaMilestone;
+public final class EngineGetBlobsV3<BAP extends BlobAndProofV2> extends EngineGetBlobsV2<BAP> {
 
   public EngineGetBlobsV3(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final MetricsSystem metricsSystem) {
-    super(vertx, protocolSchedule, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
-    // create counters
-    this.requestedCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v3_requested_total",
-            "Number of blobs requested via engine_getBlobsV3");
-    this.availableCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v3_available_total",
-            "Number of blobs requested via engine_getBlobsV3 that are present in the blob pool");
-    this.partialResponseCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v3_partial_total",
-            "Number of calls to engine_getBlobsV3 that returned partial responses");
-    this.fullResponseCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v3_full_total",
-            "Number of calls to engine_getBlobsV3 that returned complete responses");
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override
@@ -114,87 +54,12 @@ public class EngineGetBlobsV3 extends ExecutionEngineJsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
-    final VersionedHash[] versionedHashes = extractVersionedHashes(requestContext);
-    if (versionedHashes.length > REQUEST_MAX_VERSIONED_HASHES) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(),
-          RpcErrorType.INVALID_ENGINE_GET_BLOBS_TOO_LARGE_REQUEST);
-    }
-    if (mergeContext.get().isSyncing()) {
-      return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), null);
-    }
-    long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
-    ValidationResult<RpcErrorType> forkValidationResult = validateForkSupported(timestamp);
-    if (!forkValidationResult.isValid()) {
-      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
-    }
-
-    requestedCounter.inc(versionedHashes.length);
-
-    final List<BlobAndProofV2> result = getBlobV3Result(versionedHashes);
-
-    // count available blobs (non-null entries)
-    long availableCount = result.stream().mapToLong(blob -> blob != null ? 1 : 0).sum();
-    availableCounter.inc(availableCount);
-
-    // track if this was a partial or full response
-    if (availableCount == versionedHashes.length) {
-      fullResponseCounter.inc();
-    } else {
-      partialResponseCounter.inc();
-    }
-
-    LOG.debug(
-        "Requested {} bundles, found {} valid bundles ({} partial response)",
-        versionedHashes.length,
-        availableCount,
-        availableCount < versionedHashes.length);
-
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
-  }
-
-  private VersionedHash[] extractVersionedHashes(final JsonRpcRequestContext requestContext) {
-    try {
-      return requestContext.getRequiredParameter(0, VersionedHash[].class);
-    } catch (JsonRpcParameter.JsonRpcParameterException e) {
-      throw new InvalidJsonRpcParameters(
-          "Invalid versioned hashes parameter (index 0)",
-          RpcErrorType.INVALID_VERSIONED_HASHES_PARAMS,
-          e);
-    }
-  }
-
-  private @NotNull List<BlobAndProofV2> getBlobV3Result(final VersionedHash[] versionedHashes) {
-    return Arrays.stream(versionedHashes)
-        .map(transactionPool::getBlobProofBundle)
-        .map(this::getBlobAndProofV2)
-        .toList();
-  }
-
-  private @Nullable BlobAndProofV2 getBlobAndProofV2(final BlobProofBundle bundle) {
-    if (bundle == null) {
-      return null;
-    }
-    // V3 only supports KZG_CELL_PROOFS (like V2), reject KZG_PROOF
-    if (bundle.getBlobType() == BlobType.KZG_PROOF) {
-      LOG.trace(
-          "Unsupported blob type KZG_PROOF for versioned hash: {}", bundle.getVersionedHash());
-      return null;
-    }
-    return createBlobAndProofV2(bundle);
-  }
-
-  private BlobAndProofV2 createBlobAndProofV2(final BlobProofBundle blobProofBundle) {
-    return new BlobAndProofV2(
-        HexUtils.toFastHex(blobProofBundle.getBlob().getData(), true),
-        blobProofBundle.getKzgProof().parallelStream()
-            .map(proof -> HexUtils.toFastHex(proof.getData(), true))
-            .toList());
+  protected List<BlobAndProofV1> getEmptyResult(final VersionedHash[] versionedHashes) {
+    return Collections.nCopies(versionedHashes.length, null);
   }
 
   @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(OSAKA, osakaMilestone, currentTimestamp);
+  protected List<BAP> getBlobResult(final VersionedHash[] versionedHashes) {
+    return getResultPartialMode(versionedHashes);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
@@ -29,9 +29,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobCellsAndProofsV1;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.core.kzg.CKZG4844Helper;
+import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.util.HexUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -75,8 +75,7 @@ public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
     super(constructorArguments, minSupportedFork, firstUnsupportedFork);
     this.transactionPool = constructorArguments.transactionPool();
     this.getBlobsMetrics =
-        new GetBlobsMetrics(
-            constructorArguments.metricsSystem(), getName().charAt(getName().length() - 1));
+        new GetBlobsMetrics(constructorArguments.metricsSystem(), getNumericVersion());
   }
 
   @Override
@@ -195,16 +194,10 @@ public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
       return null;
     }
     final int cellSize = blobCells.size() / CKZG4844Helper.CELL_PROOFS_PER_BLOB;
-    final List<String> cells =
-        cellIndexes.stream()
-            .map(index -> blobCells.slice(index * cellSize, cellSize))
-            .map(cell -> HexUtils.toFastHex(cell, true))
-            .toList();
-    final List<String> proofs =
-        cellIndexes.stream()
-            .map(index -> bundle.getKzgProof().get(index))
-            .map(proof -> HexUtils.toFastHex(proof.getData(), true))
-            .toList();
+    final List<Bytes> cells =
+        cellIndexes.stream().map(index -> blobCells.slice(index * cellSize, cellSize)).toList();
+    final List<KZGProof> proofs =
+        cellIndexes.stream().map(index -> bundle.getKzgProof().get(index)).toList();
     return new BlobCellsAndProofsV1(cells, proofs);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
@@ -14,11 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -32,20 +30,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobCellsAndPr
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.core.kzg.CKZG4844Helper;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.util.HexUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
 import org.apache.tuweni.bytes.Bytes;
 import org.jspecify.annotations.Nullable;
@@ -74,42 +66,17 @@ public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
   private static final int INDICES_BITARRAY_BYTE_LENGTH = 16;
 
   private final TransactionPool transactionPool;
-  private final Counter requestedCounter;
-  private final Counter availableCounter;
-  private final Counter partialResponseCounter;
-  private final Counter fullResponseCounter;
-  private final Optional<Long> amsterdamMilestone;
+  protected final GetBlobsMetrics getBlobsMetrics;
 
   public EngineGetBlobsV4(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final MetricsSystem metricsSystem) {
-    super(vertx, protocolSchedule, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
-    this.requestedCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v4_requested_total",
-            "Number of blobs requested via engine_getBlobsV4");
-    this.availableCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v4_available_total",
-            "Number of blobs requested via engine_getBlobsV4 that are present in the blob pool");
-    this.partialResponseCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v4_partial_total",
-            "Number of calls to engine_getBlobsV4 that returned partial responses");
-    this.fullResponseCounter =
-        metricsSystem.createCounter(
-            BesuMetricCategory.RPC,
-            "execution_engine_getblobs_v4_full_total",
-            "Number of calls to engine_getBlobsV4 that returned complete responses");
-    this.amsterdamMilestone = protocolSchedule.milestoneFor(AMSTERDAM);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.transactionPool = constructorArguments.transactionPool();
+    this.getBlobsMetrics =
+        new GetBlobsMetrics(
+            constructorArguments.metricsSystem(), getName().charAt(getName().length() - 1));
   }
 
   @Override
@@ -135,27 +102,28 @@ public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
       return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
     }
 
-    requestedCounter.inc(versionedHashes.length);
+    getBlobsMetrics.increaseRequested(versionedHashes.length);
 
     final List<Integer> cellIndexes = cellIndexesFor(indicesBitarray);
     final List<BlobCellsAndProofsV1> result = getBlobV4Result(versionedHashes, cellIndexes);
 
     // count available blobs (non-null entries)
-    long availableCount = result.stream().filter(Objects::nonNull).count();
-    availableCounter.inc(availableCount);
+    final int availableCount = (int) result.stream().filter(Objects::nonNull).count();
+    getBlobsMetrics.increaseAvailable(availableCount);
+    getBlobsMetrics.increaseMissing(versionedHashes.length - availableCount);
 
     // track if this was a partial or full response
     if (availableCount == versionedHashes.length) {
-      fullResponseCounter.inc();
+      getBlobsMetrics.increaseFull();
     } else {
-      partialResponseCounter.inc();
+      getBlobsMetrics.increasePartial();
     }
 
     LOG.atDebug()
-        .setMessage("Requested {} bundles, found {} valid bundles{}")
+        .setMessage("Requested {} bundles, found {} valid bundles, {} missing")
         .addArgument(versionedHashes.length)
         .addArgument(availableCount)
-        .addArgument(() -> availableCount < versionedHashes.length ? " (partial response)" : "")
+        .addArgument(() -> versionedHashes.length - availableCount)
         .log();
 
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
@@ -238,10 +206,5 @@ public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
             .map(proof -> HexUtils.toFastHex(proof.getData(), true))
             .toList();
     return new BlobCellsAndProofsV1(cells, proofs);
-  }
-
-  @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(AMSTERDAM, amsterdamMilestone, currentTimestamp);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/GetBlobsMetrics.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/GetBlobsMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+
+class GetBlobsMetrics {
+  private final LabelledMetric<Counter> requestedCounter;
+  private final LabelledMetric<Counter> availableCounter;
+  private final LabelledMetric<Counter> missingCounter;
+  private final LabelledMetric<Counter> unsupportedCounter;
+  private final LabelledMetric<Counter> fullCounter;
+  private final LabelledMetric<Counter> partialCounter;
+  private final String version;
+
+  public GetBlobsMetrics(final MetricsSystem metricsSystem, final int version) {
+    this.version = String.valueOf(version);
+    this.requestedCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_requested_total",
+            "Number of blobs requested via engine_getBlobsV*",
+            "version");
+    this.availableCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_available_total",
+            "Number of blobs requested via engine_getBlobsV* that are present in the blob pool",
+            "version");
+    this.missingCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_missing_total",
+            "Number of blobs requested via engine_getBlobsV* that are not present in the blob pool",
+            "version");
+    this.unsupportedCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_unsupported_total",
+            "Number of blobs requested via engine_getBlobsV* that have unsupported type",
+            "version");
+    this.fullCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_full_total",
+            "Number of calls to engine_getBlobsV* that returned all blobs",
+            "version");
+    this.partialCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_partial_total",
+            "Number of calls to engine_getBlobsV* that returned partial responses",
+            "version");
+  }
+
+  public void increaseRequested(final int count) {
+    requestedCounter.labels(version).inc(count);
+  }
+
+  public void increaseAvailable(final long availableCount) {
+    availableCounter.labels(version).inc(availableCount);
+  }
+
+  public void increaseUnsupported(final int unsupportedBlobs) {
+    unsupportedCounter.labels(version).inc(unsupportedBlobs);
+  }
+
+  public void increaseMissing(final int missingBlobs) {
+    missingCounter.labels(version).inc(missingBlobs);
+  }
+
+  public void increaseFull() {
+    fullCounter.labels(version).inc();
+  }
+
+  public void increasePartial() {
+    partialCounter.labels(version).inc();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -7,8 +7,8 @@ changing anything in this package, in the related parameter/result classes, or i
 
 ## Migration status
 
-Not every series has been migrated to the pattern below yet — the migration is landing series by
-series, each in its own PR, to keep changes reviewable:
+The migration landed series by series, each in its own PR, to keep changes reviewable. Every series
+is now on the pattern below:
 
 | Series | Constructor takes `ConstructorArguments`? | Registered via `VersionScheduler`? |
 |---|---|---|
@@ -17,33 +17,35 @@ series, each in its own PR, to keep changes reviewable:
 | `engine_getPayloadV*` | Yes | Yes |
 | `engine_getPayloadBodiesBy*` | Yes | Yes |
 | `engine_exchangeCapabilities`, `engine_getClientVersionV1`, `engine_exchangeTransitionConfigurationV1` | Yes | Yes |
-| `engine_getBlobsV*` | Not yet | Not yet |
+| `engine_getBlobsV1`–`V3`, `engine_getBlobsV4` | Yes | Yes |
 
-The not-yet-migrated series still take their old flat constructor argument list (some via
-`ExecutionEngineJsonRpcMethod`'s TRANSITIONAL SHIM constructors, kept until every series has moved
-over) and are registered in `ExecutionEngineJsonRpcMethods.create()` via plain `Arrays.asList(...)`
-plus manual `protocolSchedule.milestoneFor(FORK).isPresent()` checks. When migrating one of them,
-follow the pattern below and update this table.
+Nothing is left to migrate, so a new series must follow the pattern below from the start. The
+TRANSITIONAL SHIM constructors on `ExecutionEngineJsonRpcMethod` (and the matching
+`Optional<Long>` overload on `ForkSupportHelper`) no longer have callers and are removed in the
+cleanup PR that closes this stack — do not write new code against them.
 
 ## Architecture (migrated series)
 
 Each migrated series that has more than one version (`engine_forkchoiceUpdatedV*`,
-`engine_newPayloadV*`, `engine_getPayloadV*`, `engine_getPayloadBodiesBy*` — see the migration
-status table above) is a **sealed class hierarchy mirroring the specification**: version N extends
-version N−1 and overrides only what its spec version adds or changes.
+`engine_newPayloadV*`, `engine_getPayloadV*`, `engine_getPayloadBodiesBy*`, `engine_getBlobsV1`–`V3`
+— see the migration status table above) is a **sealed class hierarchy mirroring the
+specification**: version N extends version N−1 and overrides only what its spec version adds or
+changes.
 
 - `EngineForkchoiceUpdatedV1 permits EngineForkchoiceUpdatedV2`, `... V3 permits
   EngineForkchoiceUpdatedV4`; `EngineNewPayloadV1 permits EngineNewPayloadV2`, `... V4 permits
   EngineNewPayloadV5`; `EngineGetPayloadV1 permits EngineGetPayloadV2`, `... V5 permits
   EngineGetPayloadV6`; `EngineGetPayloadBodiesByHashV1 permits EngineGetPayloadBodiesByHashV2` and
-  `EngineGetPayloadBodiesByRangeV1 permits EngineGetPayloadBodiesByRangeV2`; and the latest version
-  of each is `final`. Future migrated series follow the same shape.
-- The remaining migrated series (`engine_exchangeCapabilities`,
-  `engine_getClientVersionV1`, `engine_exchangeTransitionConfigurationV1`) have a single spec
-  version so far, so they are plain (non-`sealed`, no `permits`) classes extending
+  `EngineGetPayloadBodiesByRangeV1 permits EngineGetPayloadBodiesByRangeV2`;
+  `EngineGetBlobsV1 permits EngineGetBlobsV2 permits EngineGetBlobsV3`; and the latest version of
+  each is `final`. Future migrated series follow the same shape.
+- The remaining migrated series (`engine_exchangeCapabilities`, `engine_getClientVersionV1`,
+  `engine_exchangeTransitionConfigurationV1`, `engine_getBlobsV4`) have a single spec version so
+  far, so they are plain (non-`sealed`, no `permits`) classes extending
   `ExecutionEngineJsonRpcMethod` directly. They become sealed hierarchies the day a V2 is
   specified — everything else about them (constructor shape, registration) is already the
-  migrated pattern.
+  migrated pattern. Note that `engine_getBlobsV4` is a *series of its own* despite its name: see
+  "Registration and scheduling" below.
 - All versions extend `ExecutionEngineJsonRpcMethod`, which owns the fork-window validation
   (`minSupportedFork` / `firstUnsupportedFork` constructor arguments, `validateForkSupported`,
   see also `ForkSupportHelper`). Concrete versions never check fork timestamps themselves.
@@ -54,15 +56,15 @@ version N−1 and overrides only what its spec version adds or changes.
   via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`
   build every version through one shared factory shape (see below). `ConstructorArguments` only
-  carries the fields the currently-migrated series need — mark a field `@Nullable` if only some
-  migrated series read it (e.g. `ethPeers`/`metricsSystem` are `engine_newPayloadV*`-only) — and
-  extend it (and its builder) when migrating a series that needs a field it doesn't have yet.
+  carries the fields the series actually need — mark a field `@Nullable` if only some series read
+  it (e.g. `mergeCoordinator` is absent for `engine_exchangeTransitionConfigurationV1`) — and
+  extend it (and its builder) when adding a series that needs a field it doesn't have yet.
 - The JSON data structures relevant to migrated series are sealed hierarchies too, mirroring the
   spec versions: request parameters in `..internal.parameters` (`ExecutionPayloadV1..V4`,
   `NewPayloadRequestParametersV1..V3`, `ForkchoiceStateV1`, `PayloadAttributesV1..V4`), results in
   `..internal.results` (`PayloadStatusV1`, `ForkchoiceUpdatedResultV1`,
-  `EngineGetPayloadResultV1..V6`, `ExecutionPayloadBodiesV1..V2`). Result classes reuse the
-  request-side payload hierarchy rather than re-declaring header fields:
+  `EngineGetPayloadResultV1..V6`, `ExecutionPayloadBodiesV1..V2`, `BlobAndProofV1..V2`). Result
+  classes reuse the request-side payload hierarchy rather than re-declaring header fields:
   `EngineGetPayloadResultV1` wraps an `ExecutionPayloadV1` via `@JsonValue`.
 - A version class overrides narrow, protected hooks of its parent (e.g. `createResponse`,
   `createExecutionPayload`, `validateParameters`, `validatePayloadAttributes`) — it never
@@ -85,7 +87,31 @@ VersionScheduler.startsFromBeginningUntil(EngineForkchoiceUpdatedV1::new, SHANGH
 Not every series is a version-supersedes-version chain: in `engine_getPayloadBodiesBy*` V2 only adds
 an optional field, so V1 and V2 coexist permanently, with no fork window on either — use
 `VersionScheduler.alwaysActive(EngineGetPayloadBodiesByHashV1::new, EngineGetPayloadBodiesByHashV2::new)`
-for series like this instead of `startsFromBeginningUntil`/`thenFrom`.
+for series like this instead of `startsFromBeginningUntil`/`thenFrom`. Two versions can also share
+one fork window inside a chain — `thenFrom` takes varargs, which is how `engine_getBlobsV2` and
+`engine_getBlobsV3` (both introduced at Osaka, neither superseding the other) are scheduled:
+
+```java
+VersionScheduler.startsFromBeginningUntil(EngineGetBlobsV1::new, OSAKA)
+    .thenFrom(OSAKA, EngineGetBlobsV2::new, EngineGetBlobsV3::new)
+    .build(constructorArguments);
+```
+
+`VersionScheduler.startsFrom(<FORK>, EngineBarV1::new)` is the entry point for a **brand-new series
+with no earlier version**: one factory, active from `<FORK>` onward, with no upper bound, registered
+as its own independent chain. Use it instead of appending `.thenFrom(<FORK>, ...)` to an existing
+chain whenever the new method does not supersede that chain's current version — `thenFrom` closes
+the previous window at `<FORK>`, which would wrongly retire methods that stay valid.
+
+`engine_getBlobsV4` is exactly that case: despite looking like "the version after V3", it takes
+different request parameters (`versioned_blob_hashes` plus a new `indices_bitarray`), returns
+`BlobCellsAndProofsV1` rather than `BlobAndProofV1`/`V2`, and does not extend `EngineGetBlobsV3`.
+It is an *addition* at Amsterdam alongside V2/V3, which remain valid indefinitely, so it gets its
+own scheduler:
+
+```java
+VersionScheduler.startsFrom(AMSTERDAM, EngineGetBlobsV4::new).build(constructorArguments);
+```
 
 The scheduler instantiates each version with the right `(minSupportedFork, firstUnsupportedFork)`
 pair derived from the chain. Method names live in the `RpcMethod` enum;
@@ -129,7 +155,9 @@ Use the commits that introduced the current latest version as the exemplar
 3. Add `ENGINE_FOO_VN+1("engine_fooVN+1")` to `RpcMethod` (this also advertises it via
    `engine_exchangeCapabilities`).
 4. Extend the series' `VersionScheduler` chain in `ExecutionEngineJsonRpcMethods` with
-   `.thenFrom(<ACTIVATION_FORK>, EngineFooVN+1::new)`.
+   `.thenFrom(<ACTIVATION_FORK>, EngineFooVN+1::new)`. Only do this if VN+1 really supersedes VN;
+   if the "next version" is unrelated in request/response shape it belongs in its own chain via
+   `startsFrom(...)` — see `engine_getBlobsV4` under "Registration and scheduling".
 5. Add `EngineFooVN+1Test extends EngineFooVNTest`: override `createMethodInstance()`, the
    method-name test, the fork-window hooks, and any builder/assertion hooks; add tests only for
    the new behavior. All inherited tests must pass unmodified.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobAndProofV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobAndProofV1.java
@@ -14,6 +14,14 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.KZGProof;
+import org.hyperledger.besu.ethereum.core.kzg.Blob;
+import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
@@ -21,22 +29,35 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * BlobAndProofV1 contains the blob data and the kzg proof for the blob.
  */
 @JsonPropertyOrder({"blob", "proof"})
-public class BlobAndProofV1 {
+public sealed class BlobAndProofV1 permits BlobAndProofV2 {
 
-  private final String blob;
+  private final Blob blob;
 
-  private final String proof;
+  private final KZGProof proof;
 
-  public BlobAndProofV1(final String blob, final String proof) {
+  public BlobAndProofV1(final Blob blob) {
+    this(blob, null);
+  }
+
+  public BlobAndProofV1(final BlobProofBundle blobProofBundle) {
+    checkArgument(
+        blobProofBundle.getBlobType() == BlobType.KZG_PROOF,
+        "Blob type must be KZG_PROOF for BlobAndProofV1");
+    this(blobProofBundle.getBlob(), blobProofBundle.getKzgProof().getFirst());
+  }
+
+  public BlobAndProofV1(final Blob blob, final KZGProof proof) {
     this.blob = blob;
     this.proof = proof;
   }
 
-  public String getProof() {
-    return proof;
+  @JsonGetter("blob")
+  public Blob getBlob() {
+    return blob;
   }
 
-  public String getBlob() {
-    return blob;
+  @JsonGetter("proof")
+  public KZGProof getProof() {
+    return proof;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobAndProofV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobAndProofV2.java
@@ -14,8 +14,13 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
+import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
+
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
@@ -23,22 +28,18 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * BlobAndProofV2 contains the blob data and a list of kzg proof for the cells.
  */
 @JsonPropertyOrder({"blob", "proofs"})
-public class BlobAndProofV2 {
+@JsonIgnoreProperties({"proof"})
+public final class BlobAndProofV2 extends BlobAndProofV1 {
 
-  private final String blob;
+  private final List<KZGProof> cellProofs;
 
-  private final List<String> cellProofs;
-
-  public BlobAndProofV2(final String blob, final List<String> cellProofs) {
-    this.blob = blob;
-    this.cellProofs = cellProofs;
+  public BlobAndProofV2(final BlobProofBundle blobProofBundle) {
+    super(blobProofBundle.getBlob());
+    this.cellProofs = blobProofBundle.getKzgProof();
   }
 
-  public List<String> getProofs() {
+  @JsonGetter("proofs")
+  public List<KZGProof> getProofs() {
     return cellProofs;
-  }
-
-  public String getBlob() {
-    return blob;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobCellsAndProofsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobCellsAndProofsV1.java
@@ -14,10 +14,13 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
+import org.hyperledger.besu.ethereum.core.kzg.KZGProof;
+
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.tuweni.bytes.Bytes;
 
 /**
  * The result of the engine_getBlobsV4 JSON-RPC method contains an array of BlobCellsAndProofsV1.
@@ -27,21 +30,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({"blob_cells", "proofs"})
 public class BlobCellsAndProofsV1 {
 
-  private final List<String> blobCells;
+  private final List<Bytes> blobCells;
 
-  private final List<String> proofs;
+  private final List<KZGProof> proofs;
 
-  public BlobCellsAndProofsV1(final List<String> blobCells, final List<String> proofs) {
+  public BlobCellsAndProofsV1(final List<Bytes> blobCells, final List<KZGProof> proofs) {
     this.blobCells = blobCells;
     this.proofs = proofs;
   }
 
   @JsonProperty("blob_cells")
-  public List<String> getBlobCells() {
+  public List<Bytes> getBlobCells() {
     return blobCells;
   }
 
-  public List<String> getProofs() {
+  @JsonProperty("proofs")
+  public List<KZGProof> getProofs() {
     return proofs;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -227,7 +227,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
       final ConstructorArguments constructorArguments) {
     // V2 and V3 both activate at Osaka and coexist from then on: V2 answers all-or-nothing, V3
     // answers partially, so neither supersedes the other.
-    return VersionScheduler.startsFromBeginningUntil(EngineGetBlobsV1::new, OSAKA)
+    return VersionScheduler.startsFrom(CANCUN, EngineGetBlobsV1::new)
         .thenFrom(OSAKA, EngineGetBlobsV2::new, EngineGetBlobsV3::new)
         .build(constructorArguments);
   }
@@ -266,7 +266,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
     static VersionScheduler startsFrom(final HardforkId from, final EngineMethodFactory factory) {
       final VersionScheduler vs = new VersionScheduler();
-      vs.readyMethods.add(new MethodVersionBuildData(factory, from, null));
+      vs.pendingMethods.add(new MethodVersionBuildData(factory, from, null));
       return vs;
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -143,47 +143,13 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
           createGetPayloadBodiesByRangeMethods(constructorArguments));
       executionEngineApisSupported.addAll(
           createEngineExchangeTransitionConfigurationMethods(constructorArguments));
+      executionEngineApisSupported.addAll(createGetBlobsMethods(constructorArguments));
+      executionEngineApisSupported.addAll(createGetBlobsV4Methods(constructorArguments));
 
       executionEngineApisSupported.addAll(
           Arrays.asList(
               new EngineExchangeCapabilities(constructorArguments),
-              new EngineGetClientVersionV1(constructorArguments, clientVersion, commit),
-              new EngineGetBlobsV1(
-                  consensusEngineServer,
-                  protocolContext,
-                  protocolSchedule,
-                  engineQosTimer,
-                  transactionPool)));
-
-      if (protocolSchedule.milestoneFor(OSAKA).isPresent()) {
-        executionEngineApisSupported.add(
-            new EngineGetBlobsV2(
-                consensusEngineServer,
-                protocolContext,
-                protocolSchedule,
-                engineQosTimer,
-                transactionPool,
-                metricsSystem));
-        executionEngineApisSupported.add(
-            new EngineGetBlobsV3(
-                consensusEngineServer,
-                protocolContext,
-                protocolSchedule,
-                engineQosTimer,
-                transactionPool,
-                metricsSystem));
-      }
-
-      if (protocolSchedule.milestoneFor(AMSTERDAM).isPresent()) {
-        executionEngineApisSupported.add(
-            new EngineGetBlobsV4(
-                consensusEngineServer,
-                protocolContext,
-                protocolSchedule,
-                engineQosTimer,
-                transactionPool,
-                metricsSystem));
-      }
+              new EngineGetClientVersionV1(constructorArguments, clientVersion, commit)));
 
       return mapOf(executionEngineApisSupported);
     } else {
@@ -257,6 +223,24 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
         .build(constructorArguments);
   }
 
+  private Collection<? extends JsonRpcMethod> createGetBlobsMethods(
+      final ConstructorArguments constructorArguments) {
+    // V2 and V3 both activate at Osaka and coexist from then on: V2 answers all-or-nothing, V3
+    // answers partially, so neither supersedes the other.
+    return VersionScheduler.startsFromBeginningUntil(EngineGetBlobsV1::new, OSAKA)
+        .thenFrom(OSAKA, EngineGetBlobsV2::new, EngineGetBlobsV3::new)
+        .build(constructorArguments);
+  }
+
+  private Collection<? extends JsonRpcMethod> createGetBlobsV4Methods(
+      final ConstructorArguments constructorArguments) {
+    // engine_getBlobsV4 is not the next version of the V1-V3 chain: it takes different request
+    // parameters and returns BlobCellsAndProofsV1 instead of BlobAndProofV1/V2, so it is its own
+    // standalone series that is simply added from Amsterdam on, leaving V2/V3 valid indefinitely.
+    return VersionScheduler.startsFrom(AMSTERDAM, EngineGetBlobsV4::new)
+        .build(constructorArguments);
+  }
+
   @VisibleForTesting
   static class VersionScheduler {
     final List<MethodVersionBuildData> readyMethods = new ArrayList<>();
@@ -277,6 +261,12 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
         final EngineMethodFactory firstVersion, final HardforkId to) {
       final VersionScheduler vs = new VersionScheduler();
       vs.readyMethods.add(new MethodVersionBuildData(firstVersion, null, to));
+      return vs;
+    }
+
+    static VersionScheduler startsFrom(final HardforkId from, final EngineMethodFactory factory) {
+      final VersionScheduler vs = new VersionScheduler();
+      vs.readyMethods.add(new MethodVersionBuildData(factory, from, null));
       return vs;
     }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
@@ -15,12 +15,16 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECPPrivateKey;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
@@ -34,6 +38,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -44,7 +49,9 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.math.BigInteger;
@@ -54,7 +61,6 @@ import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,8 +90,9 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
   @Mock private TransactionPool transactionPool;
   @Mock private BlockHeader blockHeader;
   @Mock private MergeContext mergeContext;
+  private final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
 
-  private EngineGetBlobsV1 method;
+  private EngineGetBlobsV1<?> method;
 
   private static final Vertx vertx = Vertx.vertx();
 
@@ -99,8 +106,20 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
     when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
     this.method =
         spy(
-            new EngineGetBlobsV1(
-                vertx, protocolContext, protocolSchedule, engineCallListener, transactionPool));
+            new EngineGetBlobsV1<>(
+                new ConstructorArgumentsBuilder()
+                    .protocolSchedule(protocolSchedule)
+                    .protocolContext(protocolContext)
+                    .vertx(vertx)
+                    .engineCallListener(engineCallListener)
+                    .mergeCoordinator(mock(MergeMiningCoordinator.class))
+                    .transactionPool(transactionPool)
+                    .ethPeers(mock(EthPeers.class))
+                    .metricsSystem(metricsSystem)
+                    .maxRequestBlocks(0)
+                    .build(),
+                CANCUN,
+                OSAKA));
   }
 
   @Test
@@ -127,11 +146,11 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
     assertThat(blobAndProofV1s.size()).isEqualTo(versionedHashes.length);
     // for loop to check each blob and proof
     for (int i = 0; i < versionedHashes.length; i++) {
-      assertThat(Bytes.fromHexString(blobAndProofV1s.get(i).getBlob()))
+      assertThat(blobAndProofV1s.get(i).getBlob().getData())
           .isEqualTo(blobsWithCommitments.getBlobProofBundles().get(i).getBlob().getData());
       assertThat(blobsWithCommitments.getBlobProofBundles().get(i).getKzgProof().size())
           .isEqualTo(1);
-      assertThat(Bytes.fromHexString(blobAndProofV1s.get(i).getProof()))
+      assertThat(blobAndProofV1s.get(i).getProof().getData())
           .isEqualTo(
               blobsWithCommitments.getBlobProofBundles().get(i).getKzgProof().getFirst().getData());
     }
@@ -160,11 +179,11 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
     // for loop to check each blob and proof
     for (int i = 0; i < versionedHashesList.size(); i++) {
       if (i != 1) {
-        assertThat(Bytes.fromHexString(blobAndProofV1s.get(i).getBlob()))
+        assertThat(blobAndProofV1s.get(i).getBlob().getData())
             .isEqualTo(blobsWithCommitments.getBlobProofBundles().get(i).getBlob().getData());
         assertThat(blobsWithCommitments.getBlobProofBundles().get(i).getKzgProof().size())
             .isEqualTo(1);
-        assertThat(Bytes.fromHexString(blobAndProofV1s.get(i).getProof()))
+        assertThat(blobAndProofV1s.get(i).getProof().getData())
             .isEqualTo(
                 blobsWithCommitments
                     .getBlobProofBundles()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
@@ -17,22 +17,22 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -43,10 +43,9 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.metrics.ObservableMetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Arrays;
@@ -67,16 +66,12 @@ import org.mockito.quality.Strictness;
 public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
   @Mock private BlockHeader blockHeader;
   @Mock private MutableBlockchain blockchain;
+  @Mock private MergeContext mergeContext;
 
   private TransactionPool transactionPool;
-  private EngineGetBlobsV2 method;
+  private EngineGetBlobsV2<?> method;
 
-  @Mock Counter requestedCounter;
-  @Mock Counter availableCounter;
-  @Mock Counter hitCounter;
-  @Mock Counter missCounter;
-  @Mock ObservableMetricsSystem metricsSystem;
-  @Mock MergeContext mergeContext;
+  private final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
 
   @BeforeEach
   public void setup() {
@@ -88,31 +83,21 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone());
     when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
 
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_requested_total"),
-            anyString()))
-        .thenReturn(requestedCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_available_total"),
-            anyString()))
-        .thenReturn(availableCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC), eq("execution_engine_getblobs_hit_total"), anyString()))
-        .thenReturn(hitCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC), eq("execution_engine_getblobs_miss_total"), anyString()))
-        .thenReturn(missCounter);
-
     method =
-        new EngineGetBlobsV2(
-            mock(Vertx.class),
-            protocolContext,
-            protocolSchedule,
-            mock(EngineCallListener.class),
-            transactionPool,
-            metricsSystem);
+        new EngineGetBlobsV2<>(
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .vertx(mock(Vertx.class))
+                .engineCallListener(mock(EngineCallListener.class))
+                .mergeCoordinator(mock(MergeMiningCoordinator.class))
+                .transactionPool(transactionPool)
+                .ethPeers(mock(EthPeers.class))
+                .metricsSystem(metricsSystem)
+                .maxRequestBlocks(0)
+                .build(),
+            OSAKA,
+            null);
   }
 
   @Test
@@ -126,11 +111,6 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     JsonRpcSuccessResponse response =
         getSuccessResponse(buildRequestContext(bundle.getVersionedHash()));
     assertSingleValidBlob(response, bundle);
-
-    verify(requestedCounter).inc(1);
-    verify(availableCounter).inc(1);
-    verify(hitCounter).inc();
-    verifyNoInteractions(missCounter);
   }
 
   @Test
@@ -139,11 +119,6 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     JsonRpcSuccessResponse response = getSuccessResponse(buildRequestContext(unknown));
     List<BlobAndProofV2> result = extractResult(response);
     assertThat(result).isNull();
-
-    verify(requestedCounter).inc(1);
-    verify(availableCounter).inc(0);
-    verify(missCounter).inc();
-    verifyNoInteractions(hitCounter);
   }
 
   @Test
@@ -157,10 +132,6 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     List<BlobAndProofV2> result = extractResult(response);
 
     assertThat(result).isNull();
-    verify(requestedCounter).inc(3);
-    verify(availableCounter).inc(2);
-    verify(missCounter).inc();
-    verifyNoInteractions(hitCounter);
   }
 
   @Test
@@ -175,10 +146,6 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     List<BlobAndProofV2> result = extractResult(response);
 
     assertThat(result).isNull();
-    verify(requestedCounter).inc(1);
-    verify(availableCounter).inc(0);
-    verify(missCounter).inc();
-    verifyNoInteractions(hitCounter);
   }
 
   @Test
@@ -223,10 +190,6 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     JsonRpcSuccessResponse response =
         getSuccessResponse(buildRequestContext(bundle.getVersionedHash()));
     assertThat(response.getResult()).isNull();
-    verifyNoInteractions(requestedCounter);
-    verifyNoInteractions(availableCounter);
-    verifyNoInteractions(missCounter);
-    verifyNoInteractions(hitCounter);
   }
 
   private BlobProofBundle createBundleAndRegisterToPool() {
@@ -265,11 +228,8 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
     assertThat(result).hasSize(1);
     BlobAndProofV2 blob = result.getFirst();
     assertThat(blob).isNotNull();
-    assertThat(blob.getBlob()).isEqualTo(bundle.getBlob().getData().toHexString());
+    assertThat(blob.getBlob().getData()).isEqualTo(bundle.getBlob().getData());
 
-    List<String> expectedProofs =
-        bundle.getKzgProof().stream().map(p -> p.getData().toHexString()).toList();
-
-    assertThat(blob.getProofs()).containsExactlyElementsOf(expectedProofs);
+    assertThat(blob.getProofs()).containsExactlyElementsOf(bundle.getKzgProof());
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3Test.java
@@ -17,22 +17,21 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -41,10 +40,9 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.metrics.ObservableMetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Arrays;
@@ -65,16 +63,12 @@ import org.mockito.quality.Strictness;
 public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
   @Mock private BlockHeader blockHeader;
   @Mock private MutableBlockchain blockchain;
+  @Mock private MergeContext mergeContext;
 
   private TransactionPool transactionPool;
-  private EngineGetBlobsV3 method;
+  private EngineGetBlobsV3<?> method;
 
-  @Mock Counter requestedCounter;
-  @Mock Counter availableCounter;
-  @Mock Counter partialResponseCounter;
-  @Mock Counter fullResponseCounter;
-  @Mock ObservableMetricsSystem metricsSystem;
-  @Mock MergeContext mergeContext;
+  private final NoOpMetricsSystem metricsSystem = new NoOpMetricsSystem();
 
   @BeforeEach
   public void setup() {
@@ -86,33 +80,21 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone());
     when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
 
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v3_requested_total"),
-            anyString()))
-        .thenReturn(requestedCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v3_available_total"),
-            anyString()))
-        .thenReturn(availableCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v3_partial_total"),
-            anyString()))
-        .thenReturn(partialResponseCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC), eq("execution_engine_getblobs_v3_full_total"), anyString()))
-        .thenReturn(fullResponseCounter);
-
     method =
-        new EngineGetBlobsV3(
-            mock(Vertx.class),
-            protocolContext,
-            protocolSchedule,
-            mock(EngineCallListener.class),
-            transactionPool,
-            metricsSystem);
+        new EngineGetBlobsV3<>(
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .vertx(mock(Vertx.class))
+                .engineCallListener(mock(EngineCallListener.class))
+                .mergeCoordinator(mock(MergeMiningCoordinator.class))
+                .transactionPool(transactionPool)
+                .ethPeers(mock(EthPeers.class))
+                .metricsSystem(metricsSystem)
+                .maxRequestBlocks(0)
+                .build(),
+            OSAKA,
+            null);
   }
 
   @Test
@@ -126,16 +108,10 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     JsonRpcSuccessResponse response =
         getSuccessResponse(buildRequestContext(bundle.getVersionedHash()));
     assertSingleValidBlob(response, bundle);
-
-    verify(requestedCounter).inc(1);
-    verify(availableCounter).inc(1);
-    verify(fullResponseCounter).inc();
-    verifyNoInteractions(partialResponseCounter);
   }
 
   @Test
   public void shouldReturnNullForMissingBlobsInPartialResponse() {
-    // V3 key feature: partial responses with null for missing blobs
     BlobProofBundle bundle1 = createBundleWithBlobType(KZG_CELL_PROOFS);
     VersionedHash unknownHash = new VersionedHash((byte) 1, Hash.ZERO);
     BlobProofBundle bundle3 = createBundleWithBlobType(KZG_CELL_PROOFS);
@@ -152,19 +128,13 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     @SuppressWarnings("unchecked")
     List<BlobAndProofV2> result = (List<BlobAndProofV2>) response.getResult();
     assertThat(result).hasSize(3);
-    assertThat(result.get(0)).isNotNull(); // first blob found
-    assertThat(result.get(1)).isNull(); // middle blob missing - KEY V3 BEHAVIOR
-    assertThat(result.get(2)).isNotNull(); // third blob found
-
-    verify(requestedCounter).inc(3);
-    verify(availableCounter).inc(2); // only 2 available
-    verify(partialResponseCounter).inc(); // partial response
-    verifyNoInteractions(fullResponseCounter);
+    assertThat(result.get(0)).isNotNull();
+    assertThat(result.get(1)).isNull();
+    assertThat(result.get(2)).isNotNull();
   }
 
   @Test
   public void shouldReturnNullForKzgProofBlobType() {
-    // V3 rejects KZG_PROOF like V2 does
     BlobProofBundle bundle = createBundleWithBlobType(KZG_PROOF);
     JsonRpcSuccessResponse response =
         getSuccessResponse(buildRequestContext(bundle.getVersionedHash()));
@@ -172,12 +142,7 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     @SuppressWarnings("unchecked")
     List<BlobAndProofV2> result = (List<BlobAndProofV2>) response.getResult();
     assertThat(result).hasSize(1);
-    assertThat(result.getFirst()).isNull(); // KZG_PROOF not supported
-
-    verify(requestedCounter).inc(1);
-    verify(availableCounter).inc(0); // 0 available due to unsupported type
-    verify(partialResponseCounter).inc(); // partial response (0 out of 1)
-    verifyNoInteractions(fullResponseCounter);
+    assertThat(result.getFirst()).isNull();
   }
 
   @Test
@@ -196,7 +161,6 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
                 "0x0400000000000000000000000000000000000000000000000000000000000000"));
     BlobProofBundle bundle5 = createBundleWithBlobType(KZG_CELL_PROOFS);
 
-    // Manually setup mocks to override the automatic setup in createBundleWithBlobType
     when(transactionPool.getBlobProofBundle(bundle1.getVersionedHash())).thenReturn(bundle1);
     when(transactionPool.getBlobProofBundle(bundle2.getVersionedHash())).thenReturn(bundle2);
     when(transactionPool.getBlobProofBundle(missing1)).thenReturn(null);
@@ -215,18 +179,16 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     @SuppressWarnings("unchecked")
     List<BlobAndProofV2> result = (List<BlobAndProofV2>) response.getResult();
     assertThat(result).hasSize(5);
-    assertThat(result.get(0)).isNotNull(); // bundle1
-    assertThat(result.get(1)).isNotNull(); // bundle2
-    assertThat(result.get(2)).isNull(); // missing1
-    assertThat(result.get(3)).isNull(); // missing2
-    assertThat(result.get(4)).isNotNull(); // bundle5
-
-    verify(partialResponseCounter).inc();
+    assertThat(result.get(0)).isNotNull();
+    assertThat(result.get(1)).isNotNull();
+    assertThat(result.get(2)).isNull();
+    assertThat(result.get(3)).isNull();
+    assertThat(result.get(4)).isNotNull();
   }
 
   @Test
   public void shouldReturnErrorForTooLargeRequest() {
-    VersionedHash[] tooManyHashes = new VersionedHash[129]; // > 128 limit
+    VersionedHash[] tooManyHashes = new VersionedHash[129];
     Arrays.fill(tooManyHashes, new VersionedHash((byte) 1, Hash.ZERO));
 
     JsonRpcResponse response = method.syncResponse(buildRequestContext(tooManyHashes));
@@ -236,26 +198,39 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
   }
 
   @Test
-  public void shouldReturnNullWhenSyncing() {
+  void shouldFailWhenOsakaNotActive() {
+    when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone() - 1);
+    var response = method.syncResponse(buildRequestContext());
+    assertThat(fromErrorResp(response).getCode())
+        .isEqualTo(RpcErrorType.UNSUPPORTED_FORK.getCode());
+  }
+
+  @Test
+  void shouldSucceedWhenOsakaActive() {
+    when(blockHeader.getTimestamp()).thenReturn(osakaHardfork.milestone());
+    var response = method.syncResponse(buildRequestContext());
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
+  }
+
+  @Test
+  public void shouldReturnNullsWhenSyncing() {
     when(mergeContext.isSyncing()).thenReturn(true);
     BlobProofBundle bundle = createBundleWithBlobType(KZG_CELL_PROOFS);
 
     JsonRpcSuccessResponse response =
         getSuccessResponse(buildRequestContext(bundle.getVersionedHash()));
 
-    assertThat(response.getResult()).isNull();
-    // No metrics should be incremented when syncing
-    verifyNoInteractions(
-        requestedCounter, availableCounter, partialResponseCounter, fullResponseCounter);
+    @SuppressWarnings("unchecked")
+    List<BlobAndProofV2> result = (List<BlobAndProofV2>) response.getResult();
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst()).isNull();
   }
 
   @Test
   public void shouldSupportMinimum128Hashes() {
-    // Test capacity requirement from spec
     VersionedHash[] maxHashes = new VersionedHash[128];
     Arrays.fill(maxHashes, new VersionedHash((byte) 1, Hash.ZERO));
 
-    // Should not error for exactly 128 hashes
     JsonRpcResponse response = method.syncResponse(buildRequestContext(maxHashes));
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
   }
@@ -286,7 +261,7 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
     List<BlobAndProofV2> result = (List<BlobAndProofV2>) response.getResult();
     assertThat(result).hasSize(1);
     assertThat(result.getFirst()).isNotNull();
-    assertThat(result.getFirst().getBlob()).isEqualTo(expected.getBlob().getData().toHexString());
+    assertThat(result.getFirst().getBlob().getData()).isEqualTo(expected.getBlob().getData());
     assertThat(result.getFirst().getProofs()).hasSize(expected.getKzgProof().size());
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -35,6 +37,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -44,6 +47,7 @@ import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.core.kzg.CKZG4844Helper;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
@@ -113,12 +117,19 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     method =
         new EngineGetBlobsV4(
-            mock(Vertx.class),
-            protocolContext,
-            protocolSchedule,
-            mock(EngineCallListener.class),
-            transactionPool,
-            metricsSystem);
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .vertx(mock(Vertx.class))
+                .engineCallListener(mock(EngineCallListener.class))
+                .mergeCoordinator(mock(MergeMiningCoordinator.class))
+                .transactionPool(transactionPool)
+                .ethPeers(mock(EthPeers.class))
+                .metricsSystem(metricsSystem)
+                .maxRequestBlocks(0)
+                .build(),
+            AMSTERDAM,
+            null);
   }
 
   @Test
@@ -243,6 +254,23 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     assertThat(exception).isNotNull();
     assertThat(exception.getRpcErrorType()).isEqualTo(RpcErrorType.INVALID_INDICES_BITARRAY_PARAMS);
+  }
+
+  @Test
+  void shouldFailWhenAmsterdamNotActive() {
+    when(blockHeader.getTimestamp()).thenReturn(amsterdamHardfork.milestone() - 1);
+    JsonRpcResponse response =
+        method.syncResponse(buildRequestContext(FULL_BITARRAY, new VersionedHash[0]));
+    assertThat(fromErrorResp(response).getCode())
+        .isEqualTo(RpcErrorType.UNSUPPORTED_FORK.getCode());
+  }
+
+  @Test
+  void shouldSucceedWhenAmsterdamActive() {
+    when(blockHeader.getTimestamp()).thenReturn(amsterdamHardfork.milestone());
+    JsonRpcResponse response =
+        method.syncResponse(buildRequestContext(FULL_BITARRAY, new VersionedHash[0]));
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
@@ -52,6 +52,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Arrays;
@@ -79,8 +80,19 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
   private TransactionPool transactionPool;
   private EngineGetBlobsV4 method;
 
+  // GetBlobsMetrics calls labelledMetric.labels(version) once per inc(...) call, so each
+  // LabelledMetric mock must resolve .labels(...) to a fixed Counter mock: chained
+  // verify(labelledMetric).labels(x).inc(y) does not reliably resolve the intermediate
+  // labels(x) return value through Mockito's stub for a plain (non deep-stub) mock, so the
+  // production code's actual Counter instance is captured here and verified against directly.
+  @Mock LabelledMetric<Counter> requestedLabelledCounter;
+  @Mock LabelledMetric<Counter> availableLabelledCounter;
+  @Mock LabelledMetric<Counter> missingLabelledCounter;
+  @Mock LabelledMetric<Counter> partialResponseLabelledCounter;
+  @Mock LabelledMetric<Counter> fullResponseLabelledCounter;
   @Mock Counter requestedCounter;
   @Mock Counter availableCounter;
+  @Mock Counter missingCounter;
   @Mock Counter partialResponseCounter;
   @Mock Counter fullResponseCounter;
   @Mock ObservableMetricsSystem metricsSystem;
@@ -96,24 +108,42 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
     when(blockHeader.getTimestamp()).thenReturn(amsterdamHardfork.milestone());
     when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
 
-    when(metricsSystem.createCounter(
+    when(metricsSystem.createLabelledCounter(
             eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v4_requested_total"),
-            anyString()))
-        .thenReturn(requestedCounter);
-    when(metricsSystem.createCounter(
+            eq("execution_engine_getblobs_requested_total"),
+            anyString(),
+            eq("version")))
+        .thenReturn(requestedLabelledCounter);
+    when(metricsSystem.createLabelledCounter(
             eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v4_available_total"),
-            anyString()))
-        .thenReturn(availableCounter);
-    when(metricsSystem.createCounter(
+            eq("execution_engine_getblobs_available_total"),
+            anyString(),
+            eq("version")))
+        .thenReturn(availableLabelledCounter);
+    when(metricsSystem.createLabelledCounter(
             eq(BesuMetricCategory.RPC),
-            eq("execution_engine_getblobs_v4_partial_total"),
-            anyString()))
-        .thenReturn(partialResponseCounter);
-    when(metricsSystem.createCounter(
-            eq(BesuMetricCategory.RPC), eq("execution_engine_getblobs_v4_full_total"), anyString()))
-        .thenReturn(fullResponseCounter);
+            eq("execution_engine_getblobs_missing_total"),
+            anyString(),
+            eq("version")))
+        .thenReturn(missingLabelledCounter);
+    when(metricsSystem.createLabelledCounter(
+            eq(BesuMetricCategory.RPC),
+            eq("execution_engine_getblobs_partial_total"),
+            anyString(),
+            eq("version")))
+        .thenReturn(partialResponseLabelledCounter);
+    when(metricsSystem.createLabelledCounter(
+            eq(BesuMetricCategory.RPC),
+            eq("execution_engine_getblobs_full_total"),
+            anyString(),
+            eq("version")))
+        .thenReturn(fullResponseLabelledCounter);
+
+    when(requestedLabelledCounter.labels(anyString())).thenReturn(requestedCounter);
+    when(availableLabelledCounter.labels(anyString())).thenReturn(availableCounter);
+    when(missingLabelledCounter.labels(anyString())).thenReturn(missingCounter);
+    when(partialResponseLabelledCounter.labels(anyString())).thenReturn(partialResponseCounter);
+    when(fullResponseLabelledCounter.labels(anyString())).thenReturn(fullResponseCounter);
 
     method =
         new EngineGetBlobsV4(
@@ -151,6 +181,7 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     verify(requestedCounter).inc(1);
     verify(availableCounter).inc(1);
+    verify(missingCounter).inc(0);
     verify(fullResponseCounter).inc();
     verifyNoInteractions(partialResponseCounter);
   }
@@ -175,13 +206,11 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     Bytes blobCells = bundle.getBlobCellsBytes().orElseThrow();
     int cellSize = blobCells.size() / CKZG4844Helper.CELL_PROOFS_PER_BLOB;
-    String expectedCell0 = blobCells.slice(0, cellSize).toHexString();
-    String expectedCell127 = blobCells.slice(127 * cellSize, cellSize).toHexString();
+    Bytes expectedCell0 = blobCells.slice(0, cellSize);
+    Bytes expectedCell127 = blobCells.slice(127 * cellSize, cellSize);
     assertThat(result.getFirst().getBlobCells()).containsExactly(expectedCell0, expectedCell127);
     assertThat(result.getFirst().getProofs())
-        .containsExactly(
-            bundle.getKzgProof().get(0).getData().toHexString(),
-            bundle.getKzgProof().get(127).getData().toHexString());
+        .containsExactly(bundle.getKzgProof().get(0), bundle.getKzgProof().get(127));
   }
 
   @Test
@@ -211,6 +240,7 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     verify(requestedCounter).inc(3);
     verify(availableCounter).inc(2);
+    verify(missingCounter).inc(1);
     verify(partialResponseCounter).inc();
     verifyNoInteractions(fullResponseCounter);
   }
@@ -228,6 +258,7 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     verify(requestedCounter).inc(1);
     verify(availableCounter).inc(0);
+    verify(missingCounter).inc(1);
     verify(partialResponseCounter).inc();
     verifyNoInteractions(fullResponseCounter);
   }
@@ -283,7 +314,11 @@ public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
 
     assertThat(response.getResult()).isNull();
     verifyNoInteractions(
-        requestedCounter, availableCounter, partialResponseCounter, fullResponseCounter);
+        requestedCounter,
+        availableCounter,
+        missingCounter,
+        partialResponseCounter,
+        fullResponseCounter);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
@@ -152,6 +152,30 @@ class VersionSchedulerTest {
   }
 
   @Test
+  void startsFromBuildsTheVersionGatedOnItsOwnFork() {
+    when(protocolSchedule.milestoneFor(AMSTERDAM)).thenReturn(Optional.of(0L));
+
+    final List<ExecutionEngineJsonRpcMethod> builtMethods =
+        List.copyOf(VersionScheduler.startsFrom(AMSTERDAM, v1).build(constructorArguments));
+
+    assertThat(builtMethods).containsExactly(v1.instance);
+    assertThat(v1.invocations).isOne();
+    assertThat(v1.constructorArguments).isSameAs(constructorArguments);
+    v1.assertForkWindow(AMSTERDAM, null);
+  }
+
+  @Test
+  void startsFromSkipsTheVersionWhenItsForkIsNotScheduled() {
+    when(protocolSchedule.milestoneFor(AMSTERDAM)).thenReturn(Optional.empty());
+
+    final List<ExecutionEngineJsonRpcMethod> builtMethods =
+        List.copyOf(VersionScheduler.startsFrom(AMSTERDAM, v1).build(constructorArguments));
+
+    assertThat(builtMethods).isEmpty();
+    assertThat(v1.invocations).isZero();
+  }
+
+  @Test
   void alwaysActiveCanBeExtendedWithAForkGatedVersion() {
     when(protocolSchedule.milestoneFor(AMSTERDAM)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## Summary

This is PR8 — the **last** PR in the Engine API refactor stack — based directly on `main` (PR7's
accessory-methods migration is already merged, #11010; `main` also already includes an unrelated
upstream EIP-8070 commit that added `engine_getBlobsV4` and a `transactionPool` field to
`ConstructorArguments`). It migrates `engine_getBlobsV*`, the only series left unmigrated:

- `engine_getBlobsV1-V3` move onto the established sealed hierarchy
  (`EngineGetBlobsV1 permits EngineGetBlobsV2 permits EngineGetBlobsV3`), with `V2`/`V3` both
  activating at Osaka and coexisting indefinitely — a `.thenFrom(OSAKA, V2::new, V3::new)` varargs
  window, not a supersedes-chain (same shape as `engine_getPayloadBodiesBy*`'s two series). Their
  result classes `BlobAndProofV1`/`V2` move onto the same sealed pattern used by the other migrated
  result hierarchies.
- **`engine_getBlobsV4` is deliberately *not* chained onto `EngineGetBlobsV3`.** Per the
  [Amsterdam spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_getblobsv4)
  it takes a different request shape (adds an `indices_bitarray` parameter) and returns
  `BlobCellsAndProofsV1` (partial cells + per-cell proofs) instead of `BlobAndProofV1`/`V2` (full
  blobs) — and it doesn't extend `EngineGetBlobsV3` on `main` today either. Chaining it via
  `.thenFrom(AMSTERDAM, ...)` onto the V1-V3 scheduler would have wrongly capped V2/V3's validity
  window at Amsterdam (they remain valid indefinitely; V4 is an *addition*, not a replacement).
  It's migrated as its own single-version series — a constructor-shape change only, no logic
  change — and registered via a new `VersionScheduler.startsFrom(HardforkId, EngineMethodFactory)`
  entry point: for a brand-new series with no earlier version, gated from a fork onward, registered
  as its own independent chain. Documented in the README alongside `alwaysActive(...)`.
- Renames `EngineGetBlobsV1`/`V2`'s `isSupportedBlob(...)` to `isUnsupportedBlob(...)`: the
  method's boolean was already used to mean "skip this blob as unsupported" at every call site, the
  old name just said the opposite of what it checked.

## Scope

This is the last series in the migration stack. The `TRANSITIONAL SHIM` constructors on
`ExecutionEngineJsonRpcMethod` and the `Optional<Long>` overload on `ForkSupportHelper` have no
remaining callers after this PR and are left in place for a follow-up cleanup PR that removes them
(not part of this PR, to keep the diff reviewable).

No user-visible behavior changes to the already-shipped `engine_getBlobsV1-V4` responses beyond
what the pre-existing (unmerged) `engine_getBlobsV1-V3` refactor work already introduced — see the
metrics-naming note below. No CHANGELOG entry, matching this stack's precedent for internal
restructuring.

**Metrics note**: `engine_getBlobsV*` move from ad hoc/missing counters to a shared
`execution_engine_getblobs_{requested,available,missing,unsupported,full,partial}_total` set of
`LabelledMetric<Counter>`s labelled by `version`.

## Test plan

Hive tests are passing and performance is fine

- [x] `./gradlew :ethereum:api:compileJava :ethereum:api:compileTestJava` — clean
- [x] `./gradlew :ethereum:api:test --tests "*.engine.EngineGetBlobs*" --tests "*.methods.VersionSchedulerTest"` — pass
- [x] `./gradlew :ethereum:api:test` (full module suite) — pass
- [x] `./gradlew compileJava compileTestJava :acceptance-tests:tests:compileAcceptanceTestJava spotlessJavaCheck` (whole project) — clean
