### PR TITLE
include account-only accesses in eth_createAccessList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- `eth_createAccessList` now includes accounts accessed via `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`, `SELFDESTRUCT` and call targets, matching other clients; previously accounts without storage accesses were omitted. [#11134](https://github.com/besu-eth/besu/issues/11134)
 - `debug_getRawReceipts` now accepts a block hash as well as a block number or tag. [#11156](https://github.com/besu-eth/besu/pull/11156)
 - Support dynamic reorg tracking for transaction receipt logs in `eth_getTransactionReceipt` and `eth_getBlockReceipts` by populating the `removed` field. [#11076](https://github.com/besu-eth/besu/pull/11076)
 - `testing_buildBlockV1` now uses the genesis gas limit as the effective target when no `targetGasLimit` is specified, so the gas limit calculator applies a one-step decrement rather than holding the parent value. [#11166](https://github.com/besu-eth/besu/pull/11166)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
@@ -15,28 +15,37 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.CreateAccessListResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
 import org.hyperledger.besu.evm.tracing.AccessListOperationTracer;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 public class EthCreateAccessList extends AbstractEstimateGas {
 
+  private final ProtocolSchedule protocolSchedule;
+
   public EthCreateAccessList(
-      final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
+      final BlockchainQueries blockchainQueries,
+      final TransactionSimulator transactionSimulator,
+      final ProtocolSchedule protocolSchedule) {
     super(blockchainQueries, transactionSimulator);
+    this.protocolSchedule = protocolSchedule;
   }
 
   @Override
@@ -53,7 +62,8 @@ public class EthCreateAccessList extends AbstractEstimateGas {
       final long gasLimitUpperBound,
       final long minTxCost) {
 
-    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    final Set<Address> excludedAddresses = excludedAddresses(callParams, blockHeader);
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create(excludedAddresses);
     if (attemptOptimisticSimulationWithMinimumBlockGasUsed(
         minTxCost, callParams, simulationFunction, tracer)) {
       return new CreateAccessListResult(tracer.getAccessList(), minTxCost);
@@ -66,11 +76,28 @@ public class EthCreateAccessList extends AbstractEstimateGas {
     if (shouldProcessWithAccessListOverride(callParams, tracer)) {
       final AccessListSimulatorResult result =
           processTransactionWithAccessListOverride(
-              callParams, gasLimitUpperBound, tracer.getAccessList(), simulationFunction);
+              callParams,
+              gasLimitUpperBound,
+              tracer.getAccessList(),
+              simulationFunction,
+              excludedAddresses);
       return createResponse(requestContext, result);
     } else {
       return createResponse(requestContext, new AccessListSimulatorResult(firstResult, tracer));
     }
+  }
+
+  private Set<Address> excludedAddresses(
+      final CallParameter callParams, final ProcessableBlockHeader blockHeader) {
+    final Set<Address> excluded = new HashSet<>();
+    callParams.getSender().ifPresent(excluded::add);
+    callParams.getTo().ifPresent(excluded::add);
+    excluded.addAll(
+        protocolSchedule
+            .getByBlockHeader(blockHeader)
+            .getPrecompileContractRegistry()
+            .getPrecompileAddresses());
+    return excluded;
   }
 
   private Object createResponse(
@@ -112,9 +139,10 @@ public class EthCreateAccessList extends AbstractEstimateGas {
       final CallParameter callParameter,
       final long gasLimit,
       final List<AccessListEntry> accessList,
-      final TransactionSimulationFunction simulationFunction) {
+      final TransactionSimulationFunction simulationFunction,
+      final Set<Address> excludedAddresses) {
 
-    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create(excludedAddresses);
     final CallParameter modifiedCallParameter =
         overrideAccessList(callParameter, gasLimit, accessList);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -173,7 +173,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthSendRawTransaction(transactionPool),
             new EthSendTransaction(),
             new EthEstimateGas(blockchainQueries, transactionSimulator, apiConfiguration),
-            new EthCreateAccessList(blockchainQueries, transactionSimulator),
+            new EthCreateAccessList(blockchainQueries, transactionSimulator, protocolSchedule),
             new EthCapabilities(blockchainQueries),
             new EthConfig(blockchainQueries, protocolSchedule, genesisConfigOptions),
             new EthProtocolVersion(supportedCapabilities),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -36,16 +36,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.CreateAccessLi
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.tracing.AccessListOperationTracer;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -77,6 +81,9 @@ public class EthCreateAccessListTest {
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private TransactionSimulator transactionSimulator;
   @Mock private WorldStateArchive worldStateArchive;
+  @Mock private ProtocolSchedule protocolSchedule;
+  @Mock private ProtocolSpec protocolSpec;
+  @Mock private PrecompileContractRegistry precompileContractRegistry;
 
   @BeforeEach
   public void setUp() {
@@ -101,8 +108,11 @@ public class EthCreateAccessListTest {
     when(pendingBlockHeader.getNumber()).thenReturn(3L);
     when(transactionSimulator.simulatePendingBlockHeader()).thenReturn(pendingBlockHeader);
     when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(true);
+    when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
+    when(protocolSpec.getPrecompileContractRegistry()).thenReturn(precompileContractRegistry);
+    when(precompileContractRegistry.getPrecompileAddresses()).thenReturn(Set.of());
 
-    method = new EthCreateAccessList(blockchainQueries, transactionSimulator);
+    method = new EthCreateAccessList(blockchainQueries, transactionSimulator, protocolSchedule);
   }
 
   @Test
@@ -387,6 +397,7 @@ public class EthCreateAccessListTest {
     try (final MockedStatic<AccessListOperationTracer> tracerMockedStatic =
         Mockito.mockStatic(AccessListOperationTracer.class)) {
       tracerMockedStatic.when(AccessListOperationTracer::create).thenReturn(tracer);
+      tracerMockedStatic.when(() -> AccessListOperationTracer.create(any())).thenReturn(tracer);
       return method.response(request);
     }
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracer.java
@@ -17,10 +17,13 @@ package org.hyperledger.besu.evm.tracing;
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.Table;
 import org.apache.tuweni.bytes.Bytes32;
@@ -28,11 +31,50 @@ import org.apache.tuweni.bytes.Bytes32;
 /** The Access List Operation Tracer. */
 public class AccessListOperationTracer implements OperationTracer {
 
+  private static final int BALANCE_OPCODE = 0x31;
+  private static final int EXTCODESIZE_OPCODE = 0x3B;
+  private static final int EXTCODECOPY_OPCODE = 0x3C;
+  private static final int EXTCODEHASH_OPCODE = 0x3F;
+  private static final int SELFDESTRUCT_OPCODE = 0xFF;
+  private static final int CALL_OPCODE = 0xF1;
+  private static final int CALLCODE_OPCODE = 0xF2;
+  private static final int DELEGATECALL_OPCODE = 0xF4;
+  private static final int STATICCALL_OPCODE = 0xFA;
+
+  private final Set<Address> excludedAddresses;
+  private final Set<Address> touchedAddresses = new TreeSet<>();
+
   private Table<Address, Bytes32, Boolean> warmedUpStorage;
 
-  /** Default constructor. */
-  private AccessListOperationTracer() {
-    super();
+  private AccessListOperationTracer(final Set<Address> excludedAddresses) {
+    this.excludedAddresses = excludedAddresses;
+  }
+
+  @Override
+  public void tracePreExecution(final MessageFrame frame) {
+    switch (frame.getCurrentOperation().getOpcode()) {
+      case BALANCE_OPCODE,
+          EXTCODESIZE_OPCODE,
+          EXTCODECOPY_OPCODE,
+          EXTCODEHASH_OPCODE,
+          SELFDESTRUCT_OPCODE -> {
+        if (frame.stackSize() >= 1) {
+          touch(Words.toAddress(frame.getStackItem(0)));
+        }
+      }
+      case CALL_OPCODE, CALLCODE_OPCODE, DELEGATECALL_OPCODE, STATICCALL_OPCODE -> {
+        if (frame.stackSize() >= 5) {
+          touch(Words.toAddress(frame.getStackItem(1)));
+        }
+      }
+      default -> {}
+    }
+  }
+
+  private void touch(final Address address) {
+    if (!excludedAddresses.contains(address)) {
+      touchedAddresses.add(address);
+    }
   }
 
   @Override
@@ -46,8 +88,8 @@ public class AccessListOperationTracer implements OperationTracer {
    * @return the access list
    */
   public List<AccessListEntry> getAccessList() {
+    final List<AccessListEntry> list = new ArrayList<>();
     if (warmedUpStorage != null && !warmedUpStorage.isEmpty()) {
-      final List<AccessListEntry> list = new ArrayList<>(warmedUpStorage.size());
       warmedUpStorage
           .rowMap()
           .forEach(
@@ -56,9 +98,13 @@ public class AccessListOperationTracer implements OperationTracer {
                       new AccessListEntry(
                           address,
                           new ArrayList<>(storageKeys.keySet().stream().sorted().toList()))));
-      return list;
     }
-    return List.of();
+    for (final Address address : touchedAddresses) {
+      if (warmedUpStorage == null || !warmedUpStorage.containsRow(address)) {
+        list.add(new AccessListEntry(address, List.of()));
+      }
+    }
+    return list;
   }
 
   /**
@@ -67,6 +113,16 @@ public class AccessListOperationTracer implements OperationTracer {
    * @return the AccessListOperationTracer
    */
   public static AccessListOperationTracer create() {
-    return new AccessListOperationTracer();
+    return new AccessListOperationTracer(Set.of());
+  }
+
+  /**
+   * Create an AccessListOperationTracer that omits the given addresses from account-only accesses.
+   *
+   * @param excludedAddresses addresses never added by account-touching opcodes
+   * @return the AccessListOperationTracer
+   */
+  public static AccessListOperationTracer create(final Set<Address> excludedAddresses) {
+    return new AccessListOperationTracer(excludedAddresses);
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracerTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.AccessListEntry;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AccessListOperationTracerTest {
+
+  private static final Address TARGET =
+      Address.fromHexString("0x00000000000000000000000000000000deadbe02");
+  private static final Address STORAGE_ADDRESS =
+      Address.fromHexString("0x000000000000000000000000000000000000aaaa");
+
+  private MessageFrame frame;
+  private Table<Address, Bytes32, Boolean> warmedUpStorage;
+
+  @BeforeEach
+  void setUp() {
+    frame = mock(MessageFrame.class);
+    warmedUpStorage = HashBasedTable.create();
+    when(frame.getWarmedUpStorage()).thenReturn(warmedUpStorage);
+  }
+
+  private void mockOperation(final int opcode, final int stackSize) {
+    final Operation operation = mock(Operation.class);
+    when(operation.getOpcode()).thenReturn(opcode);
+    when(frame.getCurrentOperation()).thenReturn(operation);
+    when(frame.stackSize()).thenReturn(stackSize);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0x31, 0x3B, 0x3C, 0x3F, 0xFF})
+  void accountTouchingOpcodeTargetIsIncludedWithEmptyStorageKeys(final int opcode) {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    mockOperation(opcode, 1);
+    when(frame.getStackItem(0)).thenReturn(Bytes32.leftPad(TARGET.getBytes()));
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).containsExactly(new AccessListEntry(TARGET, List.of()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xF1, 0xF2, 0xF4, 0xFA})
+  void callOpcodeTargetIsIncludedWithEmptyStorageKeys(final int opcode) {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    mockOperation(opcode, 7);
+    when(frame.getStackItem(1)).thenReturn(Bytes32.leftPad(TARGET.getBytes()));
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).containsExactly(new AccessListEntry(TARGET, List.of()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0xF1, 0xF2, 0xF4, 0xFA})
+  void callOpcodeWithUnderflowingStackIsNotCaptured(final int opcode) {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    mockOperation(opcode, 4);
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).isEmpty();
+  }
+
+  @Test
+  void accountTouchingOpcodeWithEmptyStackIsNotCaptured() {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    mockOperation(0x31, 0);
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).isEmpty();
+  }
+
+  @Test
+  void nonCapturingOpcodeAddsNothing() {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    mockOperation(0x01, 2);
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).isEmpty();
+  }
+
+  @Test
+  void excludedAddressIsNotIncluded() {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create(Set.of(TARGET));
+    mockOperation(0x31, 1);
+    when(frame.getStackItem(0)).thenReturn(Bytes32.leftPad(TARGET.getBytes()));
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).isEmpty();
+  }
+
+  @Test
+  void touchedAddressWithWarmedStorageIsListedOnceWithItsKeys() {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    final Bytes32 slot = Bytes32.leftPad(Bytes32.fromHexString("0x01"));
+    warmedUpStorage.put(TARGET, slot, Boolean.TRUE);
+    mockOperation(0x31, 1);
+    when(frame.getStackItem(0)).thenReturn(Bytes32.leftPad(TARGET.getBytes()));
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList()).containsExactly(new AccessListEntry(TARGET, List.of(slot)));
+  }
+
+  @Test
+  void storageOnlyEntriesAreUnchanged() {
+    final AccessListOperationTracer tracer = AccessListOperationTracer.create();
+    final Bytes32 slot = Bytes32.leftPad(Bytes32.fromHexString("0x02"));
+    warmedUpStorage.put(STORAGE_ADDRESS, slot, Boolean.TRUE);
+    mockOperation(0x54, 1);
+    when(frame.getStackItem(0)).thenReturn(slot);
+
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, mock(OperationResult.class));
+
+    assertThat(tracer.getAccessList())
+        .containsExactly(new AccessListEntry(STORAGE_ADDRESS, List.of(slot)));
+  }
+}


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
 Our access list tracer only picked up accounts when their storage was touched, so a transaction that read an account with BALANCE or EXTCODESIZE came back with an empty access list. I updated the tracer to also capture accounts touched by account level opcodes and call targets, and the RPC layer now filters out the sender, the recipient and precompiles to match what geth and the other clients return. Fixes #11134.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


