### PR TITLE
Treat engine API uint64 timestamps as unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Move to a new BFT round and select a new proposer for a block if transactions arrive at a non-proposing node after blockperiodseconds but before emptyblockperiodseconds [#11031](https://github.com/besu-eth/besu/pull/11031) 
 - Complete QBFT votes in a reasonable time when `empyblockperiodseconds` is set by treating QBFT votes as "non empty blocks" [#11111](https://github.com/besu-eth/besu/pull/11111)
 - `engine_newPayload` no longer briefly answers `SYNCING` after startup on a peerless node: `PostMergeContext.isSyncing()` now treats an undetermined terminal-difficulty flag as "reached", matching `SyncState.isInSync()`. [#11168](https://github.com/besu-eth/besu/pull/11168)
+- Engine API timestamps above `2^63-1` are no longer treated as negative: `engine_newPayload` rejected such a payload's withdrawals as pre-Shanghai, `engine_forkchoiceUpdated` failed to parse the payload attributes timestamp at all, and post-merge header validation saw the block as older than its parent.
 
 ### Additions and Improvements
 - Add JMH `GasProfiler` that emits `mgas_per_s` as a secondary metric on each benchmark iteration using Besu's own `GasCalculator`. Enable with `-PgasProfiler=true`; override the EVM fork with `-PgasProfilerFork=<fork>` (defaults to Osaka). [#10807](https://github.com/besu-eth/besu/pull/10807)

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampRule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampRule.java
@@ -38,7 +38,9 @@ public class IncrementalTimestampRule extends MergeConsensusRule {
         && !isTerminalProofOfWorkBlock(header, protocolContext)) {
       final long blockTimestamp = header.getTimestamp();
       final long parentTimestamp = parent.getTimestamp();
-      final boolean isMoreRecent = blockTimestamp > parentTimestamp;
+      // Both timestamps are uint64 carried in longs, so they must be compared unsigned: a value
+      // above Long.MAX_VALUE is negative and would otherwise look older than its parent.
+      final boolean isMoreRecent = Long.compareUnsigned(blockTimestamp, parentTimestamp) > 0;
 
       LOG.trace(
           "Is block timestamp more recent that its parent? {}, [block timestamp {}, parent timestamp {}]",

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampValidationTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampValidationTest.java
@@ -75,6 +75,19 @@ public class IncrementalTimestampValidationTest {
   }
 
   @Test
+  public void validWhenTimestampAboveLongMaxValueIsMoreRecentThanParent() {
+    final IncrementalTimestampRule rule = new IncrementalTimestampRule();
+    final BlockHeader parentHeader = mock(BlockHeader.class);
+    when(parentHeader.getTimestamp()).thenReturn(System.currentTimeMillis());
+    final BlockHeader validHeader = mock(BlockHeader.class);
+    when(validHeader.getNumber()).thenReturn(1337L);
+    // uint64 0xffffffffffffffff, carried as -1
+    when(validHeader.getTimestamp()).thenReturn(-1L);
+
+    assertThat(rule.validate(validHeader, parentHeader, protocolContext)).isTrue();
+  }
+
+  @Test
   public void alwaysValidWhenTTDNotReached() {
     when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(2L));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -325,7 +325,9 @@ public sealed class EngineForkchoiceUpdatedV1<
       final BlockHeader newHead, final PA attrs) {
     // 8.i. Verify that payloadAttributes.timestamp is greater than timestamp of a block referenced
     // by forkchoiceState.headBlockHash and return -38003: Invalid payload attributes on failure.
-    if (attrs.getTimestamp() <= newHead.getTimestamp()) {
+    // Both timestamps are uint64 carried in longs, so they must be compared unsigned: a value above
+    // Long.MAX_VALUE is negative and would otherwise look older than the head block.
+    if (Long.compareUnsigned(attrs.getTimestamp(), newHead.getTimestamp()) <= 0) {
       return ValidationResult.invalid(
           getInvalidPayloadAttributesError(),
           "Payload attributes timestamp %d not greater than head block timestamp %d"

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -87,7 +87,10 @@ public sealed class EngineForkchoiceUpdatedV2<
     // Shanghai timestamp,
     // PayloadAttributesV2 MUST be used to build a payload with the timestamp value greater or equal
     // to the Shanghai timestamp,
-    if (shanghaiTimestamp.isEmpty() || attrs.getTimestamp() < shanghaiTimestamp.get()) {
+    // The timestamp is a uint64 carried in a long, so it must be compared unsigned: a value above
+    // Long.MAX_VALUE is negative and would otherwise look pre-Shanghai.
+    if (shanghaiTimestamp.isEmpty()
+        || Long.compareUnsigned(attrs.getTimestamp(), shanghaiTimestamp.get()) < 0) {
       if (attrs.getWithdrawals() != null) {
         return ValidationResult.invalid(
             RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
@@ -68,7 +68,10 @@ public sealed class EngineGetPayloadV2 extends EngineGetPayloadV1 permits Engine
     // ExecutionPayloadV2 MUST be returned if the payload timestamp is greater or equal to the
     // Shanghai timestamp
     final long timestamp = block.getHeader().getTimestamp();
-    if (shanghaiTimestamp.isEmpty() || timestamp < shanghaiTimestamp.get()) {
+    // The timestamp is a uint64 carried in a long, so it must be compared unsigned: a payload built
+    // for a timestamp above Long.MAX_VALUE is negative and would otherwise look pre-Shanghai.
+    if (shanghaiTimestamp.isEmpty()
+        || Long.compareUnsigned(timestamp, shanghaiTimestamp.get()) < 0) {
       if (blockBody.getWithdrawals().isPresent()) {
         throw new IllegalStateException(
             "Withdrawals should not be present before Shanghai hardfork");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
@@ -91,7 +91,9 @@ public sealed class EngineNewPayloadV2<
     // Shanghai timestamp,
     // Client software MUST return -32602: Invalid params error if the wrong version of the
     // structure is used in the method call.
-    if (executionPayload.getTimestamp() < shanghaiTimestamp.orElse(0L)) {
+    // The timestamp is a uint64 carried in a long, so it must be compared unsigned: a value above
+    // Long.MAX_VALUE is negative and would otherwise look pre-Shanghai.
+    if (Long.compareUnsigned(executionPayload.getTimestamp(), shanghaiTimestamp.orElse(0L)) < 0) {
       if (executionPayload.getWithdrawals() != null) {
         return ValidationResult.invalid(
             RpcErrorType.INVALID_WITHDRAWALS_PARAMS,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PayloadAttributesV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PayloadAttributesV1.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Address;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 
 public sealed class PayloadAttributesV1 permits PayloadAttributesV2 {
 
@@ -31,9 +32,21 @@ public sealed class PayloadAttributesV1 permits PayloadAttributesV2 {
       @JsonProperty("timestamp") final String timestamp,
       @JsonProperty("prevRandao") final String prevRandao,
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient) {
-    this.timestamp = Long.decode(timestamp);
+    this.timestamp = parseTimestamp(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
+  }
+
+  /**
+   * The timestamp is a uint64 QUANTITY, so the whole range must parse ({@link Long#decode} throws
+   * above {@link Long#MAX_VALUE}). Values above {@link Long#MAX_VALUE} are carried as negative
+   * longs and compared unsigned, as the {@code engine_newPayload} payload fields are.
+   */
+  private static long parseTimestamp(final String timestamp) {
+    if (timestamp.startsWith("0x") || timestamp.startsWith("0X")) {
+      return UInt64.fromHexString(timestamp).toBytes().toLong();
+    }
+    return Long.decode(timestamp);
   }
 
   public long getTimestamp() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PayloadAttributesV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PayloadAttributesV1.java
@@ -32,21 +32,12 @@ public sealed class PayloadAttributesV1 permits PayloadAttributesV2 {
       @JsonProperty("timestamp") final String timestamp,
       @JsonProperty("prevRandao") final String prevRandao,
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient) {
-    this.timestamp = parseTimestamp(timestamp);
+    // The timestamp is a uint64 QUANTITY, so the whole range must parse: Long.decode reads hex, but
+    // signed, and throws above Long.MAX_VALUE. Larger values are carried as negative longs and
+    // compared unsigned, as the engine_newPayload payload fields are.
+    this.timestamp = UInt64.fromHexString(timestamp).toBytes().toLong();
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
-  }
-
-  /**
-   * The timestamp is a uint64 QUANTITY, so the whole range must parse ({@link Long#decode} throws
-   * above {@link Long#MAX_VALUE}). Values above {@link Long#MAX_VALUE} are carried as negative
-   * longs and compared unsigned, as the {@code engine_newPayload} payload fields are.
-   */
-  private static long parseTimestamp(final String timestamp) {
-    if (timestamp.startsWith("0x") || timestamp.startsWith("0X")) {
-      return UInt64.fromHexString(timestamp).toBytes().toLong();
-    }
-    return Long.decode(timestamp);
   }
 
   public long getTimestamp() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.ForkchoiceUpdatedResultV1;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -170,14 +171,14 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
 
   protected Object validPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV1(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         "0x0000000000000000000000000000000000000001");
   }
 
   protected Object invalidTimestampPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV1(
-        String.valueOf(head.getTimestamp()),
+        Quantity.create(head.getTimestamp()),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         "0x0000000000000000000000000000000000000001");
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -78,6 +78,12 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   protected static final Consumer<BlockHeaderTestFixture> NO_OP = _ -> {};
+
+  /**
+   * uint64 {@code 0xfffffffffffffffe}: above {@code Long.MAX_VALUE}, so carried as a negative long.
+   */
+  protected static final long TIMESTAMP_ABOVE_LONG_MAX_VALUE = -2L;
+
   protected EngineForkchoiceUpdatedV1<?, ?> method;
 
   protected static final Vertx vertx = Vertx.vertx();
@@ -499,6 +505,28 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
 
     assertInvalidForkchoiceState(resp, RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES);
     verify(engineCallListener, times(1)).executionEngineCalled();
+  }
+
+  @Test
+  public void shouldHandlePayloadAttributesTimestampAboveLongMaxValue() {
+    // A head block at 0xfffffffffffffffe puts the payload attributes timestamp at
+    // 0xffffffffffffffff. Compared signed both are negative, so the attributes would be rejected as
+    // not newer than the head block, and from V2 on their withdrawals as pre-Shanghai.
+    final BlockHeader mockHeader =
+        setupValidForkchoiceUpdate(bhb -> bhb.timestamp(TIMESTAMP_ABOVE_LONG_MAX_VALUE));
+
+    final JsonRpcResponse resp =
+        resp(
+            new ForkchoiceStateV1(mockHeader.getBlockHash(), Hash.ZERO, Hash.ZERO),
+            Optional.of(validPayloadAttributesForBlock(mockHeader)));
+
+    if (getMaxSupportedTimestamp().isPresent()) {
+      // every version but the latest one rejects such a timestamp for being past its fork window,
+      // which it only gets to once the timestamp has parsed and passed the checks above
+      assertInvalidForkchoiceState(resp, RpcErrorType.UNSUPPORTED_FORK);
+    } else {
+      assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+    }
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -105,8 +105,9 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
 
   @Override
   protected Object validPayloadAttributesForBlock(final BlockHeader head) {
-    // if called with a timestamp before, Shanghai should behave like V1
-    if (head.getTimestamp() < withdrawalsEnabledTimestamp) {
+    // if called with a timestamp before, Shanghai should behave like V1. The timestamp is a uint64
+    // carried in a long, so it must be compared unsigned.
+    if (Long.compareUnsigned(head.getTimestamp(), withdrawalsEnabledTimestamp) < 0) {
       when(protocolSpec.getWithdrawalsValidator())
           .thenReturn(new WithdrawalsValidator.ProhibitedWithdrawals());
       return super.validPayloadAttributesForBlock(head);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttr
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.ForkchoiceUpdatedResultV1;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -115,7 +116,7 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
 
   private PayloadAttributesV2 validPayloadAttributesForBlockV2(final BlockHeader head) {
     return new PayloadAttributesV2(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         emptyList());
@@ -124,7 +125,7 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
   @Override
   protected Object invalidTimestampPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV2(
-        String.valueOf(head.getTimestamp()),
+        Quantity.create(head.getTimestamp()),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         emptyList());
@@ -168,7 +169,7 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
 
   protected Object payloadAttributesWithNullWithdrawalsForBlock(final BlockHeader head) {
     return new PayloadAttributesV2(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         null);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -96,7 +97,7 @@ public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test
   @Override
   protected Object validPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV3(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         Collections.emptyList(),
@@ -106,7 +107,7 @@ public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test
   @Override
   protected Object invalidTimestampPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV3(
-        String.valueOf(head.getTimestamp()),
+        Quantity.create(head.getTimestamp()),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         Collections.emptyList(),
@@ -116,7 +117,7 @@ public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test
   @Override
   protected Object payloadAttributesWithNullWithdrawalsForBlock(final BlockHeader head) {
     return new PayloadAttributesV3(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         null,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -106,7 +107,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
   @Override
   protected Object validPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV4(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         Collections.emptyList(),
@@ -118,7 +119,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
   @Override
   protected Object invalidTimestampPayloadAttributesForBlock(final BlockHeader head) {
     return new PayloadAttributesV4(
-        String.valueOf(head.getTimestamp()),
+        Quantity.create(head.getTimestamp()),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         Collections.emptyList(),
@@ -130,7 +131,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
   @Override
   protected Object payloadAttributesWithNullWithdrawalsForBlock(final BlockHeader head) {
     return new PayloadAttributesV4(
-        String.valueOf(head.getTimestamp() + 1),
+        Quantity.create(head.getTimestamp() + 1),
         Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
         Address.ECREC.toString(),
         null,
@@ -147,7 +148,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
 
     final PayloadAttributesV4 payloadWithNegativeSlot =
         new PayloadAttributesV4(
-            String.valueOf(mockHeader.getTimestamp() + 1),
+            Quantity.create(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             Collections.emptyList(),
@@ -171,7 +172,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
 
     final PayloadAttributesV4 payloadWithZeroSlot =
         new PayloadAttributesV4(
-            String.valueOf(mockHeader.getTimestamp() + 1),
+            Quantity.create(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             Collections.emptyList(),
@@ -193,7 +194,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
 
     final PayloadAttributesV4 payloadWithMissingTargetGasLimit =
         new PayloadAttributesV4(
-            String.valueOf(mockHeader.getTimestamp() + 1),
+            Quantity.create(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             Collections.emptyList(),
@@ -218,7 +219,7 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
 
     final PayloadAttributesV4 attrs =
         new PayloadAttributesV4(
-            String.valueOf(mockHeader.getTimestamp() + 1),
+            Quantity.create(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -236,30 +236,6 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
     assertThat(captor.getValue().targetGasLimit()).contains(targetGasLimitValue);
   }
 
-  @Test
-  public void shouldReturnValidForTimestampAboveLongMaxValue() {
-    final BlockHeader mockHeader = setupValidForkchoiceUpdate();
-
-    // uint64 0xffffffffffffffff, carried as -1: it must parse, must count as newer than the head
-    // block, and must count as post-Shanghai so that the withdrawals below are expected.
-    final PayloadAttributesV4 attrs =
-        new PayloadAttributesV4(
-            "0xffffffffffffffff",
-            Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
-            Address.ECREC.toString(),
-            Collections.emptyList(),
-            Bytes32.ZERO.toHexString(),
-            "0x1",
-            "0x1C9C380");
-
-    final JsonRpcResponse resp =
-        resp(
-            new ForkchoiceStateV1(mockHeader.getBlockHash(), Hash.ZERO, Hash.ZERO),
-            Optional.of(attrs));
-
-    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
-  }
-
   // ---- custodyColumns (EIP-8070 Engine API) tests ----
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -235,6 +235,30 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
     assertThat(captor.getValue().targetGasLimit()).contains(targetGasLimitValue);
   }
 
+  @Test
+  public void shouldReturnValidForTimestampAboveLongMaxValue() {
+    final BlockHeader mockHeader = setupValidForkchoiceUpdate();
+
+    // uint64 0xffffffffffffffff, carried as -1: it must parse, must count as newer than the head
+    // block, and must count as post-Shanghai so that the withdrawals below are expected.
+    final PayloadAttributesV4 attrs =
+        new PayloadAttributesV4(
+            "0xffffffffffffffff",
+            Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
+            Address.ECREC.toString(),
+            Collections.emptyList(),
+            Bytes32.ZERO.toHexString(),
+            "0x1",
+            "0x1C9C380");
+
+    final JsonRpcResponse resp =
+        resp(
+            new ForkchoiceStateV1(mockHeader.getBlockHash(), Hash.ZERO, Hash.ZERO),
+            Optional.of(attrs));
+
+    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+  }
+
   // ---- custodyColumns (EIP-8070 Engine API) tests ----
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
@@ -86,6 +86,12 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
+
+  /**
+   * uint64 {@code 0xffffffffffffffff}: above {@code Long.MAX_VALUE}, so carried as a negative long.
+   */
+  protected static final long TIMESTAMP_ABOVE_LONG_MAX_VALUE = -1L;
+
   protected EngineNewPayloadV1<?, ?> method;
 
   public EngineNewPayloadV1Test() {}
@@ -415,6 +421,25 @@ public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
               assertThat(jsonRpcError.getCode()).isEqualTo(UNSUPPORTED_FORK.getCode());
               verify(engineCallListener, times(1)).executionEngineCalled();
             });
+  }
+
+  @Test
+  public void shouldHandleTimestampAboveLongMaxValue() {
+    // uint64 0xffffffffffffffff, carried as -1. Compared signed it looks pre-Shanghai, and from V2
+    // on the payload's withdrawals are then rejected as "must not be present before Shanghai".
+    final BlockHeader mockHeader =
+        setupPayloadV1(
+            TIMESTAMP_ABOVE_LONG_MAX_VALUE,
+            new BlockProcessingResult(Optional.of(new BlockProcessingOutputs(null, List.of()))));
+
+    var resp = resp(requestParams(mockEnginePayloadParam(mockHeader, emptyList())));
+
+    if (getMaxSupportedTimestamp().isPresent()) {
+      // every version but the latest one rejects such a timestamp for being past its fork window
+      assertThat(fromErrorResp(resp).getCode()).isEqualTo(UNSUPPORTED_FORK.getCode());
+    } else {
+      assertValidResponse(mockHeader, resp);
+    }
   }
 
   protected Object[] requestParams(final Map<String, Object> payloadParams) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
@@ -165,7 +165,8 @@ public class EngineNewPayloadV2Test extends EngineNewPayloadV1Test {
   protected void setDefaultExecutionPayloadFields(
       final Map<String, Object> payload, final BlockHeader header, final List<String> txs) {
     super.setDefaultExecutionPayloadFields(payload, header, txs);
-    if (header.getTimestamp() >= shanghaiHardfork.milestone()) {
+    // unsigned: a uint64 timestamp above Long.MAX_VALUE is carried as a negative long
+    if (Long.compareUnsigned(header.getTimestamp(), shanghaiHardfork.milestone()) >= 0) {
       payload.put("withdrawals", List.of());
     }
   }
@@ -202,7 +203,8 @@ public class EngineNewPayloadV2Test extends EngineNewPayloadV1Test {
   @Override
   protected BlockHeaderTestFixture versionSpecificBlockHeaderFixture(final long timestamp) {
     BlockHeaderTestFixture baseFixture = super.versionSpecificBlockHeaderFixture(timestamp);
-    if (timestamp >= shanghaiHardfork.milestone()) {
+    // unsigned: a uint64 timestamp above Long.MAX_VALUE is carried as a negative long
+    if (Long.compareUnsigned(timestamp, shanghaiHardfork.milestone()) >= 0) {
       baseFixture.withdrawalsRoot(BodyValidation.withdrawalsRoot(List.of()));
       when(protocolSpec.getWithdrawalsValidator())
           .thenReturn(new WithdrawalsValidator.AllowedWithdrawals());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -179,22 +179,6 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
     assertValidResponse(header, resp);
   }
 
-  @Test
-  public void shouldReturnValidIfTimestampIsAboveLongMaxValue() {
-    // uint64 0xffffffffffffffff, carried as -1. Compared signed it looks pre-Shanghai, and the
-    // payload's withdrawals are then rejected as "must not be present before Shanghai hardfork".
-    final long timestamp = -1L;
-
-    final BlockHeader header =
-        setupPayloadV5(
-            timestamp, new BlockProcessingResult(Optional.empty()), BLOCK_ACCESS_LIST, 0L);
-
-    final JsonRpcResponse resp =
-        respV5(mockEnginePayloadParam(header, emptyList(), BLOCK_ACCESS_LIST, 0L));
-
-    assertValidResponse(header, resp);
-  }
-
   protected BlockHeader setupPayloadV5(
       final long timestamp,
       final BlockProcessingResult value,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -179,6 +179,22 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
     assertValidResponse(header, resp);
   }
 
+  @Test
+  public void shouldReturnValidIfTimestampIsAboveLongMaxValue() {
+    // uint64 0xffffffffffffffff, carried as -1. Compared signed it looks pre-Shanghai, and the
+    // payload's withdrawals are then rejected as "must not be present before Shanghai hardfork".
+    final long timestamp = -1L;
+
+    final BlockHeader header =
+        setupPayloadV5(
+            timestamp, new BlockProcessingResult(Optional.empty()), BLOCK_ACCESS_LIST, 0L);
+
+    final JsonRpcResponse resp =
+        respV5(mockEnginePayloadParam(header, emptyList(), BLOCK_ACCESS_LIST, 0L));
+
+    assertValidResponse(header, resp);
+  }
+
   protected BlockHeader setupPayloadV5(
       final long timestamp,
       final BlockProcessingResult value,


### PR DESCRIPTION
## PR description

Engine API QUANTITYs are `uint64` and are carried in Besu as `long`s, so a timestamp above
`Long.MAX_VALUE` is a negative long and must be compared unsigned. Signed comparisons meant:

- `engine_newPayload` treated such a payload as pre-Shanghai and rejected its withdrawals with
  `-32602 Invalid withdrawals` (`EngineNewPayloadV2`, also reached via V3/V4/V5);
- post-merge header validation saw the block as older than its parent (merge
  `IncrementalTimestampRule`);
- `engine_forkchoiceUpdated` rejected the payload attributes timestamp against the head block, and
  the same Shanghai gate rejected its withdrawals (`EngineForkchoiceUpdatedV1`/`V2`);
- `engine_getPayloadV2` would have returned the wrong payload version (`EngineGetPayloadV2`).

`engine_forkchoiceUpdated` could not even parse such a timestamp: `PayloadAttributesV1` used
`Long.decode`, which throws above `Long.MAX_VALUE`, so the call failed with an invalid-params error
before any of the above was reached. It now parses hex values as `uint64`, matching what #11143 did
for `slotNumber` and the execution payload fields.

Follow-up to #11143, which fixed the `uint64` *parsing* of the execution payload but left these
comparisons signed.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


