### PR TITLE
Fix flaky DefaultP2PNetworkTest.checkMaintainedConnectionPeers_connectedPeer

### DIFF
--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -203,13 +203,20 @@ public final class DefaultP2PNetworkTest {
     final DefaultP2PNetwork network = network();
     final Peer peer = PeerTestHelper.createPeer();
 
+    // Stubbed before start(), which arms a 2s timer that runs checkMaintainedConnectionPeers() on
+    // the scheduler thread. That background call invokes rlpxAgent too, and Mockito tracks the
+    // invocation being stubbed per mock rather than per thread, so stubbing after start() can have
+    // its when(...)/thenReturn(...) pair torn apart by the timer on a slow enough run.
+    // thenAnswer() rather than thenReturn() because a Stream is single-use and the timer may
+    // consume one before this test does.
+    when(rlpxAgent.streamActiveConnections())
+        .thenAnswer(invocation -> Stream.of(MockPeerConnection.create(peer)));
+
     network.start();
 
     maintainedPeers.add(peer);
 
     // Don't connect to an already connected peer
-    when(rlpxAgent.streamActiveConnections())
-        .thenReturn(Stream.of(MockPeerConnection.create(peer)));
     network.checkMaintainedConnectionPeers();
     verify(rlpxAgent, times(0)).connect(peer, ConnectSource.MAINTAIN);
   }


### PR DESCRIPTION
## PR description

`DefaultP2PNetworkTest.checkMaintainedConnectionPeers_connectedPeer` fails intermittently, typically under a loaded parallel build:

```
org.mockito.exceptions.misusing.WrongTypeOfReturnValue:
Head cannot be returned by connect()
connect() should return CompletableFuture
```

### Cause

`DefaultP2PNetwork.start()` arms a real background timer:

```java
peerConnectionScheduler.scheduleWithFixedDelay(
    this::checkMaintainedConnectionPeers, 2, checkMaintainedConnectionsSec, TimeUnit.SECONDS);
```

A **2 second** initial delay. The observed failure had a test duration of 2.423s, so the timer fired mid-test and called `rlpxAgent.connect(peer, MAINTAIN)` from the scheduler thread.

Mockito tracks the invocation currently being stubbed per *mock* (`InvocationContainerImpl`), not per thread. That background call can therefore land between `when(rlpxAgent.streamActiveConnections())` and `.thenReturn(...)` and replace the pending stub target, so `thenReturn` ends up type-checking a `Stream` (`ReferencePipeline$Head`) against `connect()`'s `CompletableFuture`.

### Fix

Move the stubbing above `network.start()`, so nothing is being stubbed while the timer is armed, and use `thenAnswer()` rather than `thenReturn()` so each call gets a fresh `Stream` (a `Stream` is single-use, and the timer may now consume one first).

This also makes the background firing behaviourally inert: it sees the peer as already connected and skips `connect()`, so the `times(0)` assertion holds regardless of timing.

### Verification

The race was reproduced deterministically by forcing the timer to fire (a sleep after `start()`):

- pre-fix: fails, with `connect(..., MAINTAIN)` "invoked here: `DefaultP2PNetwork.lambda$checkMaintainedConnectionPeers$2(DefaultP2PNetwork.java:418)`" — i.e. the scheduled task
- post-fix: passes

### Not addressed here

- `checkMaintainedConnectionPeers_unconnectedPeer` has the same latent race: it asserts `times(1)`, and a timer firing would make it 2. Fixing it means either weakening the assertion or decoupling the scheduler, so it is left out of this test-only change.
- The real cure is production-side: the hardcoded `2` is inconsistent with the line below it (which uses its configured frequency as the initial delay), and `start()` already runs one `checkMaintainedConnectionPeers()` synchronously just above. Making the initial delay config-driven would let these tests disarm the timer entirely, but it would also delay static-peer reconnect retries from 2s to the configured frequency, which is a behavioural change and out of scope here.

## Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if [updates are required](https://github.com/besu-eth/besu/blob/main/docs/README.md).
- [x] Considered the changelog and included an [update if required](https://github.com/besu-eth/besu/blob/main/docs/README.md#changelog). (test-only change, no changelog entry)
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
