### PR TITLE
Return hex-encoded transactions from engine_getInclusionListV1

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetInclusionListV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetInclusionListV1.java
@@ -20,7 +20,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.encoding.EncodingContext;
+import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -76,8 +77,14 @@ public class EngineGetInclusionListV1 extends ExecutionEngineJsonRpcMethod {
         transactionPool.getInclusionListPendingTransactions();
     final long durationMs = Duration.ofNanos(System.nanoTime() - startTimeNanos).toMillis();
 
-    final List<Transaction> result =
-        selectedPendingTransactions.stream().map(PendingTransaction::getTransaction).toList();
+    final List<String> result =
+        selectedPendingTransactions.stream()
+            .map(PendingTransaction::getTransaction)
+            .map(
+                transaction ->
+                    TransactionEncoder.encodeOpaqueBytes(transaction, EncodingContext.BLOCK_BODY)
+                        .toHexString())
+            .toList();
 
     transactionsGeneratedCounter.inc(result.size());
     selectorDurationMsCounter.inc(durationMs);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetInclusionListV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetInclusionListV1Test.java
@@ -37,6 +37,8 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
+import org.hyperledger.besu.ethereum.core.encoding.EncodingContext;
+import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.StubMetricsSystem;
@@ -115,7 +117,7 @@ public class EngineGetInclusionListV1Test {
     final JsonRpcResponse response = resp(KNOWN_PARENT_HASH);
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
 
-    final List<Transaction> result = fromSuccessResp(response);
+    final List<String> result = fromSuccessResp(response);
     assertThat(result).isEmpty();
   }
 
@@ -133,8 +135,8 @@ public class EngineGetInclusionListV1Test {
     final JsonRpcResponse response = resp(KNOWN_PARENT_HASH);
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
 
-    final List<Transaction> result = fromSuccessResp(response);
-    assertThat(result).contains(tx1, tx2);
+    final List<String> result = fromSuccessResp(response);
+    assertThat(result).containsExactly(encode(tx1), encode(tx2));
   }
 
   @Test
@@ -150,7 +152,7 @@ public class EngineGetInclusionListV1Test {
     final JsonRpcResponse response = resp(KNOWN_PARENT_HASH);
     assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
 
-    final List<Transaction> result = fromSuccessResp(response);
+    final List<String> result = fromSuccessResp(response);
     assertThat(result).hasSize(1);
   }
 
@@ -191,6 +193,11 @@ public class EngineGetInclusionListV1Test {
         .isEqualTo(0);
   }
 
+  private static String encode(final Transaction transaction) {
+    return TransactionEncoder.encodeOpaqueBytes(transaction, EncodingContext.BLOCK_BODY)
+        .toHexString();
+  }
+
   private Transaction createLegacyTransaction(final long nonce, final Wei gasPrice) {
     return new TransactionTestFixture()
         .to(Optional.of(Address.ZERO))
@@ -212,7 +219,7 @@ public class EngineGetInclusionListV1Test {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private List<Transaction> fromSuccessResp(final JsonRpcResponse resp) {
+  private List<String> fromSuccessResp(final JsonRpcResponse resp) {
     assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/InclusionListWorkflowIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/InclusionListWorkflowIntegrationTest.java
@@ -217,21 +217,17 @@ public class InclusionListWorkflowIntegrationTest {
     assertThat(getILResponse.getType()).isEqualTo(RpcResponseType.SUCCESS);
 
     @SuppressWarnings("unchecked")
-    final List<Transaction> ilTxList =
-        (List<Transaction>) ((JsonRpcSuccessResponse) getILResponse).getResult();
-    assertThat(ilTxList).isNotEmpty();
+    final List<String> ilTxHexList =
+        (List<String>) ((JsonRpcSuccessResponse) getILResponse).getResult();
+    assertThat(ilTxHexList)
+        .containsExactly(
+            TransactionEncoder.encodeOpaqueBytes(tx, EncodingContext.BLOCK_BODY).toHexString());
     assertThat(metricsSystem.getCounterValue("engine_inclusion_list_transactions_generated"))
         .isGreaterThan(0);
 
     // Step 2: forkchoiceUpdatedV5 - initiate payload building with IL transactions
     final BlockHeader childHeader = createChildBlockHeader(parentHeader);
     setupValidForkchoiceUpdate(childHeader, parentHeader);
-
-    final List<String> ilTxHexList =
-        ilTxList.stream()
-            .map(t -> TransactionEncoder.encodeOpaqueBytes(t, EncodingContext.POOLED_TRANSACTION))
-            .map(Bytes::toHexString)
-            .toList();
 
     final PayloadAttributesV5 payloadAttrs =
         new PayloadAttributesV5(


### PR DESCRIPTION
## PR description

`engine_getInclusionListV1` is specified (execution-apis #609, `openrpc/methods/inclusion_list.yaml`) to return an array of `DATA` — the opaque transaction bytes. The `focil-devnet-0` implementation returns the `Transaction` objects, which Jackson serializes as JSON objects, so consensus clients that follow the spec cannot parse the response.

Observed on `focil-devnet-0` (`ethpandaops/besu:focil-devnet-0`, `f21307f`) with Lodestar:

```
produceInclusionList error - Invalid hex string: hex argument type object must be of type string
    at deserializeInclusionList (packages/beacon-node/src/execution/engine/types.ts:484:15)
    at ExecutionEngineHttp.getInclusionList (packages/beacon-node/src/execution/engine/http.ts:578:12)
```

so no Lodestar+Besu validator ever produced an inclusion list.

This encodes each selected transaction with `TransactionEncoder.encodeOpaqueBytes(tx, EncodingContext.BLOCK_BODY)` — the same context `engine_newPayloadV6` / `InclusionListValidator` use to decode the inclusion list transactions handed back — and returns the hex strings. Tests updated accordingly (`EngineGetInclusionListV1Test`, `InclusionListWorkflowIntegrationTest`).

## Fixed Issue(s)

Found while testing FOCIL on `focil-devnet-0` with ethereum-package (ethrex/besu × lodestar/teku).

https://claude.ai/code/session_01YHCg1Q6QaZn8rPjB7za3UB