### PR TITLE
Deprecate unreachable plugin-api types for removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - `PluginTransactionSelectorFactory.create(final SelectorsStateManager selectorsStateManager)` is deprecated for removal
   - `PoaQueryService` and `BftQueryService` are deprecated and will be removed in a future release, with no replacement. They have no known usage
   - `MiningService` is deprecated for removal and will be removed in a future release, with no replacement. It has no known usage
+  - `PluginVersionsProvider`, `plugin.data.Request`, `plugin.data.Restriction`, `plugin.data.UnsignedPrivateMarkerTransaction` and `plugin.data.Signature` are deprecated for removal, with no replacement. None is reachable through any plugin service or data contract: the three privacy types were orphaned when private transaction support was removed, `Request` is implemented internally but never exposed, and `PluginVersionsProvider` is internal `--version` plumbing
 - `--Xbft-legacy-protocol-encoding` will be removed once Besu 25.x is no longer supported. [#10499](https://github.com/besu-eth/besu/pull/10499)
 - `--Xsnapsync-synchronizer-pivot-block-distance-before-caching` is deprecated and will be removed in a future release; the flag is now a silent no-op.
 - `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` is deprecated and will be removed in a future release; the flag is now a silent no-op.

--- a/app/src/main/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactory.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactory.java
@@ -22,6 +22,8 @@ import picocli.CommandLine;
  * Custom PicoCli IFactory to handle version provider construction with plugin versions. Based on
  * same logic as PicoCLI DefaultFactory.
  */
+// PluginVersionsProvider is deprecated for removal from the plugin API
+@SuppressWarnings("removal")
 public class BesuCommandCustomFactory implements CommandLine.IFactory {
   private final PluginVersionsProvider pluginVersionsProvider;
   private final CommandLine.IFactory defaultFactory = CommandLine.defaultFactory();

--- a/app/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
+++ b/app/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
@@ -22,6 +22,8 @@ import java.util.stream.Stream;
 import picocli.CommandLine;
 
 /** The Version provider used by PicoCli to report Besu version on Cli. */
+// PluginVersionsProvider is deprecated for removal from the plugin API
+@SuppressWarnings("removal")
 public class VersionProvider implements CommandLine.IVersionProvider {
   private final PluginVersionsProvider pluginVersionsProvider;
 

--- a/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/app/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -49,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** The Besu plugin context implementation. */
+// PluginVersionsProvider is deprecated for removal from the plugin API
+@SuppressWarnings("removal")
 public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(BesuPluginContextImpl.class);

--- a/app/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("removal")
 public class BesuCommandCustomFactoryTest {
 
   @Mock private PluginVersionsProvider pluginVersionsProvider;

--- a/app/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
+++ b/app/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("removal")
 public class VersionProviderTest {
 
   @Mock private PluginVersionsProvider pluginVersionsProvider;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Request.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Request.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.tuweni.bytes.Bytes;
 
+// implements the deprecated plugin.data.Request until the next breaking release
+@SuppressWarnings("removal")
 public record Request(RequestType type, Bytes data)
     implements org.hyperledger.besu.plugin.data.Request {
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -62,6 +62,9 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.apache.tuweni.units.bigints.UInt256s;
 
 /** An operation submitted by an external actor to be applied to the system. */
+// implements the deprecated plugin.data.UnsignedPrivateMarkerTransaction until the next breaking
+// release
+@SuppressWarnings("removal")
 public class Transaction
     implements org.hyperledger.besu.datatypes.Transaction,
         org.hyperledger.besu.plugin.data.UnsignedPrivateMarkerTransaction {

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Request.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Request.java
@@ -19,7 +19,13 @@ import org.hyperledger.besu.plugin.Unstable;
 
 import org.apache.tuweni.bytes.Bytes;
 
-/** A request is an operation sent to the Beacon Node */
+/**
+ * A request is an operation sent to the Beacon Node
+ *
+ * @deprecated This type is scheduled for removal in a future release, with no replacement. No
+ *     plugin service or data contract returns or accepts it, so it cannot be used by plugins.
+ */
+@Deprecated(forRemoval = true)
 @Unstable
 public interface Request {
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Restriction.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Restriction.java
@@ -18,7 +18,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.apache.tuweni.bytes.Bytes;
 
-/** The enum Restriction. */
+/**
+ * The enum Restriction.
+ *
+ * @deprecated This type is scheduled for removal in a future release, with no replacement. It
+ *     belonged to the private transaction API removed in Besu 25.6.0 and is no longer reachable
+ *     from any plugin contract.
+ */
+@Deprecated(forRemoval = true)
 public enum Restriction {
   /** Restricted restriction. */
   RESTRICTED(Bytes.wrap("restricted".getBytes(UTF_8))),

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Signature.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Signature.java
@@ -18,6 +18,13 @@ import org.hyperledger.besu.plugin.Unstable;
 
 import org.apache.tuweni.bytes.Bytes;
 
-/** An interface for {@link Bytes} that also represents a signature */
+/**
+ * An interface for {@link Bytes} that also represents a signature
+ *
+ * @deprecated This type is scheduled for removal in a future release, with no replacement. It is
+ *     not referenced by any plugin contract; signing uses {@code
+ *     org.hyperledger.besu.plugin.services.securitymodule.data.Signature}.
+ */
+@Deprecated(forRemoval = true)
 @Unstable
 public interface Signature extends Bytes {}

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/UnsignedPrivateMarkerTransaction.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/UnsignedPrivateMarkerTransaction.java
@@ -22,7 +22,14 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
-/** The interface Unsigned private marker transaction. */
+/**
+ * The interface Unsigned private marker transaction.
+ *
+ * @deprecated This type is scheduled for removal in a future release, with no replacement. It
+ *     belonged to the private transaction API removed in Besu 25.6.0 and is no longer reachable
+ *     from any plugin contract.
+ */
+@Deprecated(forRemoval = true)
 public interface UnsignedPrivateMarkerTransaction {
 
   /**

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PluginVersionsProvider.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PluginVersionsProvider.java
@@ -16,7 +16,13 @@ package org.hyperledger.besu.plugin.services;
 
 import java.util.Map;
 
-/** The interface Plugin versions provider. */
+/**
+ * The interface Plugin versions provider.
+ *
+ * @deprecated This type is scheduled for removal from the plugin API in a future release, with no
+ *     replacement. It is used only internally to print plugin versions for {@code --version}.
+ */
+@Deprecated(forRemoval = true)
 public interface PluginVersionsProvider {
   /**
    * Gets plugin versions by name.


### PR DESCRIPTION
## PR description

Marks five plugin-api types as `@Deprecated(forRemoval = true)`: `PluginVersionsProvider`, `plugin.data.Request`, `plugin.data.Restriction`, `plugin.data.UnsignedPrivateMarkerTransaction` and `plugin.data.Signature`.

None of them is reachable by a plugin. `Restriction` and `UnsignedPrivateMarkerTransaction` belonged to the private transaction API removed in 25.6.0 and were left behind. `Request` is implemented by the internal core `Request` but no contract returns or accepts it. `plugin.data.Signature` is an empty interface with no references; signing uses `services.securitymodule.data.Signature`. `PluginVersionsProvider` is used only internally to print plugin versions for `--version`; plugins report their version through `BesuPlugin.getVersion()`, which is unchanged.

Every plugin in this repo and the public external plugins (Linea sequencer, state-recovery and tracer, Shomei, Consensys besu-plugins, fleet, exflo, storage-replication, plugin-starter, HSM, Azure KeyVault, PluginsAPIDemo, besu-docs) were checked: zero references to any of the five.

Part of #10820.

## Fixed Issue(s)



### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
