### PR TITLE
engine: name executionRequests in the unsupported-request-type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - Complete QBFT votes in a reasonable time when `empyblockperiodseconds` is set by treating QBFT votes as "non empty blocks" [#11111](https://github.com/besu-eth/besu/pull/11111)
 - `engine_newPayload` no longer briefly answers `SYNCING` after startup on a peerless node: `PostMergeContext.isSyncing()` now treats an undetermined terminal-difficulty flag as "reached", matching `SyncState.isInSync()`. [#11168](https://github.com/besu-eth/besu/pull/11168)
 - Engine API timestamps above `2^63-1` are no longer treated as negative: `engine_newPayload` rejected such a payload's withdrawals as pre-Shanghai, `engine_forkchoiceUpdated` failed to parse the payload attributes timestamp at all, and post-merge header validation saw the block as older than its parent.
+- `engine_newPayloadV4`+ now reports an unrecognised `executionRequests` type byte as `Invalid execution requests: Unsupported request type: 0xNN`. The `validationError` on the `INVALID` payload status previously named only the type byte, not the parameter it came from.
 
 ### Additions and Improvements
 - Add `eth_getRawTransactionByHash` JSON-RPC method. [#11170](https://github.com/besu-eth/besu/pull/11170)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -126,7 +126,11 @@ public sealed class EngineNewPayloadV4<
                 .getLatestValidAncestor(e.getPayloadParameter().getParentHash())
                 .orElse(null),
             EngineStatus.INVALID,
-            maybeRequestTypeEx.get().getMessage());
+            // The validationError is the only diagnostic the consensus client receives, so it has
+            // to identify the field at fault, not just the reason.
+            RpcErrorType.INVALID_EXECUTION_REQUESTS.getMessage()
+                + ": "
+                + maybeRequestTypeEx.get().getMessage());
       } else {
         // payload parameter should be present in this case, so treat this as an internal error
         logger()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -61,6 +61,7 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_ENODE_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid enode params"),
   INVALID_EXCESS_BLOB_GAS_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid excess blob gas params (missing or invalid)"),
+  INVALID_EXECUTION_REQUESTS(INVALID_PARAMS_ERROR_CODE, "Invalid execution requests"),
   INVALID_EXECUTION_REQUESTS_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid execution requests params"),
   INVALID_BLOCK_ACCESS_LIST_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid block access list params (missing or invalid)"),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -243,6 +243,9 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
     var result = fromSuccessResp(resp);
     assertThat(result.getStatus()).isEqualTo(INVALID);
     assertThat(result.getLatestValidHash().get()).isEqualTo(mockHash);
+    // The validationError is the only diagnostic the consensus client receives.
+    assertThat(result.getError())
+        .isEqualTo("Invalid execution requests: Unsupported request type: 0xFF");
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 


### PR DESCRIPTION
## PR description

`engine_newPayloadV4`+ rejects a payload whose `executionRequests` contain an unrecognised type byte with an `INVALID` payload status, and the `validationError` it carries is whatever `RequestType.of` threw: `Unsupported request type: 0xA9`. That says which byte was not recognised, but not which parameter it came from — and the `validationError` is the only diagnostic a consensus client receives.

This prefixes it with `Invalid execution requests`, the wording every other `executionRequests` rejection uses.

execution-spec-tests maps `BlockException.INVALID_REQUESTS` to that phrase, so the EIP-7685 `multi_type_requests` fixtures covering unknown request types and requests missing their type byte now match instead of reporting an unmapped error — 16 fixtures across Amsterdam and Osaka.

Behaviour is otherwise unchanged: the payload is still rejected with `INVALID`, as before.