### PR TITLE
Reject an empty EIP-7702 authorization list in validation, not in decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Besu no longer announces the EIP-4844 version 0 size of a blob transaction while serving the EIP-7594 version 1 (cell proofs) encoding. From Osaka on, a locally submitted version 0 blob transaction is upgraded to version 1 before it is pooled, but the pre-upgrade transaction was the one broadcast, so `NewPooledTransactionHashes` under-announced it by 6,226 bytes per blob against what `GetPooledTransactions` then served, and go-ethereum peers responded with `dropPeer()`. [#11203](https://github.com/besu-eth/besu/pull/11203)
 - `admin_logsRemoveCache` no longer reports `Cache Removed` when nothing was removed. `TransactionLogBloomCacher.removeSegments` skips the whole deletion while log bloom caching is in progress, so the RPC returned success while every cache file was still on disk. It now returns an error in that case. [#11080](https://github.com/besu-eth/besu/pull/11080)
 - Serialize `BftMiningCoordinator` `enable()`/`disable()` with `start()`/`stop()` so the mining state flips and their surrounding checks can no longer interleave with concurrent lifecycle transitions. [#10887](https://github.com/besu-eth/besu/pull/10887)
+- An EIP-7702 transaction with an empty `authorization_list` is now rejected by transaction validation rather than by RLP decoding. Over the Engine API such a transaction made the whole payload report `Failed to decode transactions from block parameter`, hiding both the rule that was broken and any other defect the transaction had.
 
 ### Additions and Improvements
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -252,9 +252,12 @@ public class Transaction
         checkArgument(
             maybeCodeDelegationList.isPresent(),
             "Must specify code delegation authorizations for code delegation transaction");
-        checkArgument(
-            !maybeCodeDelegationList.get().isEmpty(),
-            "Code delegation transaction must have at least one authorization");
+        // An empty authorization_list is well-formed RLP; EIP-7702 makes it a transaction validity
+        // rule, not an encoding one, so it is rejected by MainnetTransactionValidator rather than
+        // here. Rejecting it at construction would abort decoding of the whole enclosing list --
+        // an engine_newPayload transactions array, an eth/68 message -- and report a decode
+        // failure in place of the real reason the transaction was invalid, hiding any other
+        // defect it has.
       }
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -252,12 +252,6 @@ public class Transaction
         checkArgument(
             maybeCodeDelegationList.isPresent(),
             "Must specify code delegation authorizations for code delegation transaction");
-        // An empty authorization_list is well-formed RLP; EIP-7702 makes it a transaction validity
-        // rule, not an encoding one, so it is rejected by MainnetTransactionValidator rather than
-        // here. Rejecting it at construction would abort decoding of the whole enclosing list --
-        // an engine_newPayload transactions array, an eth/68 message -- and report a decode
-        // failure in place of the real reason the transaction was invalid, hiding any other
-        // defect it has.
       }
     }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
@@ -110,7 +110,10 @@ class TransactionBuilderTest {
   }
 
   @Test
-  void emptyCodeDelegationListIsInvalid() {
+  void emptyCodeDelegationListBuilds() {
+    // EIP-7702 makes an empty authorization_list a transaction validity rule, not an encoding one,
+    // so building one succeeds and MainnetTransactionValidator rejects it -- see
+    // MainnetTransactionValidatorTest.shouldRejectCodeDelegationTransactionWithEmptyDelegationList.
     TransactionTestFixture ttf =
         new TransactionTestFixture()
             .type(TransactionType.DELEGATE_CODE)
@@ -118,13 +121,8 @@ class TransactionBuilderTest {
             .maxFeePerGas(Optional.of(Wei.of(5)))
             .maxPriorityFeePerGas(Optional.of(Wei.of(5)))
             .codeDelegations(List.of());
-    try {
-      ttf.createTransaction(senderKeys);
-      fail();
-    } catch (IllegalArgumentException iea) {
-      assertThat(iea)
-          .hasMessage("Code delegation transaction must have at least one authorization");
-    }
+
+    assertThat(ttf.createTransaction(senderKeys).getCodeDelegationList()).contains(List.of());
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionBuilderTest.java
@@ -111,9 +111,7 @@ class TransactionBuilderTest {
 
   @Test
   void emptyCodeDelegationListBuilds() {
-    // EIP-7702 makes an empty authorization_list a transaction validity rule, not an encoding one,
-    // so building one succeeds and MainnetTransactionValidator rejects it -- see
-    // MainnetTransactionValidatorTest.shouldRejectCodeDelegationTransactionWithEmptyDelegationList.
+    // an empty authorization_list is a validity rule, not an encoding one, so building succeeds
     TransactionTestFixture ttf =
         new TransactionTestFixture()
             .type(TransactionType.DELEGATE_CODE)

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -432,6 +432,43 @@ public class MainnetTransactionValidatorTest extends TrustedSetupClassLoaderExte
   }
 
   @Test
+  public void shouldRejectCodeDelegationTransactionWithEmptyDelegationList() {
+    final TransactionValidator validator =
+        createTransactionValidator(
+            gasCalculator,
+            GasLimitCalculator.constant(),
+            FeeMarket.london(0L),
+            false,
+            Optional.of(BigInteger.ONE),
+            Set.of(TransactionType.DELEGATE_CODE),
+            Integer.MAX_VALUE);
+    final Transaction transaction =
+        Transaction.builder()
+            .type(TransactionType.DELEGATE_CODE)
+            .nonce(0)
+            .maxPriorityFeePerGas(Wei.of(1))
+            .maxFeePerGas(Wei.of(2))
+            .gasLimit(21_000)
+            .to(Address.ZERO)
+            .value(Wei.ZERO)
+            .payload(Bytes.EMPTY)
+            .chainId(BigInteger.ONE)
+            .codeDelegations(List.of())
+            .signAndBuild(senderKeys);
+
+    final ValidationResult<TransactionInvalidReason> validationResult =
+        validator.validate(
+            transaction, Optional.of(Wei.ONE), Optional.empty(), transactionPoolParams);
+
+    assertThat(validationResult.isValid()).isFalse();
+    assertThat(validationResult.getInvalidReason())
+        .isEqualTo(TransactionInvalidReason.EMPTY_CODE_DELEGATION);
+    assertThat(validationResult.getErrorMessage())
+        .isEqualTo(
+            "transaction code delegation transactions must have a non-empty code delegation list");
+  }
+
+  @Test
   public void shouldRejectCodeDelegationTransactionWhenAuthorizationChainIdIsOutOfRange() {
     final TransactionValidator validator =
         createTransactionValidator(


### PR DESCRIPTION
## PR description

EIP-7702 states that a transaction is invalid if the length of its `authorization_list` is zero. Besu enforced that in the `Transaction` constructor, which every RLP decoder goes through, so an empty list aborted *decoding* rather than failing *validation*.

Over the Engine API that is a worse answer than it looks. `engine_newPayload` decodes the whole `transactions` array in one pass, so one such transaction makes the payload report `Failed to decode transactions from block parameter` instead of naming the rule that was broken — and any other defect the transaction has is never reached. A type-4 transaction carrying both an empty authorization list and a foreign chain id was reported as a decode failure rather than as the wrong chain id.

`MainnetTransactionValidator` already had the `EMPTY_CODE_DELEGATION` check; the constructor invariant made it unreachable. This drops the invariant so the validator runs, and moves the assertion to the validator's test.

The transaction is rejected either way — only the reported reason changes.