### PR TITLE
wire remaining opcode gas benchmarks

### DIFF
--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AddModOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AddModOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmark {
+public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
 
   // Cases for (a + b) % c
   // Format "ADDMOD_a_b_c" - where a, b and c are the size in bits
@@ -86,5 +89,10 @@ public class AddModOperationBenchmark extends TernaryArithmeticOperationBenchmar
   @Override
   protected String caseName() {
     return caseName;
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new AddModOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class AndOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class AndOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AndOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class AndOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class AndOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return AndOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new AndOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/AndOperationOptimizedBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.AndOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class AndOperationOptimizedBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class AndOperationOptimizedBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return AndOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new AndOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CountLeadingZerosOperation;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
@@ -31,6 +32,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
@@ -46,7 +49,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class CountLeadingZerosOperationBenchmark {
+public class CountLeadingZerosOperationBenchmark implements GasCostBenchmark {
   // variable used to run inner loop of invocations because CLZ runs in under 15 nanoseconds so
   // overhead from framework
   // taking measurements is high. There are variable and offset errors either in baseline and the
@@ -91,6 +94,14 @@ public class CountLeadingZerosOperationBenchmark {
             .build();
     bytes = Bytes.fromHexString(bytesHex);
   }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new CountLeadingZerosOperation(calc).getGasCost();
+  }
+
+  @Override
+  public void executeOperation(final Blackhole blackhole) {}
 
   @Benchmark
   @OperationsPerInvocation(OPERATIONS_PER_INVOCATION)

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/CountLeadingZerosOperationBenchmark.java
@@ -32,8 +32,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.infra.BenchmarkParams;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OperationsPerInvocation;
@@ -43,6 +41,8 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)
 @Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -101,11 +101,9 @@ public class CountLeadingZerosOperationBenchmark implements GasCostBenchmark {
   }
 
   @Override
-  public void executeOperation(final Blackhole blackhole) {}
-
   @Benchmark
   @OperationsPerInvocation(OPERATIONS_PER_INVOCATION)
-  public void executeOperation() {
+  public void executeOperation(final Blackhole blackhole) {
     for (int i = 0; i < OPERATIONS_PER_INVOCATION; i++) {
       frame.pushStackItem(bytes);
       CountLeadingZerosOperation.staticOperation(frame);

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DivOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.DivOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class DivOperationBenchmark extends BinaryArithmeticOperationBenchmark {
+public class DivOperationBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param({
     "DIV_32_32",
     "DIV_64_32",
@@ -62,5 +65,10 @@ public class DivOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Override
   protected String opCode() {
     return "DIV";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new DivOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DupNOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/DupNOperationBenchmark.java
@@ -15,11 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.DupNOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the DUPN operation (EIP-8024). */
-public class DupNOperationBenchmark extends ImmediateByteOperationBenchmark {
+public class DupNOperationBenchmark extends ImmediateByteOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected int getOpcode() {
@@ -42,5 +46,10 @@ public class DupNOperationBenchmark extends ImmediateByteOperationBenchmark {
   protected int getStackDelta() {
     // DUPN adds one item to the stack
     return 1;
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new DupNOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.EqOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
@@ -25,8 +26,10 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class EqOperationBenchmark extends BinaryOperationBenchmark {
+public class EqOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   // public because of jmh code generator
   public enum MODE {
@@ -173,5 +176,10 @@ public class EqOperationBenchmark extends BinaryOperationBenchmark {
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return EqOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new EqOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/EqOperationBenchmark.java
@@ -28,8 +28,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class EqOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class EqOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   // public because of jmh code generator
   public enum MODE {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ExchangeOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ExchangeOperationBenchmark.java
@@ -15,11 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.ExchangeOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the EXCHANGE operation (EIP-8024). */
-public class ExchangeOperationBenchmark extends ImmediateByteOperationBenchmark {
+public class ExchangeOperationBenchmark extends ImmediateByteOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected int getOpcode() {
@@ -43,5 +47,10 @@ public class ExchangeOperationBenchmark extends ImmediateByteOperationBenchmark 
   protected int getStackDelta() {
     // EXCHANGE does not change stack size
     return 0;
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ExchangeOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.GtOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class GtOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class GtOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return GtOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new GtOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/GtOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class GtOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class GtOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.LtOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class LtOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class LtOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return LtOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new LtOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/LtOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class LtOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class LtOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ModOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.ModOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class ModOperationBenchmark extends BinaryArithmeticOperationBenchmark {
+public class ModOperationBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param({
     "MOD_32_32",
     "MOD_64_32",
@@ -56,5 +59,10 @@ public class ModOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Override
   protected String opCode() {
     return "MOD";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ModOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulModOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.MulModOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class MulModOperationBenchmark extends TernaryArithmeticOperationBenchmark {
+public class MulModOperationBenchmark extends TernaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
 
   // Cases for (a * b) % c
   // Format "MULMOD_a_b_c" - where a, b and c are the size in bits
@@ -86,5 +89,10 @@ public class MulModOperationBenchmark extends TernaryArithmeticOperationBenchmar
   @Override
   protected String opCode() {
     return "MULMOD";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new MulModOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.MulOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class MulOperationBenchmark extends BinaryArithmeticOperationBenchmark {
+public class MulOperationBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param("MUL_RANDOM_RANDOM")
   private String caseName;
 
@@ -37,5 +40,10 @@ public class MulOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Override
   protected String opCode() {
     return "MUL";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new MulOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/MulOperationOptimizedBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.MulOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class MulOperationOptimizedBenchmark extends BinaryArithmeticOperationBenchmark {
+public class MulOperationOptimizedBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param("MUL_RANDOM_RANDOM")
   private String caseName;
 
@@ -37,5 +40,10 @@ public class MulOperationOptimizedBenchmark extends BinaryArithmeticOperationBen
   @Override
   protected String opCode() {
     return "MUL";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new MulOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class NotOperationBenchmark extends UnaryOperationBenchmark
-    implements GasCostBenchmark {
+public class NotOperationBenchmark extends UnaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.NotOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class NotOperationBenchmark extends UnaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class NotOperationBenchmark extends UnaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return NotOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new NotOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/NotOperationOptimizedBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.NotOperationOptimized;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class NotOperationOptimizedBenchmark extends UnaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class NotOperationOptimizedBenchmark extends UnaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return NotOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new NotOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.OrOperation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class OrOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class OrOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.OrOperation;
 
-public class OrOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class OrOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return OrOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new OrOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OrOperationOptimizedBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.OrOperationOptimized;
 
-public class OrOperationOptimizedBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class OrOperationOptimizedBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return OrOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new OrOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SDivOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SDivOperationOptimized;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class SDivOperationBenchmark extends SignedBinaryArithmeticOperationBenchmark {
+public class SDivOperationBenchmark extends SignedBinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param({
     "SDIV_32_32",
     "SDIV_64_32",
@@ -58,5 +61,10 @@ public class SDivOperationBenchmark extends SignedBinaryArithmeticOperationBench
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SDivOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SDivOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SLtOperation;
 
-public class SLtOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class SLtOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SLtOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SLtOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SLtOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.SLtOperation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class SLtOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class SLtOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SModOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SModOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SModOperationOptimized;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class SModOperationBenchmark extends SignedBinaryArithmeticOperationBenchmark {
+public class SModOperationBenchmark extends SignedBinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param({
     "SMOD_32_32",
     "SMOD_64_32",
@@ -57,5 +60,10 @@ public class SModOperationBenchmark extends SignedBinaryArithmeticOperationBench
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SModOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SModOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SarOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SarOperationBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SarOperation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the original SAR (Shift Arithmetic Right) operation. */
-public class SarOperationBenchmark extends AbstractSarOperationBenchmark {
+public class SarOperationBenchmark extends AbstractSarOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SarOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SarOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SarOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SarOperationOptimizedBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SarOperationOptimized;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the optimized SAR (Shift Arithmetic Right) operation. */
-public class SarOperationOptimizedBenchmark extends AbstractSarOperationBenchmark {
+public class SarOperationOptimizedBenchmark extends AbstractSarOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SarOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SarOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SelfBalanceOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SelfBalanceOperationBenchmark.java
@@ -28,8 +28,6 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.SelfBalanceOperation;
-
-import org.openjdk.jmh.infra.BenchmarkParams;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.concurrent.TimeUnit;
@@ -43,6 +41,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SelfBalanceOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SelfBalanceOperationBenchmark.java
@@ -28,6 +28,8 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.SelfBalanceOperation;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.concurrent.TimeUnit;
@@ -48,7 +50,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class SelfBalanceOperationBenchmark {
+public class SelfBalanceOperationBenchmark implements GasCostBenchmark {
 
   private SelfBalanceOperation operation;
   private MessageFrame frame;
@@ -82,9 +84,15 @@ public class SelfBalanceOperationBenchmark {
     worldUpdater.get(address);
   }
 
+  @Override
   @Benchmark
   public void executeOperation(final Blackhole blackhole) {
     blackhole.consume(operation.execute(frame, null));
     frame.popStackItem();
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SelfBalanceOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShlOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShlOperationBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.ShlOperation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the original SHL (Shift Left) operation. */
-public class ShlOperationBenchmark extends AbstractShiftOperationBenchmark {
+public class ShlOperationBenchmark extends AbstractShiftOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return ShlOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ShlOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShlOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShlOperationOptimizedBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.ShlOperationOptimized;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the optimized SHL (Shift Left) operation. */
-public class ShlOperationOptimizedBenchmark extends AbstractShiftOperationBenchmark {
+public class ShlOperationOptimizedBenchmark extends AbstractShiftOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return ShlOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ShlOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShrOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShrOperationBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.ShrOperation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the original SHR (Shift Right Logical) operation. */
-public class ShrOperationBenchmark extends AbstractShiftOperationBenchmark {
+public class ShrOperationBenchmark extends AbstractShiftOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return ShrOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ShrOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShrOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/ShrOperationOptimizedBenchmark.java
@@ -15,14 +15,23 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.ShrOperationOptimized;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the optimized SHR (Shift Right Logical) operation. */
-public class ShrOperationOptimizedBenchmark extends AbstractShiftOperationBenchmark {
+public class ShrOperationOptimizedBenchmark extends AbstractShiftOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return ShrOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new ShrOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SignExtendOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SignExtendOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SignExtendOperation;
 
-public class SignExtendOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class SignExtendOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return SignExtendOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SignExtendOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SubOperation;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class SubOperationBenchmark extends BinaryArithmeticOperationBenchmark {
+public class SubOperationBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param("SUB_RANDOM_RANDOM")
   private String caseName;
 
@@ -37,5 +40,10 @@ public class SubOperationBenchmark extends BinaryArithmeticOperationBenchmark {
   @Override
   protected String opCode() {
     return "SUB";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SubOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SubOperationOptimizedBenchmark.java
@@ -15,12 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SubOperationOptimized;
 
 import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class SubOperationOptimizedBenchmark extends BinaryArithmeticOperationBenchmark {
+public class SubOperationOptimizedBenchmark extends BinaryArithmeticOperationBenchmark
+    implements GasCostBenchmark {
   @Param("SUB_RANDOM_RANDOM")
   private String caseName;
 
@@ -37,5 +40,10 @@ public class SubOperationOptimizedBenchmark extends BinaryArithmeticOperationBen
   @Override
   protected String opCode() {
     return "SUB";
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SubOperationOptimized(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SwapNOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/SwapNOperationBenchmark.java
@@ -15,11 +15,15 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.SwapNOperation;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+
 /** JMH benchmark for the SWAPN operation (EIP-8024). */
-public class SwapNOperationBenchmark extends ImmediateByteOperationBenchmark {
+public class SwapNOperationBenchmark extends ImmediateByteOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected int getOpcode() {
@@ -42,5 +46,10 @@ public class SwapNOperationBenchmark extends ImmediateByteOperationBenchmark {
   protected int getStackDelta() {
     // SWAPN does not change stack size
     return 0;
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new SwapNOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TransientStorageOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TransientStorageOperationBenchmark.java
@@ -35,11 +35,11 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.infra.BenchmarkParams;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Thread)
 public class TransientStorageOperationBenchmark implements GasCostBenchmark {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TransientStorageOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/TransientStorageOperationBenchmark.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.core.MessageFrameTestFixture;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.TLoadOperation;
 import org.hyperledger.besu.evm.operation.TStoreOperation;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -34,12 +35,14 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
 @State(Scope.Thread)
-public class TransientStorageOperationBenchmark {
+public class TransientStorageOperationBenchmark implements GasCostBenchmark {
 
   private OperationBenchmarkHelper operationBenchmarkHelper;
   private TStoreOperation tstore;
@@ -78,6 +81,14 @@ public class TransientStorageOperationBenchmark {
   public void cleanUp() throws Exception {
     operationBenchmarkHelper.cleanUp();
   }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return calc.getTransientStoreOperationGasCost() + calc.getTransientLoadOperationGasCost();
+  }
+
+  @Override
+  public void executeOperation(final Blackhole blackhole) {}
 
   @Benchmark
   public Bytes executeOperation() {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationBenchmark.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.evm.operation.XorOperation;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-public class XorOperationBenchmark extends BinaryOperationBenchmark
-    implements GasCostBenchmark {
+public class XorOperationBenchmark extends BinaryOperationBenchmark implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.XorOperation;
 
-public class XorOperationBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class XorOperationBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return XorOperation.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new XorOperation(calc).getGasCost();
   }
 }

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationOptimizedBenchmark.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/XorOperationOptimizedBenchmark.java
@@ -15,13 +15,22 @@
 package org.hyperledger.besu.ethereum.vm.operations;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.XorOperationOptimized;
 
-public class XorOperationOptimizedBenchmark extends BinaryOperationBenchmark {
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+public class XorOperationOptimizedBenchmark extends BinaryOperationBenchmark
+    implements GasCostBenchmark {
 
   @Override
   protected Operation.OperationResult invoke(final MessageFrame frame) {
     return XorOperationOptimized.staticOperation(frame);
+  }
+
+  @Override
+  public long getGasCost(final BenchmarkParams params, final GasCalculator calc) {
+    return new XorOperationOptimized(calc).getGasCost();
   }
 }


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Wire 33 remaining fixed-cost opcode benchmarks with GasCostBenchmark so the gas profiler emits gas and mgas_per_s for AND, OR, XOR, NOT, SUB, MUL, DIV, MOD, SHL, SHR, SAR, EQ, LT, GT, SLT, SIGNEXTEND, DUPN, SWAPN, EXCHANGE, SELFBALANCE, and their optimized variants.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


