### PR TITLE
Revert "return INVALID for undecodable blockAccessList (#11177)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@
 ### Bug fixes
 - GraphQL `logs(filter: ...)` no longer fails when the filter's `topics` field is omitted or explicitly null, on both the top-level `logs` query and the block-scoped one. The schema declares `topics` nullable and documents "[] or nil matches any topic list", but the field was dereferenced unguarded, so a documented-valid query returned a `DataFetchingException` and `data: null`. [#11188](https://github.com/besu-eth/besu/pull/11188)
 - The Engine API JWT fast-path cache now compares the presented bearer token against the cached one with `MessageDigest.isEqual` over UTF-8 bytes instead of `String.equals`, so the comparison does not return early on the first differing byte.
-- `engine_newPayloadV5` now returns `{status: INVALID}` instead of a `-32602` JSON-RPC error when a present `blockAccessList` cannot be decoded; a missing `blockAccessList` still returns `-32602`. [#11177](https://github.com/besu-eth/besu/pull/11177)
 - `debug_getRawReceipts` now accepts a block hash as well as a block number or tag. [#11156](https://github.com/besu-eth/besu/pull/11156)
 - Support dynamic reorg tracking for transaction receipt logs in `eth_getTransactionReceipt` and `eth_getBlockReceipts` by populating the `removed` field. [#11076](https://github.com/besu-eth/besu/pull/11076)
 - `testing_buildBlockV1` now uses the genesis gas limit as the effective target when no `targetGasLimit` is specified, so the gas limit calculator applies a one-step decrement rather than holding the parent value. [#11166](https://github.com/besu-eth/besu/pull/11166)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ExecutionPayloadV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ExecutionPayloadV4;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.NewPayloadRequestParametersV3;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -110,11 +111,13 @@ public final class EngineNewPayloadV5<
         final String jsonPath = maybeJsonPath.get();
 
         if (jsonPath.equals("blockAccessList")) {
-          return respondWithInvalid(
+          return new JsonRpcErrorResponse(
               reqId,
-              "Failed to decode block access list payload parameter ("
-                  + fieldEx.getOriginalMessage()
-                  + ")");
+              ValidationResult.invalid(
+                  RpcErrorType.INVALID_BLOCK_ACCESS_LIST_PARAMS,
+                  "Failed to decode block access list payload parameter ("
+                      + fieldEx.getOriginalMessage()
+                      + ")"));
         }
       }
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -18,7 +18,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.BOGOTA;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType.INVALID_BLOCK_ACCESS_LIST_PARAMS;
 import static org.mockito.Mockito.times;
@@ -31,7 +30,6 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.PayloadStatusV1;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
@@ -131,10 +129,11 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
 
     final JsonRpcResponse resp = respV5(payloadParam);
 
-    final PayloadStatusV1 res = fromSuccessResp(resp);
-    assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(res.getLatestValidHash()).isEmpty();
-    assertThat(res.getError())
+    final var errorResp = fromErrorResp(resp);
+    assertThat(errorResp.getCode()).isEqualTo(INVALID_BLOCK_ACCESS_LIST_PARAMS.getCode());
+    assertThat(errorResp.getMessage())
+        .isEqualTo("Invalid block access list params (missing or invalid)");
+    assertThat(errorResp.getData())
         .isEqualTo(
             "Failed to decode block access list payload parameter (Illegal character 'z' found at index 0 in hex binary representation)");
     verify(engineCallListener, times(1)).executionEngineCalled();
@@ -153,10 +152,11 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
 
     final JsonRpcResponse resp = respV5(payloadParam);
 
-    final PayloadStatusV1 res = fromSuccessResp(resp);
-    assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(res.getLatestValidHash()).isEmpty();
-    assertThat(res.getError())
+    final var errorResp = fromErrorResp(resp);
+    assertThat(errorResp.getCode()).isEqualTo(INVALID_BLOCK_ACCESS_LIST_PARAMS.getCode());
+    assertThat(errorResp.getMessage())
+        .isEqualTo("Invalid block access list params (missing or invalid)");
+    assertThat(errorResp.getData())
         .isEqualTo(
             "Failed to decode block access list payload parameter (Expected current item to be a list, but it is: BYTE_ELEMENT (at bytes 0-1: [01]))");
     verify(engineCallListener, times(1)).executionEngineCalled();


### PR DESCRIPTION
## Summary
- Reverts #11177, which changed `engine_newPayloadV5` to return `{status: INVALID}` when a present `blockAccessList` cannot be decoded.
- Restores the previous behaviour: return JSON-RPC error `-32602` (`INVALID_BLOCK_ACCESS_LIST_PARAMS`) for undecodable BAL params.
- #11177 introduced a regression; the prior response was the correct one.

## Test plan
- [ ] Unit tests in `EngineNewPayloadV5Test` for invalid hex / invalid RLP `blockAccessList` expect `-32602` again
- [ ] Confirm missing `blockAccessList` still returns `-32602`
- [ ] Smoke-check `engine_newPayloadV5` with malformed BAL against a local node / hive if available
