### PR TITLE
Add eth_getHeaderByHash and eth_getHeaderByNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 
 ### Additions and Improvements
 - Add `eth_getRawTransactionByHash` JSON-RPC method. [#11170](https://github.com/besu-eth/besu/pull/11170)
+- Add `eth_getHeaderByHash` and `eth_getHeaderByNumber`, header-only alternatives to the block getters proposed for standardization in [execution-apis#877](https://github.com/ethereum/execution-apis/pull/877) [#11220](https://github.com/besu-eth/besu/pull/11220)
 - Add JMH `GasProfiler` that emits `mgas_per_s` as a secondary metric on each benchmark iteration using Besu's own `GasCalculator`. Enable with `-PgasProfiler=true`; override the EVM fork with `-PgasProfilerFork=<fork>` (defaults to Osaka). [#10807](https://github.com/besu-eth/besu/pull/10807)
 - Align Kotlin runtime dependencies to 2.4.0 to support plugins compiled against the Kotlin 2.4 API. [#10983](https://github.com/besu-eth/besu/pull/10983)
 - Upgrade log4j to 2.25.5 [#11075](https://github.com/besu-eth/besu/pull/11075)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -94,6 +94,8 @@ public enum RpcMethod {
   ETH_GET_BLOCK_TRANSACTION_COUNT_BY_HASH("eth_getBlockTransactionCountByHash"),
   ETH_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER("eth_getBlockTransactionCountByNumber"),
   ETH_GET_CODE("eth_getCode"),
+  ETH_GET_HEADER_BY_HASH("eth_getHeaderByHash"),
+  ETH_GET_HEADER_BY_NUMBER("eth_getHeaderByNumber"),
   ETH_GET_FILTER_CHANGES("eth_getFilterChanges"),
   ETH_GET_FILTER_LOGS("eth_getFilterLogs"),
   ETH_GET_LOGS("eth_getLogs"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByHash.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockHeaderResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+
+public class EthGetHeaderByHash implements JsonRpcMethod {
+
+  private final Supplier<BlockchainQueries> blockchain;
+
+  public EthGetHeaderByHash(final BlockchainQueries blockchain) {
+    this(Suppliers.ofInstance(blockchain));
+  }
+
+  public EthGetHeaderByHash(final Supplier<BlockchainQueries> blockchain) {
+    this.blockchain = blockchain;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ETH_GET_HEADER_BY_HASH.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    final Hash hash;
+    try {
+      hash = requestContext.getRequiredParameter(0, Hash.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid block hash parameter (index 0)", RpcErrorType.INVALID_BLOCK_HASH_PARAMS, e);
+    }
+
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(),
+        blockchain.get().getBlockHeaderByHash(hash).map(BlockHeaderResult::new).orElse(null));
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByNumber.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockHeaderResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+
+public class EthGetHeaderByNumber implements JsonRpcMethod {
+
+  private final Supplier<BlockchainQueries> blockchain;
+
+  public EthGetHeaderByNumber(final BlockchainQueries blockchain) {
+    this(Suppliers.ofInstance(blockchain));
+  }
+
+  public EthGetHeaderByNumber(final Supplier<BlockchainQueries> blockchain) {
+    this.blockchain = blockchain;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ETH_GET_HEADER_BY_NUMBER.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    final BlockParameter blockParameter;
+    try {
+      blockParameter = requestContext.getRequiredParameter(0, BlockParameter.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid block parameter (index 0)", RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS, e);
+    }
+
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(),
+        headerResult(blockParameter).map(BlockHeaderResult::new).orElse(null));
+  }
+
+  private Optional<BlockHeader> headerResult(final BlockParameter blockParameter) {
+    final BlockchainQueries queries = blockchain.get();
+    if (blockParameter.isPending()) {
+      // The spec returns null for the pending tag and for unresolvable safe/finalized tags.
+      return Optional.empty();
+    }
+    if (blockParameter.isLatest()) {
+      return Optional.of(queries.headBlockHeader());
+    }
+    if (blockParameter.isSafe()) {
+      return queries.safeBlockHeader();
+    }
+    if (blockParameter.isFinalized()) {
+      return queries.finalizedBlockHeader();
+    }
+    if (blockParameter.isEarliest()) {
+      return queries.getBlockHeaderByNumber(0);
+    }
+    return blockParameter.getNumber().flatMap(queries::getBlockHeaderByNumber);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockHeaderResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockHeaderResult.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.tuweni.bytes.Bytes32;
+
+/**
+ * The result of eth_getHeaderByHash and eth_getHeaderByNumber: the execution header fields plus the
+ * derived hash, without size, totalDifficulty, or any body fields.
+ */
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonPropertyOrder({
+  "number",
+  "hash",
+  "mixHash",
+  "parentHash",
+  "nonce",
+  "sha3Uncles",
+  "logsBloom",
+  "transactionsRoot",
+  "stateRoot",
+  "receiptsRoot",
+  "miner",
+  "difficulty",
+  "extraData",
+  "baseFeePerGas",
+  "gasLimit",
+  "gasUsed",
+  "timestamp",
+  "withdrawalsRoot",
+  "blobGasUsed",
+  "excessBlobGas",
+  "parentBeaconBlockRoot",
+  "requestsHash",
+  "blockAccessListHash",
+  "slotNumber"
+})
+public class BlockHeaderResult implements JsonRpcResult {
+
+  private final String number;
+  private final String hash;
+  private final String mixHash;
+  private final String parentHash;
+  private final String nonce;
+  private final String sha3Uncles;
+  private final String logsBloom;
+  private final String transactionsRoot;
+  private final String stateRoot;
+  private final String receiptsRoot;
+  private final String miner;
+  private final String difficulty;
+  private final String extraData;
+  private final String baseFeePerGas;
+  private final String gasLimit;
+  private final String gasUsed;
+  private final String timestamp;
+  private final String withdrawalsRoot;
+  private final String blobGasUsed;
+  private final String excessBlobGas;
+  private final String parentBeaconBlockRoot;
+  private final String requestsHash;
+  private final String blockAccessListHash;
+  private final String slotNumber;
+
+  public BlockHeaderResult(final BlockHeader header) {
+    this.number = Quantity.create(header.getNumber());
+    this.hash = header.getHash().toString();
+    this.mixHash = header.getMixHash().toString();
+    this.parentHash = header.getParentHash().toString();
+    this.nonce = Quantity.longToPaddedHex(header.getNonce(), 8);
+    this.sha3Uncles = header.getOmmersHash().toString();
+    this.logsBloom = header.getLogsBloom().toString();
+    this.transactionsRoot = header.getTransactionsRoot().toString();
+    this.stateRoot = header.getStateRoot().toString();
+    this.receiptsRoot = header.getReceiptsRoot().toString();
+    this.miner = header.getCoinbase().toString();
+    this.difficulty = Quantity.create(header.getDifficulty());
+    this.extraData = header.getExtraData().toString();
+    this.baseFeePerGas = header.getBaseFee().map(Quantity::create).orElse(null);
+    this.gasLimit = Quantity.create(header.getGasLimit());
+    this.gasUsed = Quantity.create(header.getGasUsed());
+    this.timestamp = Quantity.create(header.getTimestamp());
+    this.withdrawalsRoot = header.getWithdrawalsRoot().map(Hash::toString).orElse(null);
+    this.blobGasUsed = header.getBlobGasUsed().map(Quantity::create).orElse(null);
+    this.excessBlobGas = header.getExcessBlobGas().map(Quantity::create).orElse(null);
+    this.parentBeaconBlockRoot =
+        header.getParentBeaconBlockRoot().map(Bytes32::toHexString).orElse(null);
+    this.requestsHash = header.getRequestsHash().map(Hash::toString).orElse(null);
+    this.blockAccessListHash = header.getBalHash().map(Hash::toString).orElse(null);
+    this.slotNumber = header.getOptionalSlotNumber().map(Quantity::create).orElse(null);
+  }
+
+  @JsonGetter(value = "number")
+  public String getNumber() {
+    return number;
+  }
+
+  @JsonGetter(value = "hash")
+  public String getHash() {
+    return hash;
+  }
+
+  @JsonGetter(value = "mixHash")
+  public String getMixHash() {
+    return mixHash;
+  }
+
+  @JsonGetter(value = "parentHash")
+  public String getParentHash() {
+    return parentHash;
+  }
+
+  @JsonGetter(value = "nonce")
+  public String getNonce() {
+    return nonce;
+  }
+
+  @JsonGetter(value = "sha3Uncles")
+  public String getSha3Uncles() {
+    return sha3Uncles;
+  }
+
+  @JsonGetter(value = "logsBloom")
+  public String getLogsBloom() {
+    return logsBloom;
+  }
+
+  @JsonGetter(value = "transactionsRoot")
+  public String getTransactionsRoot() {
+    return transactionsRoot;
+  }
+
+  @JsonGetter(value = "stateRoot")
+  public String getStateRoot() {
+    return stateRoot;
+  }
+
+  @JsonGetter(value = "receiptsRoot")
+  public String getReceiptsRoot() {
+    return receiptsRoot;
+  }
+
+  @JsonGetter(value = "miner")
+  public String getMiner() {
+    return miner;
+  }
+
+  @JsonGetter(value = "difficulty")
+  public String getDifficulty() {
+    return difficulty;
+  }
+
+  @JsonGetter(value = "extraData")
+  public String getExtraData() {
+    return extraData;
+  }
+
+  @JsonGetter(value = "baseFeePerGas")
+  public String getBaseFeePerGas() {
+    return baseFeePerGas;
+  }
+
+  @JsonGetter(value = "gasLimit")
+  public String getGasLimit() {
+    return gasLimit;
+  }
+
+  @JsonGetter(value = "gasUsed")
+  public String getGasUsed() {
+    return gasUsed;
+  }
+
+  @JsonGetter(value = "timestamp")
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  @JsonGetter(value = "withdrawalsRoot")
+  public String getWithdrawalsRoot() {
+    return withdrawalsRoot;
+  }
+
+  @JsonGetter(value = "blobGasUsed")
+  public String getBlobGasUsed() {
+    return blobGasUsed;
+  }
+
+  @JsonGetter(value = "excessBlobGas")
+  public String getExcessBlobGas() {
+    return excessBlobGas;
+  }
+
+  @JsonGetter(value = "parentBeaconBlockRoot")
+  public String getParentBeaconBlockRoot() {
+    return parentBeaconBlockRoot;
+  }
+
+  @JsonGetter(value = "requestsHash")
+  public String getRequestsHash() {
+    return requestsHash;
+  }
+
+  @JsonGetter(value = "blockAccessListHash")
+  public String getBlockAccessListHash() {
+    return blockAccessListHash;
+  }
+
+  @JsonGetter(value = "slotNumber")
+  public String getSlotNumber() {
+    return slotNumber;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -40,6 +40,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetBlockTra
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetCode;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterChanges;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterLogs;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetHeaderByHash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetHeaderByNumber;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetLogs;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetProof;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetRawTransactionByHash;
@@ -146,6 +148,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new EthGetBlockReceipts(blockchainQueries, protocolSchedule),
             new EthGetBlockTransactionCountByNumber(blockchainQueries),
             new EthGetBlockTransactionCountByHash(blockchainQueries),
+            new EthGetHeaderByHash(blockchainQueries),
+            new EthGetHeaderByNumber(blockchainQueries),
             new EthCall(blockchainQueries, transactionSimulator, metricsSystem),
             new EthFeeHistory(
                 protocolSchedule, blockchainQueries, miningCoordinator, apiConfiguration),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByHashTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockHeaderResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EthGetHeaderByHashTest {
+
+  @Mock private BlockchainQueries blockchainQueries;
+  private EthGetHeaderByHash method;
+  private final String JSON_RPC_VERSION = "2.0";
+  private final String ETH_METHOD = "eth_getHeaderByHash";
+  private final String ZERO_HASH = String.valueOf(Hash.ZERO);
+
+  @BeforeEach
+  public void setUp() {
+    method = new EthGetHeaderByHash(blockchainQueries);
+  }
+
+  @Test
+  public void returnsCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(ETH_METHOD);
+  }
+
+  @Test
+  public void exceptionWhenNoParamsSupplied() {
+    assertThatThrownBy(() -> method.response(requestWithParams()))
+        .isInstanceOf(InvalidJsonRpcParameters.class);
+    verifyNoMoreInteractions(blockchainQueries);
+  }
+
+  @Test
+  public void exceptionWhenHashParamInvalid() {
+    assertThatThrownBy(() -> method.response(requestWithParams("hash")))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessage("Invalid block hash parameter (index 0)");
+    verifyNoMoreInteractions(blockchainQueries);
+  }
+
+  @Test
+  public void nullWhenHashUnknown() {
+    when(blockchainQueries.getBlockHeaderByHash(Hash.ZERO)).thenReturn(Optional.empty());
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams(ZERO_HASH));
+    assertThat(response.getResult()).isNull();
+  }
+
+  @Test
+  public void returnsHeaderWhenHashKnown() {
+    final BlockHeader header = new BlockHeaderTestFixture().number(7).buildHeader();
+    when(blockchainQueries.getBlockHeaderByHash(header.getHash())).thenReturn(Optional.of(header));
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams(header.getHash().toString()));
+    final BlockHeaderResult result = (BlockHeaderResult) response.getResult();
+    assertThat(result.getHash()).isEqualTo(header.getHash().toString());
+    assertThat(result.getNumber()).isEqualTo("0x7");
+  }
+
+  private JsonRpcRequestContext requestWithParams(final Object... params) {
+    return new JsonRpcRequestContext(new JsonRpcRequest(JSON_RPC_VERSION, ETH_METHOD, params));
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetHeaderByNumberTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockHeaderResult;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EthGetHeaderByNumberTest {
+
+  @Mock private BlockchainQueries blockchainQueries;
+  private EthGetHeaderByNumber method;
+  private final String JSON_RPC_VERSION = "2.0";
+  private final String ETH_METHOD = "eth_getHeaderByNumber";
+
+  @BeforeEach
+  public void setUp() {
+    method = new EthGetHeaderByNumber(blockchainQueries);
+  }
+
+  @Test
+  public void returnsCorrectMethodName() {
+    assertThat(method.getName()).isEqualTo(ETH_METHOD);
+  }
+
+  @Test
+  public void exceptionWhenNoParamsSupplied() {
+    assertThatThrownBy(() -> method.response(requestWithParams()))
+        .isInstanceOf(InvalidJsonRpcParameters.class);
+    verifyNoMoreInteractions(blockchainQueries);
+  }
+
+  @Test
+  public void returnsHeaderByNumber() {
+    final BlockHeader header = new BlockHeaderTestFixture().number(7).buildHeader();
+    when(blockchainQueries.getBlockHeaderByNumber(7)).thenReturn(Optional.of(header));
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("0x7"));
+    final BlockHeaderResult result = (BlockHeaderResult) response.getResult();
+    assertThat(result.getNumber()).isEqualTo("0x7");
+    assertThat(result.getHash()).isEqualTo(header.getHash().toString());
+  }
+
+  @Test
+  public void returnsHeaderForLatest() {
+    final BlockHeader header = new BlockHeaderTestFixture().number(3).buildHeader();
+    when(blockchainQueries.headBlockHeader()).thenReturn(header);
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("latest"));
+    final BlockHeaderResult result = (BlockHeaderResult) response.getResult();
+    assertThat(result.getNumber()).isEqualTo("0x3");
+  }
+
+  @Test
+  public void nullWhenNumberUnknown() {
+    when(blockchainQueries.getBlockHeaderByNumber(1000)).thenReturn(Optional.empty());
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("0x3e8"));
+    assertThat(response.getResult()).isNull();
+  }
+
+  @Test
+  public void nullForPendingTag() {
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("pending"));
+    assertThat(response.getResult()).isNull();
+    verifyNoMoreInteractions(blockchainQueries);
+  }
+
+  @Test
+  public void nullWhenSafeUnavailable() {
+    when(blockchainQueries.safeBlockHeader()).thenReturn(Optional.empty());
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("safe"));
+    assertThat(response.getResult()).isNull();
+  }
+
+  @Test
+  public void nullWhenFinalizedUnavailable() {
+    when(blockchainQueries.finalizedBlockHeader()).thenReturn(Optional.empty());
+
+    final JsonRpcSuccessResponse response =
+        (JsonRpcSuccessResponse) method.response(requestWithParams("finalized"));
+    assertThat(response.getResult()).isNull();
+  }
+
+  private JsonRpcRequestContext requestWithParams(final Object... params) {
+    return new JsonRpcRequestContext(new JsonRpcRequest(JSON_RPC_VERSION, ETH_METHOD, params));
+  }
+}


### PR DESCRIPTION
Adds `eth_getHeaderByHash` and `eth_getHeaderByNumber`, implementing the spec proposed in ethereum/execution-apis#877 (ethereum/execution-apis#874). geth, Nethermind, and reth already serve these methods.

The result is a new `BlockHeaderResult`: the execution header fields plus the derived `hash`, with no `size`, `totalDifficulty`, or body fields. Fork-conditional fields are omitted for headers that predate them via `NON_ABSENT` null dropping. The result is `null` for an unknown block, for the `pending` tag, and for an unresolvable `safe` or `finalized` tag. The method classes are standalone rather than extending `AbstractBlockParameterMethod`, whose dispatch aliases `pending` to `latest` and returns `-39001` for unresolvable tags; the proposed spec requires `null` for both.

The spec also declares `4444: Pruned history unavailable` for these methods. This implementation does not emit it: Besu retains all headers (history expiry prunes bodies and receipts), so no storage state distinguishes a pruned header from an unknown one. This matches geth, Nethermind, and reth; the error becomes reachable only if header pruning lands.

Includes unit tests for both methods (13 cases) and a CHANGELOG entry. `:ethereum:api:test` passes in full.
