### PR TITLE
increase account trie executor threads for glamsterdam devnet 8

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BlockProcessingExecutors.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/BlockProcessingExecutors.java
@@ -42,7 +42,7 @@ public final class BlockProcessingExecutors {
   private static final int STORAGE_TRIE_THREADS =
       intProperty("besu.block.storageTrieThreads", NCPU * 2);
   private static final int ACCOUNT_TRIE_THREADS =
-      intProperty("besu.block.accountTrieThreads", NCPU);
+      intProperty("besu.block.accountTrieThreads", NCPU * 2);
   private static final int STATE_ROOT_THREADS = intProperty("besu.block.stateRootThreads", 1);
 
   // CPU work: parallel tx execution (EVM, keccak, RLP). Bounded to cores.


### PR DESCRIPTION
## PR description

Cherry-pick of https://github.com/besu-eth/besu/pull/11036 targeting `glamsterdam-devnet-8`.

Increases default `besu.block.accountTrieThreads` from `NCPU` to `NCPU * 2`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
