### PR TITLE
fix(discv4): reduce logging level of invalid packet handling

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/PeerDiscoveryAgentV4.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/PeerDiscoveryAgentV4.java
@@ -59,7 +59,7 @@ import java.util.stream.Stream;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InetAddresses;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.rlp.EndOfRLPException;
+import org.apache.tuweni.rlp.RLPException;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.util.DecodeException;
 import org.slf4j.Logger;
@@ -279,7 +279,7 @@ public abstract class PeerDiscoveryAgentV4 implements PeerDiscoveryAgent {
                 } else {
                   if (err instanceof PeerDiscoveryPacketDecodingException
                       || err instanceof DecodeException
-                      || err instanceof EndOfRLPException) {
+                      || err instanceof RLPException) {
                     LOG.trace(
                         "Discarding invalid peer discovery packet: {}, {}", err.getMessage(), err);
                   } else {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializer.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.util.DecodeException;
 
 @Singleton
 public class PacketDeserializer {
@@ -89,11 +90,11 @@ public class PacketDeserializer {
       final PacketData packetData =
           deserializer.readFrom(RLP.input(message.slice(Packet.PACKET_DATA_INDEX)));
       return packetFactory.create(packetType, packetData, message);
-    } catch (final RLPException e) {
+    } catch (final RLPException
+        | org.apache.tuweni.rlp.RLPException
+        | DecodeException
+        | IllegalArgumentException e) {
       throw new PeerDiscoveryPacketDecodingException("Malformed packet of type: " + packetType, e);
-    } catch (final IllegalArgumentException e) {
-      throw new PeerDiscoveryPacketDecodingException(
-          "Failed decoding packet of type: " + packetType, e);
     }
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/enrresponse/EnrResponsePacketDataRlpReader.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/enrresponse/EnrResponsePacketDataRlpReader.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.enrresponse;
 
+import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 import org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.PacketDataDeserializer;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
@@ -21,8 +22,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLPException;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.util.DecodeException;
 
 @Singleton
 public class EnrResponsePacketDataRlpReader
@@ -43,8 +46,11 @@ public class EnrResponsePacketDataRlpReader
     in.enterList();
     final Bytes requestHash = in.readBytes();
     in.leaveListLenient();
-    final NodeRecord enr = nodeRecordFactory.fromBytes(in.currentListAsBytes());
-
-    return enrResponsePacketDataFactory.create(requestHash, enr);
+    try {
+      final NodeRecord enr = nodeRecordFactory.fromBytes(in.currentListAsBytes());
+      return enrResponsePacketDataFactory.create(requestHash, enr);
+    } catch (final RLPException | DecodeException | IllegalArgumentException e) {
+      throw new PeerDiscoveryPacketDecodingException("Invalid ENR in ENR_RESPONSE packet", e);
+    }
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/PacketDeserializerTest.java
@@ -295,4 +295,21 @@ public class PacketDeserializerTest {
         IdentitySchemaInterpreter.V4.getScheme(), actualPacketData.getEnr().getIdentityScheme());
     Assertions.assertEquals(UInt64.valueOf(567), actualPacketData.getEnr().getSeq());
   }
+
+  @Test
+  public void testDecodeForEnrResponsePacketWithMalformedEnrThrowsDecodingException() {
+    final Bytes sig =
+        Bytes.concatenate(
+            Bytes.repeat((byte) 0x01, 32), Bytes.repeat((byte) 0x01, 32), Bytes.of(0x00));
+    final Bytes type = Bytes.of(PacketType.ENR_RESPONSE.getValue());
+    // RLP list containing request-hash and a malformed/truncated ENR list (claims 45 bytes, has 10)
+    final Bytes body =
+        Bytes.concatenate(
+            Bytes.fromHexString("0xe0821234"), Bytes.fromHexString("0xf82d0102030405060708090a"));
+    final Bytes rest = Bytes.concatenate(sig, type, body);
+    final Bytes packet = Bytes.concatenate(Hash.keccak256(rest), rest);
+
+    Assertions.assertThrows(
+        PeerDiscoveryPacketDecodingException.class, () -> packetDeserializer.decode(packet));
+  }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/enrresponse/EnrResponsePacketDataRlpReaderTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/discv4/internal/packet/enrresponse/EnrResponsePacketDataRlpReaderTest.java
@@ -14,15 +14,21 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.discv4.internal.packet.enrresponse;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 
 import java.util.Map;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.EndOfRLPException;
+import org.apache.tuweni.rlp.InvalidRLPEncodingException;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.schema.IdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.ethereum.beacon.discovery.util.DecodeException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,5 +77,50 @@ public class EnrResponsePacketDataRlpReaderTest {
     Assertions.assertNotNull(result);
     Assertions.assertEquals(requestHash, result.getRequestHash());
     Assertions.assertEquals(enr, result.getEnr());
+  }
+
+  @Test
+  public void testReadFromWithInvalidRlpEncodingThrowsDecodingException() {
+    final BytesValueRLPInput in =
+        new BytesValueRLPInput(
+            Bytes.fromHexString("0xd384deadbeefcd84feebdaed7b836b6579824567"), false);
+
+    Mockito.when(nodeRecordFactory.fromBytes(Mockito.any(Bytes.class)))
+        .thenThrow(new InvalidRLPEncodingException("Insufficient bytes in RLP encoding"));
+
+    assertThatThrownBy(() -> reader.readFrom(in))
+        .isInstanceOf(PeerDiscoveryPacketDecodingException.class)
+        .hasMessageContaining("Invalid ENR in ENR_RESPONSE packet")
+        .hasCauseInstanceOf(InvalidRLPEncodingException.class);
+  }
+
+  @Test
+  public void testReadFromWithEndOfRlpThrowsDecodingException() {
+    final BytesValueRLPInput in =
+        new BytesValueRLPInput(
+            Bytes.fromHexString("0xd384deadbeefcd84feebdaed7b836b6579824567"), false);
+
+    Mockito.when(nodeRecordFactory.fromBytes(Mockito.any(Bytes.class)))
+        .thenThrow(new EndOfRLPException());
+
+    assertThatThrownBy(() -> reader.readFrom(in))
+        .isInstanceOf(PeerDiscoveryPacketDecodingException.class)
+        .hasMessageContaining("Invalid ENR in ENR_RESPONSE packet")
+        .hasCauseInstanceOf(EndOfRLPException.class);
+  }
+
+  @Test
+  public void testReadFromWithDecodeExceptionThrowsDecodingException() {
+    final BytesValueRLPInput in =
+        new BytesValueRLPInput(
+            Bytes.fromHexString("0xd384deadbeefcd84feebdaed7b836b6579824567"), false);
+
+    Mockito.when(nodeRecordFactory.fromBytes(Mockito.any(Bytes.class)))
+        .thenThrow(new DecodeException("decode failed"));
+
+    assertThatThrownBy(() -> reader.readFrom(in))
+        .isInstanceOf(PeerDiscoveryPacketDecodingException.class)
+        .hasMessageContaining("Invalid ENR in ENR_RESPONSE packet")
+        .hasCauseInstanceOf(DecodeException.class);
   }
 }


### PR DESCRIPTION
## PR description

Malformed or truncated `ENR_RESPONSE` packets received over DiscV4 UDP could throw `org.apache.tuweni.rlp.InvalidRLPEncodingException` from `NodeRecordFactory.fromBytes(...)`. Because `PacketDeserializer` only caught Besu's internal `RLPException`, and `PeerDiscoveryAgentV4` only checked for `EndOfRLPException`, these packets escaped to `LOG.error`.

- Wrap `org.apache.tuweni.rlp.RLPException` and `DecodeException` in `PeerDiscoveryPacketDecodingException` within `EnrResponsePacketDataRlpReader` and `PacketDeserializer`.
- Broaden `PeerDiscoveryAgentV4`'s drop condition from `EndOfRLPException` to `org.apache.tuweni.rlp.RLPException` so all Tuweni RLP decode failures are cleanly discarded at `TRACE` level.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`