### PR TITLE
fix(eth): stop flaky failures in transactionOfEncodedSize helper

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
@@ -454,13 +454,25 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
   }
 
   private Transaction transactionOfEncodedSize(final int targetEncodedSize) {
-    final Transaction tx =
-        createBaseTransaction(0)
-            .payload(Bytes.wrap(new byte[targetEncodedSize - encodedOverheadForLargePayload()]))
-            .createTransaction(KEY_PAIR1);
-    // guard the arithmetic above rather than silently testing the wrong size
-    assertThat(tx.getSizeForBlockInclusion()).isEqualTo(targetEncodedSize);
-    return tx;
+    // The ECDSA signature's r/s components are minimally RLP-encoded, so their byte length
+    // varies (about 1 in 256 times a leading zero byte is dropped) depending on the signed
+    // message. Since every payload length signs a different message, the overhead measured
+    // against one transaction isn't guaranteed to carry over exactly to another: adjust and
+    // re-sign until the actual encoded size lands on the target instead of assuming it will.
+    int payloadSize = targetEncodedSize - encodedOverheadForLargePayload();
+    for (int attempt = 0; attempt < 5; attempt++) {
+      final Transaction tx =
+          createBaseTransaction(0)
+              .payload(Bytes.wrap(new byte[payloadSize]))
+              .createTransaction(KEY_PAIR1);
+      final int actualEncodedSize = tx.getSizeForBlockInclusion();
+      if (actualEncodedSize == targetEncodedSize) {
+        return tx;
+      }
+      payloadSize += targetEncodedSize - actualEncodedSize;
+    }
+    throw new AssertionError(
+        "Could not converge on a transaction of encoded size " + targetEncodedSize);
   }
 
   @Test


### PR DESCRIPTION
shouldRejectLocalTransactionExceedingMaxEncodedSize and its siblings
occasionally failed in CI with e.g. "expected: 131073 but was: 131072".
transactionOfEncodedSize sized the payload using an overhead measured from
a separate probe transaction, then asserted the built transaction landed
exactly on the target size. But a transaction's ECDSA signature r/s values
are minimally RLP-encoded, so their byte length depends on the signed
message and occasionally drops a leading zero byte (~1 in 256 times per
component). Since the probe and the transaction under test sign different
payloads, their overhead isn't guaranteed to match, causing the occasional
off-by-one.

Make the helper self-correcting: measure the actual encoded size of the
built transaction and, if it misses the target, adjust the payload length
by the observed delta and re-sign, up to a few attempts.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.com>
