### PR TITLE
Remove unreachable ACCEPTED branch from engine_newPayload

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.ACCEPTED;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID_BLOCK_HASH;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.SYNCING;
@@ -204,7 +203,6 @@ public sealed class EngineNewPayloadV1<
     }
 
     final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(newBlockHeader);
-    final var maybeLatestValidAncestor = mergeCoordinator.getLatestValidAncestor(newBlockHeader);
 
     // 4. Client software MUST validate the payload if it extends the canonical chain, and requisite
     // data for the validation is locally available. The validation process is specified in the
@@ -249,19 +247,17 @@ public sealed class EngineNewPayloadV1<
       return respondWith(reqId, blockParam, null, SYNCING);
     }
 
-    // 6. Client software MUST respond to this method call in the following way:
-    // {status: ACCEPTED, latestValidHash: null, validationError: null} if the following conditions
-    // are met:
-    //    all transactions have non-zero length
-    //    the blockHash of the payload is valid
-    //    the payload doesn't extend the canonical chain
-    //    the payload hasn't been fully validated
-    //    ancestors of a payload are known and comprise a well-formed chain.
-    if (maybeLatestValidAncestor.isEmpty()) {
-      return respondWith(reqId, blockParam, null, ACCEPTED);
-    }
-
-    final Hash latestValidAncestor = maybeLatestValidAncestor.get();
+    // an ancestor is always found here: the parent header is present in the chain (needsSync is
+    // false) and getLatestValidAncestor only returns empty when it is not; this is also why Besu
+    // never responds with ACCEPTED — a payload whose parent is known is always fully validated,
+    // even when it does not extend the canonical chain
+    final Hash latestValidAncestor =
+        mergeCoordinator
+            .getLatestValidAncestor(newBlockHeader)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Internal error: latestValidAncestor should always be present at this point"));
 
     // async precompute sender to improve performance during transaction processing
     asyncPrecomputeSenders(blockParam.getTransactions());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
@@ -18,7 +18,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.SHANGHAI;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.ACCEPTED;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.INVALID_BLOCK_HASH;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.SYNCING;
@@ -203,21 +202,6 @@ public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
     assertThat(res.getLatestValidHash().get()).isEqualTo(mockHash);
     assertThat(res.getStatus()).isEqualTo(INVALID);
     assertThat(res.getError()).isEqualTo("error 42");
-    verify(engineCallListener, times(1)).executionEngineCalled();
-  }
-
-  @Test
-  public void shouldReturnAcceptedOnLatestValidAncestorEmpty() {
-    BlockHeader mockHeader = setupPayloadV1(getMinSupportedTimestamp());
-    when(mergeCoordinator.getLatestValidAncestor(any(BlockHeader.class)))
-        .thenReturn(Optional.empty());
-
-    var resp = resp(requestParams(mockEnginePayloadParam(mockHeader, emptyList())));
-
-    PayloadStatusV1 res = fromSuccessResp(resp);
-    assertThat(res.getLatestValidHash()).isEmpty();
-    assertThat(res.getStatus()).isEqualTo(ACCEPTED);
-    assertThat(res.getError()).isNull();
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 


### PR DESCRIPTION
## PR description

Removes the `engine_newPayload` branch that returns `ACCEPTED` when `getLatestValidAncestor` is empty: it is unreachable, and has been since it was introduced in Feb 2022.

Hive tests pass.

### Why it is unreachable

The branch sits after the `needsSync` check, so by the time it is evaluated the parent header is known to be present in the blockchain. `MergeCoordinator.getLatestValidAncestor(BlockHeader)` only returns empty when the parent is neither in the chain nor resolvable through the bad block manager — its first lookup is the very same `chain.getBlockHeader(parentHash)` that the `needsSync` check is based on. A present parent yields a non-empty result in every case (the parent's hash, or `Hash.ZERO` for a PoW parent). Since headers are never deleted once stored (reorgs via `rewindToBlock` only remap the canonical number→hash index), the two lookups cannot disagree.

### History

Tracing the branch back confirms it never fired in any version of the code:

- **Introduced in `1830d6d95e` (Feb 2022, Kiln testnet spec)** — already dead on arrival: the preceding `latestValidAncestorDescendsFromTerminal` gate returned `false` (→ `INVALID_TERMINAL_BLOCK`) in exactly the empty-ancestor case.
- **From `2458913c8a` (Mar 2022, #3607)** — structurally dead in its current form: a parent-presence gate (`getOrSyncHeaderByHash(parentHash).isEmpty()` → `SYNCING`, later `maybeParentHeader.isEmpty()`, today `needsSync`) has always run first, performing the identical chain lookup. When the post-merge terminal check was later cleaned up, this gate was already in place.
- The recent `engine_newPayload` refactor (#10840) preserved the branch as-is.

This also matches Besu's externally observable behavior: it never returns `ACCEPTED`, because it fully validates every payload whose parent is known, even when the payload does not extend the canonical chain (the spec's "MAY NOT validate if the payload doesn't belong to the canonical chain" is a MAY).

### Changes

- `EngineNewPayloadV1`: drop the `ACCEPTED` branch and the early `maybeLatestValidAncestor` computation; the ancestor is now computed only where it is used (skipping the lookup on the already-present/`SYNCING` early returns) and unwrapped with `orElseThrow()` behind a comment documenting the invariant.
- `EngineNewPayloadV1Test`: remove `shouldReturnAcceptedOnLatestValidAncestorEmpty`, which mocked the impossible state (empty ancestor while the parent header is present).

No changelog entry: no user-facing behavior changes.

## Fixed Issue(s)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply` (`:ethereum:api:spotlessJavaCheck` clean)
- [x] unit tests: `./gradlew build` (`:ethereum:api:test --tests "*EngineNewPayload*"` — full V1–V5 hierarchy passes)
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
