### PR TITLE
Fix WebSocket active connection count drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug fixes
 - Reject malformed RLPx ECIES handshake payloads under 32 bytes cleanly with `InvalidCipherTextException` instead of raising an unhandled `NegativeArraySizeException`. [#11218](https://github.com/besu-eth/besu/pull/11218)
+- WebSocket connections rejected after reaching `--rpc-ws-max-active-connections` no longer increase the active connection count, preventing the counter from drifting upward and incorrectly blocking future connections. [#11225](https://github.com/besu-eth/besu/issues/11225)
 - GraphQL `logs(filter: ...)` no longer fails when the filter's `topics` field is omitted or explicitly null, on both the top-level `logs` query and the block-scoped one. The schema declares `topics` nullable and documents "[] or nil matches any topic list", but the field was dereferenced unguarded, so a documented-valid query returned a `DataFetchingException` and `data: null`. [#11188](https://github.com/besu-eth/besu/pull/11188)
 - The Engine API JWT fast-path cache now compares the presented bearer token against the cached one with `MessageDigest.isEqual` over UTF-8 bytes instead of `String.equals`, so the comparison does not return early on the first differing byte.
 - Fix ENR fork ID not updating after timestamp-scheduled forks when no block lands exactly on the fork timestamp. [#10882](https://github.com/besu-eth/besu/issues/10882)

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -97,6 +97,7 @@ dependencies {
   testImplementation project(path: ':crypto:services', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:core', configuration: 'testArtifacts')
   testImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':metrics:core', configuration: 'testSupportArtifacts')
   testImplementation project(':services:kvstore')
   testImplementation project(':testutil')
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -260,14 +260,13 @@ public class WebSocketService {
   }
 
   private Handler<HttpConnection> connectionHandler() {
-
     return connection -> {
       if (activeConnectionsCount.get() >= maxActiveConnections) {
         // disallow new connections to prevent DoS
         LOG.warn(
             "Rejecting new connection from {}. {}/{} max active connections limit reached.",
             connection.remoteAddress(),
-            activeConnectionsCount.getAndIncrement(),
+            activeConnectionsCount.get(),
             maxActiveConnections);
         connection.close();
       } else {
@@ -276,14 +275,14 @@ public class WebSocketService {
             connection.remoteAddress(),
             activeConnectionsCount.incrementAndGet(),
             maxActiveConnections);
+        connection.closeHandler(
+            c ->
+                LOG.debug(
+                    "Connection closed from {}. Total of active connections: {}/{}",
+                    connection.remoteAddress(),
+                    activeConnectionsCount.decrementAndGet(),
+                    maxActiveConnections));
       }
-      connection.closeHandler(
-          c ->
-              LOG.debug(
-                  "Connection closed from {}. Total of active connections: {}/{}",
-                  connection.remoteAddress(),
-                  activeConnectionsCount.decrementAndGet(),
-                  maxActiveConnections));
     };
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketMeth
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.api.util.TestJsonRpcMethodsUtil;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.Arrays;
@@ -68,6 +69,7 @@ public class WebSocketServiceTest {
   private WebSocketMessageHandler webSocketMessageHandlerSpy;
   private Map<String, JsonRpcMethod> websocketMethods;
   private WebSocketService websocketService;
+  private StubMetricsSystem metricsSystem;
   private HttpClient httpClient;
   private WebSocketClient webSocketClient;
   private final int maxConnections = 5;
@@ -77,6 +79,7 @@ public class WebSocketServiceTest {
   public void before() {
     vertx = Vertx.vertx();
     testContext = new VertxTestContext();
+    metricsSystem = new StubMetricsSystem();
 
     websocketConfiguration = WebSocketConfiguration.createDefault();
     websocketConfiguration.setPort(0);
@@ -120,7 +123,7 @@ public class WebSocketServiceTest {
 
     websocketService =
         new WebSocketService(
-            vertx, websocketConfiguration, webSocketMessageHandlerSpy, new NoOpMetricsSystem());
+            vertx, websocketConfiguration, webSocketMessageHandlerSpy, metricsSystem);
     websocketService.start().join();
   }
 
@@ -170,6 +173,10 @@ public class WebSocketServiceTest {
     rejectionLatch.await(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     assertThat(successLatch.getCount()).isEqualTo(0);
     assertThat(rejectionLatch.getCount()).isEqualTo(0);
+
+    assertThat(metricsSystem.getGaugeValue("active_ws_connection_count"))
+        .as("rejected connections should not increase the active connection count")
+        .isEqualTo(maxConnections);
   }
 
   @Test


### PR DESCRIPTION
## PR description

Rejected WebSocket connections were incrementing `activeConnectionsCount` even though they were not accepted. Repeated rejected connection attempts caused the counter to drift above the configured limit and incorrectly block subsequent connections.

This change:

* Does not increment `activeConnectionsCount` for rejected connections.
* Registers the close handler only for accepted connections.
* Extends `limitActiveConnections` to verify that rejected connections do not increase the `active_ws_connection_count` gauge.
* Adds a changelog entry describing the user impact.

The regression assertion failed before the fix with an expected count of `5.0` and an actual count of `7.0`. It passes after the fix.

Additionally tested with:

* `./gradlew :ethereum:api:check`
* `./gradlew :ethereum:api:test --tests org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketServiceTest`

## Fixed Issue(s)

<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->

<!-- Example: "fixes #2" -->

Fixes #11225

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)