### PR TITLE
newPayload SYNCING response when parent worldstate is not present

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -272,6 +272,12 @@ public sealed class EngineNewPayloadV1<
       return respondWith(reqId, blockParam, newBlockHeader.getHash(), VALID);
     } else {
       logger().debug("New payload is invalid: {}", executionResult);
+      if (executionResult.isWorldStateUnavailable()) {
+        // we respond with SYNCING here to ensure a VALID newPayload is not marked INVALID.
+        // however besu should not trigger a worldstate resync until/unless this chain is
+        // finalized via forkchoiceUpdated.
+        return respondWith(reqId, blockParam, null, SYNCING);
+      }
       if (executionResult.causedBy().isPresent()) {
         Throwable causedBy = executionResult.causedBy().get();
         if (causedBy instanceof StorageException || causedBy instanceof MerkleTrieException) {


### PR DESCRIPTION
## PR description
This is a partial fix / initial response correctness fix for #11238.  

When besu gets a newPayload request which has a parent worldstate that is not present, besu will now return SYNCING rather than INVALID.  This will prevent blacklisting a potentially VALID payload that we cannot validate.

This change does *not* automatically trigger a worldstate resync.  That will be handled in a subsequent PR and should be triggered upon forkchoiceUpdated finalizing a chain for which we do not have the state for a valid ancestor.

It is worth noting that backward sync is not a fix for this case, as we cannot roll the state backward if besu does not have state for any valid ancestor.


Ran hive consume-engine suite against main and this branch to ensure there are no regressions for this response behavior change.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to / partial fix for #11238 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [x] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


