### PR TITLE
EIP-8037: Settle child frame reservoir refills on parent's gas spilled

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     )
   devnetTarConfig(
     group: 'ethereum', name: 'execution-specs',
-    version: 'tests-glamsterdam-devnet@v8.1.3', classifier: 'fixtures_glamsterdam-devnet', ext: 'tar.gz'
+    version: 'tests-glamsterdam-devnet@v8.1.4', classifier: 'fixtures_glamsterdam-devnet', ext: 'tar.gz'
     )
   referenceTestImplementation 'com.fasterxml.jackson.core:jackson-databind'
   referenceTestImplementation 'com.google.guava:guava'

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -1040,6 +1040,25 @@ public class MessageFrame {
     }
     decrementStateGasUsed(amount);
   }
+  /**
+   * EIP-8037: settle state gas into gas_left after a successful child frame merges its spill.
+   *
+   * <p>When a child succeeds, its {@code state_gas_from_gas_left} is absorbed into the parent's
+   * before this step runs. The reservoir may now hold gas that was originally drawn from
+   * {@code gas_left} (charged in a different frame), so it has to be moved from the reservoir to the parent's
+   * execution gas.
+   * {@code evm_state_gas_used} is unchanged — no state creation is undone by this step.
+   */
+  public void settleStateGasOnChildSuccess() {
+    final long reservoir = txValues.stateGasReservoir().get();
+    final long spilled = stateGasSpilled;
+    final long d = Math.min(reservoir, spilled);
+    if (d > 0L) {
+      gasRemaining += d;
+      txValues.stateGasReservoir().set(reservoir - d);
+      stateGasSpilled = spilled - d;
+    }
+  }
 
   // ============================================================
   // End EIP-8037 state gas accounting

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -1040,14 +1040,15 @@ public class MessageFrame {
     }
     decrementStateGasUsed(amount);
   }
+
   /**
    * EIP-8037: settle state gas into gas_left after a successful child frame merges its spill.
    *
    * <p>When a child succeeds, its {@code state_gas_from_gas_left} is absorbed into the parent's
-   * before this step runs. The reservoir may now hold gas that was originally drawn from
-   * {@code gas_left} (charged in a different frame), so it has to be moved from the reservoir to the parent's
-   * execution gas.
-   * {@code evm_state_gas_used} is unchanged — no state creation is undone by this step.
+   * before this step runs. The reservoir may now hold gas that was originally drawn from {@code
+   * gas_left} (charged in a different frame), so it has to be moved from the reservoir to the
+   * parent's execution gas. {@code evm_state_gas_used} is unchanged — no state creation is undone
+   * by this step.
    */
   public void settleStateGasOnChildSuccess() {
     final long reservoir = txValues.stateGasReservoir().get();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -353,6 +353,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
     // failure the child already returned it, and no account was created, so undo that charge.
     if (childFrame.getState() == State.COMPLETED_SUCCESS) {
       frame.incrementStateGasSpilled(childFrame.getStateGasSpilled());
+      frame.settleStateGasOnChildSuccess();
     } else {
       refundCallNewAccountStateGas(frame, childFrame.getRecipientAddress(), childFrame.getValue());
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -269,6 +269,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
       // combined spill rather than only this frame's share.
       frame.incrementStateGasSpilled(childFrame.getStateGasSpilled());
       // EIP-8037: a successful create adds the leaf it was charged for, so the charge stands.
+      frame.settleStateGasOnChildSuccess();
       frame.pushStackItem(Words.fromAddress(createdAddress));
       frame.setReturnData(Bytes.EMPTY);
       onSuccess(frame, createdAddress);

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -2566,14 +2566,9 @@
             <sha256 value="3e2b02d49fe903eda4fd8caca5cbf0d139c470e97e1de9a85299b1b034f97099" origin="Manual"/>
          </artifact>
       </component>
-      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v8.1.1">
-         <artifact name="execution-specs-tests-glamsterdam-devnet@v8.1.1-fixtures_glamsterdam-devnet.tar.gz">
-            <sha256 value="0d15026bd1d9514b646eeb7bb13fe5bc3464ef3529de81ae4107e480254bcd67" origin="Manual, verified against GitHub release digest"/>
-         </artifact>
-      </component>
-      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v8.1.3">
-         <artifact name="execution-specs-tests-glamsterdam-devnet@v8.1.3-fixtures_glamsterdam-devnet.tar.gz">
-            <sha256 value="f87f59b6e2eede5df3462c1784cd6b168fa6d687e36a77b604aeeaf361aaed64" origin="Manual, verified against GitHub release digest"/>
+      <component group="ethereum" name="execution-specs" version="tests-glamsterdam-devnet@v8.1.4">
+         <artifact name="execution-specs-tests-glamsterdam-devnet@v8.1.4-fixtures_glamsterdam-devnet.tar.gz">
+            <sha256 value="aed315489163dc67c4e5607d7bbb8902e8329afe939be58193b125f2e81a85d4" origin="Manual"/>
          </artifact>
       </component>
       <component group="info.picocli" name="picocli" version="4.7.6">


### PR DESCRIPTION
## PR description
For Glamsterdam devnet-8 there was a slight change introduced by this PR: https://github.com/ethereum/EIPs/pull/12265 where if a parent sets a slot without any reservoir and later on a child frame clears it, this added reservoir credit needs to be given back to the parent's execution gas upon child frame termination.
This decreases the gas spilled on the parent and credits the amount back to the parent's execution gas.

Ran `./gradlew ethereum:referencetests:referenceTestsDevnet` and all new added EELS tests pass. There are 44 failures pre-existing and unrelated to the Glamsterdam fork.
