### PR TITLE
update download artifact action to v6

### DIFF
--- a/.github/workflows/acceptance-tests-timing-reports-update.yml
+++ b/.github/workflows/acceptance-tests-timing-reports-update.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get acceptance test reports from latest merged PR
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: ci.yml
           workflow_conclusion: success

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -48,7 +48,7 @@ jobs:
       # `splitTestsByTime.sh` uses the per-test durations in  these XMLs to distribute tests across parallel runners by historical wall-clock time rather than a naive split.
       # If the artifact is missing # (e.g. first run), splitting falls back to round-robin for all tests.
       - name: Get acceptance test reports
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         continue-on-error: true
         with:
           branch: main


### PR DESCRIPTION
Resolves this CVE:

GHSA-5xr6-xhww-33m4 | dawidd6/action-download-artifact v5 | 8.7 | — | Artifact poisoning — CI workflow pins a vulnerable SHA; a malicious artifact from a fork/PR could execute code in the CI environment | Upgrade to action v6+ |
 
Update to this version:
https://github.com/dawidd6/action-download-artifact/releases/tag/v6