### PR TITLE
Fix/chain pruning fresh sync

### DIFF
--- a/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -826,15 +826,17 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
     final ChainPruningStrategy pruningMode = chainPrunerConfiguration.pruningMode();
     final boolean preMergeEnabled = dataStorageConfiguration.getHistoryExpiryPruneEnabled();
 
+    final Optional<ChainDataPruner> chainDataPruner;
     if (pruningMode != ChainPruningStrategy.NONE || preMergeEnabled) {
       LOG.info("Adding ChainDataPruner to observe block added events");
       final AtomicLong chainDataPrunerObserverId = new AtomicLong();
-      final ChainDataPruner chainDataPruner =
+      final ChainDataPruner pruner =
           createChainPruner(
               blockchainStorage,
               () -> blockchain.removeObserver(chainDataPrunerObserverId.get()),
               syncState);
-      chainDataPrunerObserverId.set(blockchain.observeBlockAdded(chainDataPruner));
+      chainDataPrunerObserverId.set(blockchain.observeBlockAdded(pruner));
+      chainDataPruner = Optional.of(pruner);
 
       if (pruningMode == ChainPruningStrategy.ALL) {
         LOG.info(
@@ -863,6 +865,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
             chainPrunerConfiguration.chainPruningFrequency(),
             chainPrunerConfiguration.preMergePruningBlocksQuantity());
       }
+    } else {
+      chainDataPruner = Optional.empty();
     }
 
     final TransactionPool transactionPool =
@@ -907,7 +911,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
             peerTaskExecutor,
             syncState,
             ethProtocolManager,
-            pivotBlockSelector);
+            pivotBlockSelector,
+            chainDataPruner);
 
     ethPeers.setTrailingPeerRequirementsSupplier(synchronizer::calculateTrailingPeerRequirements);
 
@@ -1137,7 +1142,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
       final PeerTaskExecutor peerTaskExecutor,
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager,
-      final PivotBlockSelector pivotBlockSelector) {
+      final PivotBlockSelector pivotBlockSelector,
+      final Optional<ChainDataPruner> chainDataPruner) {
 
     return new DefaultSynchronizer(
         syncConfig,
@@ -1153,7 +1159,8 @@ public abstract class BesuControllerBuilder implements MiningConfigurationOverri
         clock,
         metricsSystem,
         getFullSyncTerminationCondition(protocolContext.getBlockchain()),
-        pivotBlockSelector);
+        pivotBlockSelector,
+        chainDataPruner);
   }
 
   private PivotBlockSelector createPivotSelector(

--- a/app/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
@@ -232,7 +233,8 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
       final PeerTaskExecutor peerTaskExecutor,
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager,
-      final PivotBlockSelector pivotBlockSelector) {
+      final PivotBlockSelector pivotBlockSelector,
+      final Optional<ChainDataPruner> chainDataPruner) {
 
     DefaultSynchronizer sync =
         super.createSynchronizer(
@@ -243,7 +245,8 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
             peerTaskExecutor,
             syncState,
             ethProtocolManager,
-            pivotBlockSelector);
+            pivotBlockSelector,
+            chainDataPruner);
 
     if (genesisConfigOptions.getTerminalTotalDifficulty().isPresent()) {
       LOG.info(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -27,7 +27,9 @@ import org.slf4j.LoggerFactory;
 
 public class ChainDataPruner implements BlockAddedObserver {
   private static final Logger LOG = LoggerFactory.getLogger(ChainDataPruner.class);
-  private static final int LOG_PRE_MERGE_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS = 300;
+  private static final int LOG_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS = 300;
+  /** Catch-up cap per job: a few frequencies, not millions of keys in one txn. */
+  private static final int PRUNE_BATCH_FREQUENCY_MULTIPLIER = 3;
 
   public static final int MAX_PRUNING_THREAD_QUEUE_SIZE = 16;
 
@@ -39,6 +41,7 @@ public class ChainDataPruner implements BlockAddedObserver {
   private final ChainPrunerConfiguration config;
   private final ExecutorService pruningExecutor;
   private final AtomicBoolean logPreMergePruningProgress = new AtomicBoolean(true);
+  private final AtomicBoolean logChainPruningProgress = new AtomicBoolean(true);
 
   public ChainDataPruner(
       final BlockchainStorage blockchainStorage,
@@ -69,8 +72,10 @@ public class ChainDataPruner implements BlockAddedObserver {
 
   private void chainPrunerAction(final BlockAddedEvent event) {
     final long blockNumber = event.getHeader().getNumber();
-    final long storedBlockPruningMark = prunerStorage.getChainPruningMark().orElse(blockNumber);
-    final long storedBalPruningMark = prunerStorage.getBalPruningMark().orElse(blockNumber);
+    // Never default the mark to the current head: during snap, the first BlockAddedEvent is the
+    // tip and that used to persist a mark that skipped all historical blocks (issue #11131).
+    final long storedBlockPruningMark = prunerStorage.getChainPruningMark().orElse(1L);
+    final long storedBalPruningMark = prunerStorage.getBalPruningMark().orElse(1L);
 
     final boolean isBalHashPresent = event.getHeader().getBalHash().isPresent();
     validatePruningMarks(
@@ -122,71 +127,102 @@ public class ChainDataPruner implements BlockAddedObserver {
     final boolean shouldPruneBal =
         config.isBalPruningEnabled() && shouldPrune(balPruningMark, storedBalPruningMark);
 
-    final KeyValueStorageTransaction pruningTransaction = prunerStorage.startTransaction();
+    if (!shouldPruneBlock && !shouldPruneBal) {
+      if (config.isBalPruningEnabled() && event.getHeader().getBalHash().isEmpty()) {
+        final KeyValueStorageTransaction tx = prunerStorage.startTransaction();
+        prunerStorage.setBalPruningMark(tx, event.getHeader().getNumber());
+        tx.commit();
+      }
+      return;
+    }
 
+    final KeyValueStorageTransaction pruningTransaction = prunerStorage.startTransaction();
     long currentChainMark = storedBlockPruningMark;
     long currentBalMark = storedBalPruningMark;
 
-    if (shouldPruneBlock || shouldPruneBal) {
+    final BlockchainStorage.Updater updater = blockchainStorage.updater();
+    // When chain pruning is active, BAL is also active (mode ALL)
+    // When only BAL pruning is active (mode BAL), we prune from storedBalPruningMark to
+    // balPruningMark
+    final long startBlock = shouldPruneBlock ? storedBlockPruningMark : storedBalPruningMark;
+    final long targetEnd = shouldPruneBlock ? blockPruningMark : balPruningMark;
+    final long endBlock = cappedEndBlock(startBlock, targetEnd);
 
-      final BlockchainStorage.Updater updater = blockchainStorage.updater();
-      // When chain pruning is active, BAL is also active (mode ALL)
-      // When only BAL pruning is active (mode BAL), we prune from storedBalPruningMark to
-      // balPruningMark
-      final long startBlock = shouldPruneBlock ? storedBlockPruningMark : storedBalPruningMark;
-      final long endBlock = shouldPruneBlock ? blockPruningMark : balPruningMark;
+    for (long blockNum = startBlock; blockNum <= endBlock; blockNum++) {
+      if (blockNum < 1) {
+        continue;
+      }
+      // In mode ALL: prune chain data up to blockPruningMark, BAL data up to balPruningMark
+      // In mode BAL: only prune BAL data up to balPruningMark
+      final boolean pruneChainAtBlock = shouldPruneBlock && blockNum <= blockPruningMark;
+      final boolean pruneBalAtBlock = shouldPruneBal && blockNum <= balPruningMark;
 
-      for (long blockNum = startBlock; blockNum <= endBlock; blockNum++) {
-        // In mode ALL: prune chain data up to blockPruningMark, BAL data up to balPruningMark
-        // In mode BAL: only prune BAL data up to balPruningMark
-        final boolean pruneChainAtBlock = shouldPruneBlock && blockNum <= blockPruningMark;
-        final boolean pruneBalAtBlock = shouldPruneBal && blockNum <= balPruningMark;
+      if (!pruneChainAtBlock && !pruneBalAtBlock) {
+        continue;
+      }
 
-        if (!pruneChainAtBlock && !pruneBalAtBlock) {
-          continue;
-        }
+      final Collection<Hash> forkBlocks = hashesToPrune(blockNum);
 
-        final Collection<Hash> forkBlocks = prunerStorage.getForkBlocks(blockNum);
-
-        for (final Hash blockHash : forkBlocks) {
-          if (pruneChainAtBlock) {
-            LOG.debug("Pruning chain data at block {}", blockNum);
-            removeChainData(updater, blockHash);
-          }
-          if (pruneBalAtBlock) {
-            LOG.debug("Pruning BAL data at block {}", blockNum);
-            updater.removeBlockAccessList(blockHash);
-          }
-        }
-
+      for (final Hash blockHash : forkBlocks) {
         if (pruneChainAtBlock) {
-          updater.removeBlockHash(blockNum);
-          currentChainMark = blockNum;
-          prunerStorage.removeForkBlocks(pruningTransaction, blockNum);
+          LOG.debug("Pruning chain data at block {}", blockNum);
+          removeChainData(updater, blockHash);
         }
-
         if (pruneBalAtBlock) {
-          currentBalMark = blockNum;
-          // In BAL-only mode, remove fork blocks when pruning BAL data
-          if (!config.isBlockPruningEnabled()) {
-            prunerStorage.removeForkBlocks(pruningTransaction, blockNum);
-          }
+          LOG.debug("Pruning BAL data at block {}", blockNum);
+          updater.removeBlockAccessList(blockHash);
         }
       }
-      updater.commit();
+
+      if (pruneChainAtBlock) {
+        updater.removeBlockHash(blockNum);
+        currentChainMark = blockNum;
+        prunerStorage.removeForkBlocks(pruningTransaction, blockNum);
+      }
+
+      if (pruneBalAtBlock) {
+        currentBalMark = blockNum;
+        // In BAL-only mode, remove fork blocks when pruning BAL data
+        if (!config.isBlockPruningEnabled()) {
+          prunerStorage.removeForkBlocks(pruningTransaction, blockNum);
+        }
+      }
     }
+    updater.commit();
 
     prunerStorage.setChainPruningMark(pruningTransaction, currentChainMark);
-    if (event.getBlock().getHeader().getBalHash().isEmpty()) {
-      // BAL not activated yet just move the marker
+    if (event.getHeader().getBalHash().isEmpty() && !config.isBlockPruningEnabled()) {
+      // BAL not activated yet; only advance the BAL mark in BAL-only mode
       currentBalMark = event.getHeader().getNumber();
     }
     prunerStorage.setBalPruningMark(pruningTransaction, currentBalMark);
     pruningTransaction.commit();
+    final long loggedMark = shouldPruneBlock ? currentChainMark : currentBalMark;
+    LogUtil.throttledLog(
+        () -> LOG.info("Pruned chain data up to block {}", loggedMark),
+        logChainPruningProgress,
+        LOG_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS);
+  }
+
+  private Collection<Hash> hashesToPrune(final long blockNum) {
+    final Collection<Hash> forkBlocks = prunerStorage.getForkBlocks(blockNum);
+    if (forkBlocks.isEmpty()) {
+      // Snap / unsafe import never records fork hashes via BlockAddedEvent
+      blockchainStorage.getBlockHash(blockNum).ifPresent(forkBlocks::add);
+    }
+    return forkBlocks;
   }
 
   private boolean shouldPrune(final long newMark, final long currentMark) {
     return (newMark - currentMark) >= config.chainPruningFrequency();
+  }
+
+  private long cappedEndBlock(final long startBlock, final long targetEnd) {
+    final long frequency = config.chainPruningFrequency();
+    if (frequency <= 0) {
+      return targetEnd;
+    }
+    return Math.min(targetEnd, startBlock + frequency * PRUNE_BATCH_FREQUENCY_MULTIPLIER - 1);
   }
 
   private void removeChainData(final BlockchainStorage.Updater updater, final Hash blockHash) {
@@ -249,7 +285,7 @@ public class ChainDataPruner implements BlockAddedObserver {
             LogUtil.throttledLog(
                 () -> LOG.info("Pruned pre-merge blocks up to {}", expectedNewPruningMark),
                 logPreMergePruningProgress,
-                LOG_PRE_MERGE_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS);
+                LOG_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS);
             if (expectedNewPruningMark == mergeBlock) {
               LOG.info("Done pruning pre-merge blocks.");
               LOG.debug("Unsubscribing from block added event observation");

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -15,11 +15,13 @@
 package org.hyperledger.besu.ethereum.chain;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import org.hyperledger.besu.util.log.LogUtil;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
@@ -28,6 +30,7 @@ import org.slf4j.LoggerFactory;
 public class ChainDataPruner implements BlockAddedObserver {
   private static final Logger LOG = LoggerFactory.getLogger(ChainDataPruner.class);
   private static final int LOG_PRUNING_PROGRESS_REPEAT_DELAY_SECONDS = 300;
+
   /** Catch-up cap per job: a few frequencies, not millions of keys in one txn. */
   private static final int PRUNE_BATCH_FREQUENCY_MULTIPLIER = 3;
 
@@ -87,7 +90,30 @@ public class ChainDataPruner implements BlockAddedObserver {
     }
 
     pruningExecutor.submit(
-        () -> pruneChainAndBalData(event, storedBlockPruningMark, storedBalPruningMark));
+        () ->
+            pruneChainAndBalData(event.getHeader(), storedBlockPruningMark, storedBalPruningMark));
+  }
+
+  /**
+   * Drives catch-up chain/BAL pruning from the unsafe snap-sync import path, which bypasses {@code
+   * BlockAddedEvent} (see {@code DefaultBlockchain#unsafeImportSyncBodiesAndReceipts}). Called once
+   * per imported batch with the new chain head header. No-op unless block/BAL pruning is enabled;
+   * pre-merge-only pruning is driven by the observer path.
+   */
+  public void pruneForSyncedHead(final BlockHeader header) {
+    if (pruningMode != PruningMode.CHAIN_PRUNING) {
+      return;
+    }
+    final long storedBlockPruningMark = prunerStorage.getChainPruningMark().orElse(1L);
+    final long storedBalPruningMark = prunerStorage.getBalPruningMark().orElse(1L);
+    try {
+      pruningExecutor.submit(
+          () -> pruneChainAndBalData(header, storedBlockPruningMark, storedBalPruningMark));
+    } catch (final RejectedExecutionException e) {
+      LOG.debug(
+          "Chain pruning task rejected for head {}; will retry on the next imported batch",
+          header.getNumber());
+    }
   }
 
   private void validatePruningMarks(
@@ -114,13 +140,12 @@ public class ChainDataPruner implements BlockAddedObserver {
   }
 
   private void pruneChainAndBalData(
-      final BlockAddedEvent event,
+      final BlockHeader header,
       final long storedBlockPruningMark,
       final long storedBalPruningMark) {
 
-    final long blockPruningMark =
-        event.getHeader().getNumber() - config.chainPruningBlocksRetained();
-    final long balPruningMark = event.getHeader().getNumber() - config.chainPruningBalsRetained();
+    final long blockPruningMark = header.getNumber() - config.chainPruningBlocksRetained();
+    final long balPruningMark = header.getNumber() - config.chainPruningBalsRetained();
 
     final boolean shouldPruneBlock =
         config.isBlockPruningEnabled() && shouldPrune(blockPruningMark, storedBlockPruningMark);
@@ -128,9 +153,9 @@ public class ChainDataPruner implements BlockAddedObserver {
         config.isBalPruningEnabled() && shouldPrune(balPruningMark, storedBalPruningMark);
 
     if (!shouldPruneBlock && !shouldPruneBal) {
-      if (config.isBalPruningEnabled() && event.getHeader().getBalHash().isEmpty()) {
+      if (config.isBalPruningEnabled() && header.getBalHash().isEmpty()) {
         final KeyValueStorageTransaction tx = prunerStorage.startTransaction();
-        prunerStorage.setBalPruningMark(tx, event.getHeader().getNumber());
+        prunerStorage.setBalPruningMark(tx, header.getNumber());
         tx.commit();
       }
       return;
@@ -191,9 +216,9 @@ public class ChainDataPruner implements BlockAddedObserver {
     updater.commit();
 
     prunerStorage.setChainPruningMark(pruningTransaction, currentChainMark);
-    if (event.getHeader().getBalHash().isEmpty() && !config.isBlockPruningEnabled()) {
+    if (header.getBalHash().isEmpty() && !config.isBlockPruningEnabled()) {
       // BAL not activated yet; only advance the BAL mark in BAL-only mode
-      currentBalMark = event.getHeader().getNumber();
+      currentBalMark = header.getNumber();
     }
     prunerStorage.setBalPruningMark(pruningTransaction, currentBalMark);
     pruningTransaction.commit();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -1612,6 +1612,87 @@ public class ChainDataPrunerTest {
     checkBlocks(blockchain, mergeBlock, blockchain.getChainHeadBlockNumber(), Optional::isPresent);
   }
 
+  @Test
+  public void prunesBlocksImportedWithoutBlockAddedEvents() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions(),
+            false);
+    final Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+
+    final int importedWithoutObserver = 40;
+    gen.blockSequence(genesisBlock, importedWithoutObserver)
+        .forEach(block -> blockchain.appendBlock(block, gen.receipts(block)));
+
+    final int retention = 8;
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            () -> {},
+            new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
+            0,
+            ChainDataPruner.PruningMode.CHAIN_PRUNING,
+            new ChainPrunerConfiguration(
+                ChainDataPruner.ChainPruningStrategy.ALL, retention, retention, retention, 0, 0),
+            new BlockingExecutor());
+    blockchain.observeBlockAdded(chainDataPruner);
+
+    gen.blockSequence(blockchain.getChainHeadBlock(), 1)
+        .forEach(block -> blockchain.appendBlock(block, gen.receipts(block)));
+
+    final long head = blockchain.getChainHeadBlockNumber();
+    assertThat(blockchain.getBlockHeader(0)).isPresent();
+    assertThat(blockchain.getBlockHeader(head - retention)).isEmpty();
+    assertThat(blockchain.getBlockHeader(head - retention + 1)).isPresent();
+  }
+
+  @Test
+  public void doesNotInitializePruningMarkToHeadOnFirstEvent() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions(),
+            false);
+    final ChainDataPrunerStorage prunerStorage =
+        new ChainDataPrunerStorage(new InMemoryKeyValueStorage());
+    final Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+
+    gen.blockSequence(genesisBlock, 30)
+        .forEach(block -> blockchain.appendBlock(block, gen.receipts(block)));
+
+    final int retention = 10;
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            () -> {},
+            prunerStorage,
+            0,
+            ChainDataPruner.PruningMode.CHAIN_PRUNING,
+            new ChainPrunerConfiguration(
+                ChainDataPruner.ChainPruningStrategy.ALL, retention, retention, retention, 0, 0),
+            new BlockingExecutor());
+    blockchain.observeBlockAdded(chainDataPruner);
+
+    gen.blockSequence(blockchain.getChainHeadBlock(), 1)
+        .forEach(block -> blockchain.appendBlock(block, gen.receipts(block)));
+
+    final long head = blockchain.getChainHeadBlockNumber();
+    assertThat(prunerStorage.getChainPruningMark()).hasValue(head - retention);
+    assertThat(blockchain.getBlockHeader(head)).isPresent();
+    assertThat(blockchain.getBlockHeader(head - retention)).isEmpty();
+  }
+
   /**
    * Attaches a temporary log4j appender to the given class's logger, runs the action, and returns
    * all captured log events. The appender is properly stopped and removed regardless of outcome.

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -1653,6 +1653,47 @@ public class ChainDataPrunerTest {
   }
 
   @Test
+  public void prunesBlocksDrivenBySyncImportHookWithoutObserverEvents() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions(),
+            false);
+    final Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+
+    final int importedWithoutObserver = 40;
+    gen.blockSequence(genesisBlock, importedWithoutObserver)
+        .forEach(block -> blockchain.appendBlock(block, gen.receipts(block)));
+
+    final int retention = 8;
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            () -> {},
+            new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
+            0,
+            ChainDataPruner.PruningMode.CHAIN_PRUNING,
+            new ChainPrunerConfiguration(
+                ChainDataPruner.ChainPruningStrategy.ALL, retention, retention, retention, 0, 0),
+            new BlockingExecutor());
+
+    // The snap-sync unsafe import path never fires BlockAddedEvents, so the pruner is not
+    // registered as an observer; catch-up pruning is driven by pruneForSyncedHead, which the
+    // blockchain invokes via the sync-import pruning hook after each unsafe batch commits.
+    chainDataPruner.pruneForSyncedHead(blockchain.getChainHeadBlock().getHeader());
+
+    final long head = blockchain.getChainHeadBlockNumber();
+    assertThat(blockchain.getBlockHeader(0)).isPresent();
+    assertThat(blockchain.getBlockHeader(head - retention)).isEmpty();
+    assertThat(blockchain.getBlockHeader(head - retention + 1)).isPresent();
+  }
+
+  @Test
   public void doesNotInitializePruningMarkToHeadOnFirstEvent() {
     final BlockDataGenerator gen = new BlockDataGenerator();
     final BlockchainStorage blockchainStorage =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.hyperledger.besu.consensus.merge.ForkchoiceEvent;
 import org.hyperledger.besu.consensus.merge.UnverifiedForkchoiceListener;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.manager.ChainHeadEstimate;
@@ -82,7 +83,8 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
       final Clock clock,
       final MetricsSystem metricsSystem,
       final SyncTerminationCondition terminationCondition,
-      final PivotBlockSelector pivotBlockSelector) {
+      final PivotBlockSelector pivotBlockSelector,
+      final Optional<ChainDataPruner> chainDataPruner) {
     this.syncState = syncState;
     this.pivotBlockSelector = pivotBlockSelector;
     this.protocolContext = protocolContext;
@@ -145,7 +147,8 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
                       worldStateStorageCoordinator,
                       syncState,
                       clock,
-                      syncDurationMetrics);
+                      syncDurationMetrics,
+                      chainDataPruner);
           default -> () -> Optional.empty();
         };
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStep.java
@@ -17,11 +17,13 @@ package org.hyperledger.besu.ethereum.eth.sync.common;
 import static org.hyperledger.besu.util.log.LogUtil.throttledLog;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.core.SyncBlockWithReceipts;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -38,6 +40,7 @@ public class ImportSyncBlocksStep implements Consumer<List<SyncBlockWithReceipts
   private final SyncState syncState;
   private final long startBlock;
   private final boolean transactionIndexingEnabled;
+  private final Optional<ChainDataPruner> chainDataPruner;
   private final AtomicBoolean isTimeToUpdate = new AtomicBoolean(true);
   private final long pivotHeaderNumber;
 
@@ -47,13 +50,15 @@ public class ImportSyncBlocksStep implements Consumer<List<SyncBlockWithReceipts
       final SyncState syncState,
       final long startBlock,
       final long pivotHeaderNumber,
-      final boolean transactionIndexingEnabled) {
+      final boolean transactionIndexingEnabled,
+      final Optional<ChainDataPruner> chainDataPruner) {
     this.protocolContext = protocolContext;
     this.ethContext = ethContext;
     this.syncState = syncState;
     this.startBlock = startBlock;
     this.pivotHeaderNumber = pivotHeaderNumber;
     this.transactionIndexingEnabled = transactionIndexingEnabled;
+    this.chainDataPruner = chainDataPruner;
   }
 
   @Override
@@ -62,6 +67,11 @@ public class ImportSyncBlocksStep implements Consumer<List<SyncBlockWithReceipts
         .getBlockchain()
         .unsafeImportSyncBodiesAndReceipts(blocksWithReceipts, transactionIndexingEnabled);
     final long lastBlock = blocksWithReceipts.getLast().getNumber();
+
+    // The unsafe snap-sync import path bypasses BlockAddedEvent observers, so drive catch-up
+    // chain/BAL pruning explicitly after each batch commits.
+    chainDataPruner.ifPresent(
+        pruner -> pruner.pruneForSyncedHead(blocksWithReceipts.getLast().getBlock().getHeader()));
 
     syncState.setSyncProgress(startBlock, lastBlock, pivotHeaderNumber);
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActions.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.NoAvailablePeersException;
@@ -40,6 +41,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -62,6 +64,7 @@ public class PivotSyncActions {
   protected final Counter pivotBlockSelectionCounter;
   protected final AtomicLong pivotBlockGauge = new AtomicLong(0);
   protected final java.nio.file.Path fastSyncDataDirectory;
+  protected final Optional<ChainDataPruner> chainDataPruner;
 
   private volatile PivotUpdateListener chainDownloaderListener;
 
@@ -74,7 +77,8 @@ public class PivotSyncActions {
       final SyncState syncState,
       final PivotBlockSelector pivotBlockSelector,
       final MetricsSystem metricsSystem,
-      final Path fastSyncDataDirectory) {
+      final Path fastSyncDataDirectory,
+      final Optional<ChainDataPruner> chainDataPruner) {
     this.syncConfig = syncConfig;
     this.worldStateStorageCoordinator = worldStateStorageCoordinator;
     this.protocolSchedule = protocolSchedule;
@@ -84,6 +88,7 @@ public class PivotSyncActions {
     this.pivotBlockSelector = pivotBlockSelector;
     this.metricsSystem = metricsSystem;
     this.fastSyncDataDirectory = fastSyncDataDirectory;
+    this.chainDataPruner = chainDataPruner;
 
     pivotBlockSelectionCounter =
         metricsSystem.createCounter(
@@ -187,7 +192,8 @@ public class PivotSyncActions {
         metricsSystem,
         currentState,
         syncDurationMetrics,
-        fastSyncDataDirectory);
+        fastSyncDataDirectory,
+        chainDataPruner);
   }
 
   private CompletableFuture<SnapSyncProcessState> downloadPivotBlockHeaderByHash(final Hash hash) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
@@ -58,7 +59,8 @@ public class SnapDownloaderFactory {
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final SyncState syncState,
       final Clock clock,
-      final SyncDurationMetrics syncDurationMetrics) {
+      final SyncDurationMetrics syncDurationMetrics,
+      final Optional<ChainDataPruner> chainDataPruner) {
     if (Boolean.TRUE.equals(syncConfig.getSnapSyncConfiguration().isSnap2Enabled())) {
       // The snap/2 controller will be created here; until then v2 uses v1 behavior.
     }
@@ -75,7 +77,8 @@ public class SnapDownloaderFactory {
         worldStateStorageCoordinator,
         syncState,
         clock,
-        syncDurationMetrics);
+        syncDurationMetrics,
+        chainDataPruner);
   }
 
   public static Optional<SnapSyncController> createSnapDownloaderV1(
@@ -90,7 +93,8 @@ public class SnapDownloaderFactory {
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final SyncState syncState,
       final Clock clock,
-      final SyncDurationMetrics syncDurationMetrics) {
+      final SyncDurationMetrics syncDurationMetrics,
+      final Optional<ChainDataPruner> chainDataPruner) {
     final boolean snap2Enabled =
         Boolean.TRUE.equals(syncConfig.getSnapSyncConfiguration().isSnap2Enabled());
 
@@ -171,7 +175,8 @@ public class SnapDownloaderFactory {
                 syncState,
                 pivotBlockSelector,
                 metricsSystem,
-                syncDataDirectory),
+                syncDataDirectory,
+                chainDataPruner),
             snapWorldStateDownloader,
             syncDataDirectory,
             snapSyncState,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloadPipelineFactory.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -38,6 +39,7 @@ import org.hyperledger.besu.services.pipeline.PipelineBuilder;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +57,7 @@ public class SnapSyncChainDownloadPipelineFactory {
   protected final EthContext ethContext;
   protected final SnapSyncProcessState fastSyncState;
   protected final MetricsSystem metricsSystem;
+  protected final Optional<ChainDataPruner> chainDataPruner;
 
   public SnapSyncChainDownloadPipelineFactory(
       final SynchronizerConfiguration syncConfig,
@@ -62,13 +65,15 @@ public class SnapSyncChainDownloadPipelineFactory {
       final ProtocolContext protocolContext,
       final EthContext ethContext,
       final SnapSyncProcessState fastSyncState,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final Optional<ChainDataPruner> chainDataPruner) {
     this.syncConfig = syncConfig;
     this.protocolSchedule = protocolSchedule;
     this.protocolContext = protocolContext;
     this.ethContext = ethContext;
     this.fastSyncState = fastSyncState;
     this.metricsSystem = metricsSystem;
+    this.chainDataPruner = chainDataPruner;
   }
 
   /**
@@ -185,7 +190,8 @@ public class SnapSyncChainDownloadPipelineFactory {
             syncState,
             anchorBlock,
             pivotHeader.getNumber(),
-            syncConfig.getSnapSyncConfiguration().isSnapSyncTransactionIndexingEnabled());
+            syncConfig.getSnapSyncConfiguration().isSnapSyncTransactionIndexingEnabled(),
+            chainDataPruner);
 
     return PipelineBuilder.createPipelineFrom(
             "forwardHeaderSource",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncChainDownloader.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.ChainDataPruner;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -180,11 +181,18 @@ public class SnapSyncChainDownloader
       final MetricsSystem metricsSystem,
       final SnapSyncProcessState fastSyncState,
       final SyncDurationMetrics syncDurationMetrics,
-      final Path fastSyncDataDirectory) {
+      final Path fastSyncDataDirectory,
+      final Optional<ChainDataPruner> chainDataPruner) {
 
     final SnapSyncChainDownloadPipelineFactory pipelineFactory =
         new SnapSyncChainDownloadPipelineFactory(
-            config, protocolSchedule, protocolContext, ethContext, fastSyncState, metricsSystem);
+            config,
+            protocolSchedule,
+            protocolContext,
+            ethContext,
+            fastSyncState,
+            metricsSystem,
+            chainDataPruner);
 
     final BlockHeader pivotBlockHeader =
         fastSyncState

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStepTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.eth.core.Utils;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,8 @@ public class ImportSyncBlocksStepTest {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
 
     importSyncBlocksStep =
-        new ImportSyncBlocksStep(protocolContext, null, syncState, 0L, 10L, false);
+        new ImportSyncBlocksStep(
+            protocolContext, null, syncState, 0L, 10L, false, Optional.empty());
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/PivotSyncActionsTest.java
@@ -504,7 +504,8 @@ public class PivotSyncActionsTest {
           new SyncState(blockchain, ethContext.getEthPeers(), true, Optional.empty()),
           pivotBlockSelector,
           new NoOpMetricsSystem(),
-          java.nio.file.Files.createTempDirectory("checkpoint-sync-test"));
+          java.nio.file.Files.createTempDirectory("checkpoint-sync-test"),
+          Optional.empty());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the chain data pruning mechanism, especially to support pruning during and after snap-sync. The changes include enhancements to the `ChainDataPruner` to allow catch-up pruning even when block events are not fired

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


