### PR TITLE
Stop callTracer forcing full EVM memory capture on every opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,14 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
-- `debug_traceTransaction`, `debug_traceCall` and `debug_traceBlock*` no longer capture a full EVM memory snapshot on every opcode when a non-default tracer (`callTracer`, `prestateTracer`, `4byteTracer`) is requested without `enableMemory`. A contract holding a large memory buffer retained one full snapshot per memory-writing opcode, which could exhaust the heap.
-- `callTracer` now reports the correct `input` for CREATE2, and for call and create operations that do not spawn a callee frame.
 - Reject malformed RLPx ECIES handshake payloads under 32 bytes cleanly with `InvalidCipherTextException` instead of raising an unhandled `NegativeArraySizeException`. [#11218](https://github.com/besu-eth/besu/pull/11218)
 - GraphQL `logs(filter: ...)` no longer fails when the filter's `topics` field is omitted or explicitly null, on both the top-level `logs` query and the block-scoped one. The schema declares `topics` nullable and documents "[] or nil matches any topic list", but the field was dereferenced unguarded, so a documented-valid query returned a `DataFetchingException` and `data: null`. [#11188](https://github.com/besu-eth/besu/pull/11188)
 - The Engine API JWT fast-path cache now compares the presented bearer token against the cached one with `MessageDigest.isEqual` over UTF-8 bytes instead of `String.equals`, so the comparison does not return early on the first differing byte.
 - Fix ENR fork ID not updating after timestamp-scheduled forks when no block lands exactly on the fork timestamp. [#10882](https://github.com/besu-eth/besu/issues/10882)
 - Besu no longer announces the EIP-4844 version 0 size of a blob transaction while serving the EIP-7594 version 1 (cell proofs) encoding. From Osaka on, a locally submitted version 0 blob transaction is upgraded to version 1 before it is pooled, but the pre-upgrade transaction was the one broadcast, so `NewPooledTransactionHashes` under-announced it by 6,226 bytes per blob against what `GetPooledTransactions` then served, and go-ethereum peers responded with `dropPeer()`. [#11203](https://github.com/besu-eth/besu/pull/11203)
 - `admin_logsRemoveCache` no longer reports `Cache Removed` when nothing was removed. `TransactionLogBloomCacher.removeSegments` skips the whole deletion while log bloom caching is in progress, so the RPC returned success while every cache file was still on disk. It now returns an error in that case. [#11080](https://github.com/besu-eth/besu/pull/11080)
+- `debug_traceTransaction`, `debug_traceCall` and `debug_traceBlock*` no longer capture a full EVM memory snapshot on every opcode when a non-default tracer (`callTracer`, `prestateTracer`, `4byteTracer`) is requested without `enableMemory`. A contract holding a large memory buffer retained one full snapshot per memory-writing opcode, which could exhaust the heap.
+- `callTracer` now reports the correct `input` for CREATE2, and for call and create operations that do not spawn a callee frame.
 
 ### Additions and Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - `--rpc-tx-feecap` will treat a value of 0 as limiting fees to 0. Today it treats 0 as "do not cap fees". To achieve similar behaviour set it to a suitably large value to effectively prevent any fee capping.
 
 ### Bug fixes
+- `debug_traceTransaction`, `debug_traceCall` and `debug_traceBlock*` no longer capture a full EVM memory snapshot on every opcode when a non-default tracer (`callTracer`, `prestateTracer`, `4byteTracer`) is requested without `enableMemory`. A contract holding a large memory buffer retained one full snapshot per memory-writing opcode, which could exhaust the heap.
+- `callTracer` now reports the correct `input` for CREATE2, and for call and create operations that do not spawn a callee frame.
 - Reject malformed RLPx ECIES handshake payloads under 32 bytes cleanly with `InvalidCipherTextException` instead of raising an unhandled `NegativeArraySizeException`. [#11218](https://github.com/besu-eth/besu/pull/11218)
 - GraphQL `logs(filter: ...)` no longer fails when the filter's `topics` field is omitted or explicitly null, on both the top-level `logs` query and the block-scoped one. The schema declares `topics` nullable and documents "[] or nil matches any topic list", but the field was dereferenced unguarded, so a documented-valid query returned a `DataFetchingException` and `data: null`. [#11188](https://github.com/besu-eth/besu/pull/11188)
 - The Engine API JWT fast-path cache now compares the presented bearer token against the cached one with `MessageDigest.isEqual` over UTF-8 bytes instead of `String.equals`, so the comparison does not return early on the first differing byte.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
@@ -131,10 +131,6 @@ public interface TransactionTraceParams {
       builder.traceMemory(enableMemory());
     } else if (disableMemoryNullable() != null) {
       builder.traceMemory(!disableMemory());
-    } else if (tracerType != TracerType.OPCODE_TRACER) {
-      // Non-opcode tracers (e.g. callTracer) need memory capture enabled for internal
-      // operations such as extracting CREATE init code, even when disableMemory is not set
-      builder.traceMemory(true);
     }
     if (disableStackNullable() != null) {
       builder.traceStack(!disableStack());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/OpcodeCategory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/OpcodeCategory.java
@@ -97,6 +97,17 @@ public enum OpcodeCategory {
   }
 
   /**
+   * Checks whether a call opcode takes a value argument, which shifts every argument below it one
+   * slot deeper on the stack.
+   *
+   * @param opcode the opcode string
+   * @return true if it's CALL or CALLCODE
+   */
+  public static boolean hasValueArgument(final String opcode) {
+    return CALL_OP.equals(opcode) || CALLCODE_OP.equals(opcode);
+  }
+
+  /**
    * Checks if the opcode is a return operation.
    *
    * @param opcode the opcode string

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/StackExtractor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/StackExtractor.java
@@ -48,23 +48,18 @@ import org.slf4j.LoggerFactory;
 public final class StackExtractor {
   private static final Logger LOG = LoggerFactory.getLogger(StackExtractor.class);
 
-  // Stack position constants for CALL operations
-  // Stack layout (from top): gas, to, value, inOffset, inSize, outOffset, outSize
-  private static final int CALL_STACK_VALUE_OFFSET = 3; // 3rd from top
-  private static final int CALL_STACK_TO_OFFSET = 2; // 2nd from top
-  private static final int CALL_STACK_IN_OFFSET_POS = 4; // 4th from top
-  private static final int CALL_STACK_IN_SIZE_POS = 3; // 3rd from top (for size, after value)
+  // Stack indices, counted from the top as the EVM indexes the operand stack.
+  // CALL/CALLCODE:            gas, to, value, inOffset, inSize, outOffset, outSize
+  // DELEGATECALL/STATICCALL:  gas, to,        inOffset, inSize, outOffset, outSize
+  private static final int CALL_TO_INDEX = 1;
+  private static final int CALL_VALUE_INDEX = 2;
+  private static final int CALL_IN_OFFSET_INDEX = 3;
+  private static final int DELEGATECALL_IN_OFFSET_INDEX = 2;
 
-  // Stack position constants for CREATE operations
-  // CREATE stack layout (from top of stack): value, offset, size
-  // When accessed as stack[length-N], this translates to:
-  private static final int CREATE_STACK_VALUE_POS = 1; // Top of stack (stack[length-1])
-  private static final int CREATE_STACK_OFFSET_POS = 2; // 2nd from top
-  private static final int CREATE_STACK_SIZE_POS = 3; // 3rd from top
-
-  // CREATE2 stack layout: value, offset, size, salt
-  private static final int CREATE2_STACK_OFFSET_POS = 3; // 3rd from top
-  private static final int CREATE2_STACK_SIZE_POS = 2; // 2nd from top
+  // CREATE: value, offset, size          CREATE2: value, offset, size, salt
+  private static final int CREATE_VALUE_INDEX = 0;
+  private static final int CREATE_OFFSET_INDEX = 1;
+  private static final int CREATE_SIZE_INDEX = 2;
 
   private static final String ZERO_VALUE = "0x0";
 
@@ -81,8 +76,8 @@ public final class StackExtractor {
   public static String extractCallValue(final TraceFrame frame) {
     return frame
         .getStack()
-        .filter(stack -> stack.length >= CALL_STACK_VALUE_OFFSET)
-        .map(stack -> Wei.wrap(stack[stack.length - CALL_STACK_VALUE_OFFSET]).toShortHexString())
+        .filter(stack -> stack.length > CALL_VALUE_INDEX)
+        .map(stack -> Wei.wrap(stackItem(stack, CALL_VALUE_INDEX)).toShortHexString())
         .orElse(ZERO_VALUE);
   }
 
@@ -97,8 +92,8 @@ public final class StackExtractor {
   public static String extractCreateValue(final TraceFrame frame) {
     return frame
         .getStack()
-        .filter(stack -> stack.length >= 3) // CREATE has at least 3 items: value, offset, size
-        .map(stack -> Wei.wrap(stack[stack.length - CREATE_STACK_VALUE_POS]).toShortHexString())
+        .filter(stack -> stack.length > CREATE_SIZE_INDEX)
+        .map(stack -> Wei.wrap(stackItem(stack, CREATE_VALUE_INDEX)).toShortHexString())
         .orElse(ZERO_VALUE);
   }
 
@@ -111,47 +106,53 @@ public final class StackExtractor {
   public static String extractCallToAddress(final TraceFrame frame) {
     return frame
         .getStack()
-        .filter(
-            stack ->
-                stack.length >= CALL_STACK_TO_OFFSET
-                    && stack[stack.length - CALL_STACK_TO_OFFSET] != null)
-        .map(
-            stack -> toAddress(stack[stack.length - CALL_STACK_TO_OFFSET]).getBytes().toHexString())
+        .filter(stack -> stack.length > CALL_TO_INDEX && stackItem(stack, CALL_TO_INDEX) != null)
+        .map(stack -> toAddress(stackItem(stack, CALL_TO_INDEX)).getBytes().toHexString())
         .orElse(null);
   }
 
   /**
-   * Extracts the input data for a CALL operation from memory.
-   *
-   * <p>This method reads the inOffset and inSize from the stack, then extracts the corresponding
-   * bytes from memory.
+   * Extracts the input data for a CALL operation.
    *
    * @param frame the trace frame containing stack and memory
+   * @param opcode the call opcode, which fixes where the arguments sit on the stack
    * @return the input data bytes, or the frame's input data as fallback
    */
-  public static Bytes extractCallInputFromMemory(final TraceFrame frame) {
+  public static Bytes extractCallInputFromMemory(final TraceFrame frame, final String opcode) {
+    final Optional<Bytes> callInputData = frame.getCallInputData();
+    if (callInputData.isPresent()) {
+      return callInputData.get();
+    }
+
+    final int offsetIndex =
+        OpcodeCategory.hasValueArgument(opcode)
+            ? CALL_IN_OFFSET_INDEX
+            : DELEGATECALL_IN_OFFSET_INDEX;
+
     return frame
         .getStack()
-        .filter(stack -> stack.length >= CALL_STACK_IN_OFFSET_POS)
+        .filter(stack -> stack.length > offsetIndex + 1)
         .map(
             stack -> {
-              int inOffset = bytesToInt(stack[stack.length - CALL_STACK_IN_OFFSET_POS]);
-              int inSize = bytesToInt(stack[stack.length - CALL_STACK_IN_SIZE_POS]);
+              final int inOffset = bytesToInt(stackItem(stack, offsetIndex));
+              final int inSize = bytesToInt(stackItem(stack, offsetIndex + 1));
               return extractFromMemory(frame, inOffset, inSize);
             })
         .orElse(frame.getInputData());
+  }
+
+  private static Bytes stackItem(final Bytes[] stack, final int indexFromTop) {
+    return stack[stack.length - 1 - indexFromTop];
   }
 
   /**
    * Extracts the initialization code for a CREATE or CREATE2 operation.
    *
    * @param frame the trace frame containing stack and memory
-   * @param opcode the opcode ("CREATE" or "CREATE2")
    * @param entered whether the CREATE operation successfully entered (depth increased)
    * @return the initialization code bytes, or empty if extraction fails
    */
-  public static Bytes extractCreateInitCode(
-      final TraceFrame frame, final String opcode, final boolean entered) {
+  public static Bytes extractCreateInitCode(final TraceFrame frame, final boolean entered) {
     // Only try getMaybeCode() if the CREATE entered successfully
     // When CREATE doesn't enter (soft failure), getMaybeCode() contains the parent's code, not the
     // init code
@@ -159,7 +160,11 @@ public final class StackExtractor {
       return frame.getMaybeCode().get().getBytes();
     }
 
-    // Extract from memory for soft-failed CREATEs or as fallback
+    final Optional<Bytes> callInputData = frame.getCallInputData();
+    if (callInputData.isPresent()) {
+      return callInputData.get();
+    }
+
     if (LOG.isTraceEnabled()) {
       LOG.trace(
           "Using memory extraction for CREATE input data at depth {} (entered: {})",
@@ -169,7 +174,7 @@ public final class StackExtractor {
 
     return frame
         .getStack()
-        .map(stack -> extractCreateInitCodeFromStack(frame, stack, opcode))
+        .map(stack -> extractCreateInitCodeFromStack(frame, stack))
         .orElse(Bytes.EMPTY);
   }
 
@@ -217,7 +222,7 @@ public final class StackExtractor {
     if (OpcodeCategory.isCreateOp(opcode)) {
       // Check if the CREATE entered (depth increased)
       boolean entered = nextTrace != null && nextTrace.getDepth() > frame.getDepth();
-      return extractCreateInitCode(frame, opcode, entered);
+      return extractCreateInitCode(frame, entered);
     }
 
     // Prefer callee frame's input data for calls
@@ -231,34 +236,21 @@ public final class StackExtractor {
         LOG.trace(
             "Falling back to memory extraction for CALL input data at depth {}", frame.getDepth());
       }
-      return extractCallInputFromMemory(frame);
+      return extractCallInputFromMemory(frame, opcode);
     }
 
     return frame.getInputData();
   }
 
-  private static Bytes extractCreateInitCodeFromStack(
-      final TraceFrame frame, final Bytes[] stack, final String opcode) {
-
-    if ("CREATE".equals(opcode)) {
-      if (stack.length < CREATE_STACK_OFFSET_POS) {
-        return Bytes.EMPTY;
-      }
-
-      int offset = bytesToInt(stack[stack.length - CREATE_STACK_OFFSET_POS]);
-      int length = bytesToInt(stack[stack.length - CREATE_STACK_SIZE_POS]);
-
-      return extractFromMemory(frame, offset, length);
-    } else { // CREATE2
-      if (stack.length < CREATE2_STACK_OFFSET_POS) {
-        return Bytes.EMPTY;
-      }
-
-      int offset = bytesToInt(stack[stack.length - CREATE2_STACK_OFFSET_POS]);
-      int length = bytesToInt(stack[stack.length - CREATE2_STACK_SIZE_POS]);
-
-      return extractFromMemory(frame, offset, length);
+  private static Bytes extractCreateInitCodeFromStack(final TraceFrame frame, final Bytes[] stack) {
+    if (stack.length <= CREATE_SIZE_INDEX) {
+      return Bytes.EMPTY;
     }
+
+    final int offset = bytesToInt(stackItem(stack, CREATE_OFFSET_INDEX));
+    final int length = bytesToInt(stackItem(stack, CREATE_SIZE_INDEX));
+
+    return extractFromMemory(frame, offset, length);
   }
 
   private static Bytes extractFromMemory(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParamsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParamsTest.java
@@ -62,15 +62,25 @@ public class TransactionTraceParamsTest {
   }
 
   @Test
-  public void nonOpcodeTracerShouldEnableMemoryByDefault() throws Exception {
-    // Non-opcode tracers (e.g. callTracer) need memory for internal operations
-    // such as extracting CREATE init code, so memory should be enabled by default
+  public void nonOpcodeTracerShouldNotEnableMemoryByDefault() throws Exception {
     final TransactionTraceParams callTracerParams =
         MAPPER.readValue("{\"tracer\": \"callTracer\"}", TransactionTraceParams.class);
     final OpCodeTracerConfig config = callTracerParams.traceOptions().opCodeTracerConfig();
 
     assertThat(config.traceMemory())
-        .describedAs("callTracer should have memory enabled by default")
+        .describedAs("callTracer should not force memory capture on")
+        .isFalse();
+  }
+
+  @Test
+  public void nonOpcodeTracerShouldRespectExplicitEnableMemory() throws Exception {
+    final TransactionTraceParams params =
+        MAPPER.readValue(
+            "{\"tracer\": \"callTracer\", \"enableMemory\": true}", TransactionTraceParams.class);
+    final OpCodeTracerConfig config = params.traceOptions().opCodeTracerConfig();
+
+    assertThat(config.traceMemory())
+        .describedAs("explicit enableMemory=true should be respected")
         .isTrue();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/StackExtractorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/calltrace/StackExtractorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.calltrace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.evm.Code;
+import org.hyperledger.besu.evm.tracing.TraceFrame;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+class StackExtractorTest {
+
+  private static final Bytes MEMORY_WORD = Bytes32.fromHexString("0x" + "ab".repeat(32));
+  private static final Bytes[] MEMORY = new Bytes[] {MEMORY_WORD};
+
+  @Test
+  void extractCallInputPrefersTheCapturedCallInputData() {
+    final Bytes captured = Bytes.fromHexString("0xdeadbeef");
+    final TraceFrame frame =
+        traceFrameBuilder()
+            .setCallInputData(Optional.of(captured))
+            // A stack/memory pair decoding to something else, to prove it is not consulted.
+            .setStack(Optional.of(callStack(0, 32)))
+            .setMemory(Optional.of(MEMORY))
+            .build();
+
+    assertThat(StackExtractor.extractCallInputFromMemory(frame, "CALL")).isEqualTo(captured);
+  }
+
+  @Test
+  void extractCallInputFallsBackToMemoryWhenNoCallInputDataWasCaptured() {
+    final TraceFrame frame =
+        traceFrameBuilder()
+            .setStack(Optional.of(callStack(4, 8)))
+            .setMemory(Optional.of(MEMORY))
+            .build();
+
+    assertThat(StackExtractor.extractCallInputFromMemory(frame, "CALL"))
+        .isEqualTo(MEMORY_WORD.slice(4, 8));
+  }
+
+  @Test
+  void extractCallInputFallbackUsesTheShallowerSlotsForDelegateAndStaticCall() {
+    // Bottom to top: outSize, outOffset, inSize, inOffset, to, gas.
+    final Bytes[] stack = {
+      Bytes.EMPTY,
+      Bytes.EMPTY,
+      Bytes.ofUnsignedLong(8),
+      Bytes.ofUnsignedLong(4),
+      Bytes.EMPTY,
+      Bytes.EMPTY,
+    };
+    final TraceFrame frame =
+        traceFrameBuilder().setStack(Optional.of(stack)).setMemory(Optional.of(MEMORY)).build();
+
+    assertThat(StackExtractor.extractCallInputFromMemory(frame, "DELEGATECALL"))
+        .isEqualTo(MEMORY_WORD.slice(4, 8));
+    assertThat(StackExtractor.extractCallInputFromMemory(frame, "STATICCALL"))
+        .isEqualTo(MEMORY_WORD.slice(4, 8));
+  }
+
+  @Test
+  void extractCreateInitCodePrefersDeployedCodeWhenTheCreateEntered() {
+    final Bytes deployed = Bytes.fromHexString("0x6001600155");
+    final TraceFrame frame =
+        traceFrameBuilder()
+            .setMaybeCode(Optional.of(new Code(deployed)))
+            .setCallInputData(Optional.of(Bytes.fromHexString("0xdeadbeef")))
+            .build();
+
+    assertThat(StackExtractor.extractCreateInitCode(frame, true)).isEqualTo(deployed);
+  }
+
+  @Test
+  void extractCreateInitCodeUsesCapturedInitCodeWhenTheCreateDidNotEnter() {
+    // getMaybeCode() holds the caller's code when no callee frame was spawned, not the initcode.
+    final Bytes initCode = Bytes.fromHexString("0x60806040");
+    final TraceFrame frame =
+        traceFrameBuilder()
+            .setMaybeCode(Optional.of(new Code(Bytes.fromHexString("0xfefefe"))))
+            .setCallInputData(Optional.of(initCode))
+            .build();
+
+    assertThat(StackExtractor.extractCreateInitCode(frame, false)).isEqualTo(initCode);
+  }
+
+  @Test
+  void extractCreateInitCodeReadsTheSameStackSlotsForCreateAndCreate2() {
+    // Bottom to top: size, offset, value.
+    final Bytes[] createStack = {
+      Bytes.ofUnsignedLong(6), Bytes.ofUnsignedLong(2), Bytes.EMPTY,
+    };
+    // CREATE2 adds a salt below the same three.
+    final Bytes[] create2Stack = {
+      Bytes.EMPTY, Bytes.ofUnsignedLong(6), Bytes.ofUnsignedLong(2), Bytes.EMPTY,
+    };
+
+    final Bytes expected = MEMORY_WORD.slice(2, 6);
+    assertThat(
+            StackExtractor.extractCreateInitCode(
+                traceFrameBuilder()
+                    .setStack(Optional.of(createStack))
+                    .setMemory(Optional.of(MEMORY))
+                    .build(),
+                false))
+        .isEqualTo(expected);
+    assertThat(
+            StackExtractor.extractCreateInitCode(
+                traceFrameBuilder()
+                    .setStack(Optional.of(create2Stack))
+                    .setMemory(Optional.of(MEMORY))
+                    .build(),
+                false))
+        .isEqualTo(expected);
+  }
+
+  /** CALL stack, bottom to top: outSize, outOffset, inSize, inOffset, value, to, gas. */
+  private static Bytes[] callStack(final long inOffset, final long inSize) {
+    return new Bytes[] {
+      Bytes.EMPTY,
+      Bytes.EMPTY,
+      Bytes.ofUnsignedLong(inSize),
+      Bytes.ofUnsignedLong(inOffset),
+      Bytes.EMPTY,
+      Bytes.EMPTY,
+      Bytes.EMPTY,
+    };
+  }
+
+  private static TraceFrame.Builder traceFrameBuilder() {
+    return TraceFrame.builder().setDepth(1).setInputData(Bytes.EMPTY);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.operation.AbstractCallOperation;
 import org.hyperledger.besu.evm.operation.AbstractCreateOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
@@ -45,6 +46,9 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
   private Bytes inputData;
   private int stepCount;
   private boolean limitReached;
+
+  private long callInputOffset;
+  private long callInputLength;
 
   /**
    * Creates the operation tracer.
@@ -74,6 +78,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
 
   @Override
   protected void capturePreExecutionState(final MessageFrame frame) {
+    captureCallInputRange(frame);
     if (options.limit() > 0 && stepCount >= options.limit()) {
       limitReached = true;
       return;
@@ -92,15 +97,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     final int opcodeNumber = (opcode != null) ? currentOperation.getOpcode() : Integer.MAX_VALUE;
     final WorldUpdater worldUpdater = frame.getWorldUpdater();
     final Bytes outputData = frame.getOutputData();
-    // Always capture memory for soft-failed CREATE/CREATE2 ops so callTracer can extract init code
-    final Optional<Bytes[]> memory =
-        captureMemory(frame)
-            .or(
-                () ->
-                    operationResult.getSoftFailureReason().isPresent()
-                            && currentOperation instanceof AbstractCreateOperation
-                        ? forceCaptureMem(frame)
-                        : Optional.empty());
+    final Optional<Bytes[]> memory = captureMemory(frame);
     final Optional<Bytes> returnData = captureReturnData(frame);
     final Optional<Bytes[]> stackPostExecution = captureStack(frame);
 
@@ -142,6 +139,7 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
             .setReturnData(returnData)
             .setStack(preExecutionStack)
             .setMemory(memory)
+            .setCallInputData(captureCallInputData(frame))
             .setStorage(storage)
             .setWorldUpdater(worldUpdater)
             .setRevertReason(frame.getRevertReason())
@@ -301,6 +299,46 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     return Optional.empty();
   }
 
+  /**
+   * Records where a call or create operation declared its argument data, while those arguments are
+   * still on the stack. The operations are the authority on their own stack layout, so none is
+   * duplicated here.
+   */
+  private void captureCallInputRange(final MessageFrame frame) {
+    final Operation currentOperation = frame.getCurrentOperation();
+    if (currentOperation != null && frame.stackSize() >= currentOperation.getStackItemsConsumed()) {
+      if (currentOperation instanceof AbstractCallOperation callOperation) {
+        callInputOffset = callOperation.inputDataOffset(frame);
+        callInputLength = callOperation.inputDataLength(frame);
+        return;
+      }
+      if (currentOperation instanceof AbstractCreateOperation createOperation) {
+        callInputOffset = createOperation.getInputOffset(frame);
+        callInputLength = createOperation.getInputSize(frame);
+        return;
+      }
+    }
+    callInputOffset = 0;
+    callInputLength = 0;
+  }
+
+  /** Copies the argument slice a call or create operation declared in memory. */
+  private Optional<Bytes> captureCallInputData(final MessageFrame frame) {
+    // A call that spawned a callee carries its arguments on that callee's frame, so only calls that
+    // never spawned one need them recovered from memory here.
+    if (callInputLength <= 0 || frame.getState() == MessageFrame.State.CODE_SUSPENDED) {
+      return Optional.empty();
+    }
+    // Only memory the operation expanded has been paid for. Reading past it would let a declared
+    // length the transaction cannot afford drive the allocation.
+    final long activeBytes = frame.memoryWordSize() * 32L;
+    if (callInputOffset > activeBytes - callInputLength) {
+      return Optional.empty();
+    }
+    // shadowReadMemory does not grow the active word count, so tracing cannot perturb execution.
+    return Optional.of(frame.shadowReadMemory(callInputOffset, callInputLength));
+  }
+
   private Optional<Bytes[]> captureMemory(final MessageFrame frame) {
     if (!options.traceMemory() || frame.memoryWordSize() == 0) {
       return Optional.empty();
@@ -341,6 +379,8 @@ public class DebugOperationTracer extends AbstractDebugOperationTracer {
     stepCount = 0;
     limitReached = false;
     preExecutionStorageKey = Optional.empty();
+    callInputOffset = 0;
+    callInputLength = 0;
   }
 
   public List<TraceFrame> copyTraceFrames() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.vm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -28,6 +29,8 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 import org.hyperledger.besu.evm.operation.CallOperation;
+import org.hyperledger.besu.evm.operation.Create2Operation;
+import org.hyperledger.besu.evm.operation.CreateOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.tracing.OpCodeTracerConfigBuilder;
@@ -616,11 +619,137 @@ class DebugOperationTracerTest {
     return frame;
   }
 
+  /** CALL's stack, from the top down, is gas, to, value, inOffset, inSize, outOffset, outSize. */
+  private MessageFrame callFrameWithInputRange(
+      final Bytes memoryContents, final long inOffset, final long inSize) {
+    final MessageFrame frame = validMessageFrameBuilder().build();
+    frame.writeMemory(0L, memoryContents.size(), memoryContents);
+    frame.pushStackItem(Bytes.EMPTY); // outSize
+    frame.pushStackItem(Bytes.EMPTY); // outOffset
+    frame.pushStackItem(Bytes.ofUnsignedLong(inSize));
+    frame.pushStackItem(Bytes.ofUnsignedLong(inOffset));
+    frame.pushStackItem(Bytes.EMPTY); // value
+    frame.pushStackItem(Address.ZERO.getBytes()); // to
+    frame.pushStackItem(Bytes.ofUnsignedLong(INITIAL_GAS)); // gas
+    frame.setCurrentOperation(callOperation);
+    frame.setPC(10);
+    return frame;
+  }
+
+  /** Drives the tracer hooks around an operation without executing it. */
+  private TraceFrame traceWithoutExecuting(
+      final MessageFrame frame, final OperationResult operationResult) {
+    final DebugOperationTracer tracer = new DebugOperationTracer(OpCodeTracerConfig.DEFAULT, false);
+    tracer.tracePreExecution(frame);
+    tracer.tracePostExecution(frame, operationResult);
+    return getOnlyTraceFrame(tracer);
+  }
+
   private MessageFrame validCallFrame() {
     final MessageFrame frame = validMessageFrameBuilder().build();
     frame.setCurrentOperation(callOperation);
     frame.setPC(10);
     return frame;
+  }
+
+  @Test
+  void shouldCaptureCallInputDataWhenMemoryTracingIsDisabled() {
+    final Bytes memoryContents = Bytes.fromHexString("0x" + "ab".repeat(32));
+    final MessageFrame frame = callFrameWithInputRange(memoryContents, 4L, 8L);
+
+    final TraceFrame traceFrame = traceWithoutExecuting(frame, new OperationResult(100L, null));
+
+    assertThat(OpCodeTracerConfig.DEFAULT.traceMemory()).isFalse();
+    assertThat(traceFrame.getMemory()).isEmpty();
+    assertThat(traceFrame.getCallInputData()).contains(memoryContents.slice(4, 8));
+  }
+
+  @Test
+  void shouldNotCaptureCallInputDataForNonCallOperations() {
+    final TraceFrame traceFrame =
+        traceWithoutExecuting(validMessageFrame(), new OperationResult(20L, null));
+
+    assertThat(traceFrame.getCallInputData()).isEmpty();
+  }
+
+  @Test
+  void shouldNotCaptureCallInputDataForZeroLengthInput() {
+    final MessageFrame frame =
+        callFrameWithInputRange(Bytes.fromHexString("0x" + "ab".repeat(32)), 0L, 0L);
+
+    final TraceFrame traceFrame = traceWithoutExecuting(frame, new OperationResult(100L, null));
+
+    assertThat(traceFrame.getCallInputData()).isEmpty();
+  }
+
+  @Test
+  void shouldNotCaptureCallInputDataWhenTheCallSpawnedACallee() {
+    final MessageFrame frame =
+        callFrameWithInputRange(Bytes.fromHexString("0x" + "ab".repeat(32)), 4L, 8L);
+    frame.setState(MessageFrame.State.CODE_SUSPENDED);
+
+    final TraceFrame traceFrame = traceWithoutExecuting(frame, new OperationResult(100L, null));
+
+    assertThat(traceFrame.getCallInputData()).isEmpty();
+  }
+
+  @Test
+  void shouldCaptureCallInputDataWhenTheOperationHalted() {
+    final Bytes memoryContents = Bytes.fromHexString("0x" + "ab".repeat(32));
+    final MessageFrame frame = callFrameWithInputRange(memoryContents, 4L, 8L);
+
+    final TraceFrame traceFrame =
+        traceWithoutExecuting(
+            frame, new OperationResult(100L, ExceptionalHaltReason.INSUFFICIENT_GAS));
+
+    assertThat(traceFrame.getCallInputData()).contains(memoryContents.slice(4, 8));
+  }
+
+  @Test
+  void shouldNotCaptureCallInputDataBeyondActiveMemory() {
+    // Memory past the active words was never expanded, so the transaction never paid for it.
+    final MessageFrame frame =
+        callFrameWithInputRange(Bytes.fromHexString("0x" + "ab".repeat(32)), 16L, 32L);
+
+    final TraceFrame traceFrame = traceWithoutExecuting(frame, new OperationResult(100L, null));
+
+    assertThat(traceFrame.getCallInputData()).isEmpty();
+
+    final MessageFrame unaffordable =
+        callFrameWithInputRange(Bytes.fromHexString("0x" + "ab".repeat(32)), 0L, Integer.MAX_VALUE);
+    assertThat(
+            traceWithoutExecuting(unaffordable, new OperationResult(100L, null)).getCallInputData())
+        .isEmpty();
+  }
+
+  @Test
+  void shouldCaptureCreateInitCodeFromTheSameStackSlotsForCreateAndCreate2() {
+    final Bytes memoryContents = Bytes.fromHexString("0x" + "cd".repeat(32));
+
+    // CREATE stack, top down: value, offset, size
+    final MessageFrame createFrame = validMessageFrameBuilder().build();
+    createFrame.writeMemory(0L, memoryContents.size(), memoryContents);
+    createFrame.pushStackItem(Bytes.ofUnsignedLong(6L)); // size
+    createFrame.pushStackItem(Bytes.ofUnsignedLong(2L)); // offset
+    createFrame.pushStackItem(Bytes.EMPTY); // value
+    createFrame.setCurrentOperation(new CreateOperation(new CancunGasCalculator()));
+
+    // CREATE2 stack, top down: value, offset, size, salt
+    final MessageFrame create2Frame = validMessageFrameBuilder().build();
+    create2Frame.writeMemory(0L, memoryContents.size(), memoryContents);
+    create2Frame.pushStackItem(Bytes.EMPTY); // salt
+    create2Frame.pushStackItem(Bytes.ofUnsignedLong(6L)); // size
+    create2Frame.pushStackItem(Bytes.ofUnsignedLong(2L)); // offset
+    create2Frame.pushStackItem(Bytes.EMPTY); // value
+    create2Frame.setCurrentOperation(new Create2Operation(new CancunGasCalculator()));
+
+    final Bytes expected = memoryContents.slice(2, 6);
+    assertThat(
+            traceWithoutExecuting(createFrame, new OperationResult(100L, null)).getCallInputData())
+        .contains(expected);
+    assertThat(
+            traceWithoutExecuting(create2Frame, new OperationResult(100L, null)).getCallInputData())
+        .contains(expected);
   }
 
   private TraceFrame getOnlyTraceFrame(final DebugOperationTracer tracer) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -110,7 +110,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
    * @param frame The current message frame
    * @return the memory offset the input data starts at
    */
-  protected abstract long inputDataOffset(MessageFrame frame);
+  public abstract long inputDataOffset(MessageFrame frame);
 
   /**
    * Returns the length of the input data to read from memory.
@@ -118,7 +118,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
    * @param frame The current message frame
    * @return the length of the input data to read from memory.
    */
-  protected abstract long inputDataLength(MessageFrame frame);
+  public abstract long inputDataLength(MessageFrame frame);
 
   /**
    * Returns the memory offset the offset data starts at.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -188,8 +188,18 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
    * @param frame the message frame the operation executed in
    * @return the requested initcode size
    */
-  protected long getInputSize(final MessageFrame frame) {
+  public long getInputSize(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(2));
+  }
+
+  /**
+   * Returns the memory offset the initcode is read from, clamped to a long.
+   *
+   * @param frame the message frame the operation executed in
+   * @return the memory offset the initcode starts at
+   */
+  public long getInputOffset(final MessageFrame frame) {
+    return clampedToLong(frame.getStackItem(1));
   }
 
   /**
@@ -199,9 +209,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
    * @param frame the current execution frame
    */
   protected void fail(final MessageFrame frame) {
-    final long inputOffset = clampedToLong(frame.getStackItem(1));
-    final long inputSize = clampedToLong(frame.getStackItem(2));
-    frame.readMutableMemory(inputOffset, inputSize);
+    frame.readMutableMemory(getInputOffset(frame), getInputSize(frame));
     frame.popStackItems(getStackItemsConsumed());
     frame.pushStackItem(Bytes.EMPTY);
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallCodeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallCodeOperation.java
@@ -50,12 +50,12 @@ public class CallCodeOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long inputDataOffset(final MessageFrame frame) {
+  public long inputDataOffset(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(3));
   }
 
   @Override
-  protected long inputDataLength(final MessageFrame frame) {
+  public long inputDataLength(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(4));
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
@@ -52,12 +52,12 @@ public class CallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long inputDataOffset(final MessageFrame frame) {
+  public long inputDataOffset(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(3));
   }
 
   @Override
-  protected long inputDataLength(final MessageFrame frame) {
+  public long inputDataLength(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(4));
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DelegateCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DelegateCallOperation.java
@@ -50,12 +50,12 @@ public class DelegateCallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long inputDataOffset(final MessageFrame frame) {
+  public long inputDataOffset(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(2));
   }
 
   @Override
-  protected long inputDataLength(final MessageFrame frame) {
+  public long inputDataLength(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(3));
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/StaticCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/StaticCallOperation.java
@@ -50,12 +50,12 @@ public class StaticCallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long inputDataOffset(final MessageFrame frame) {
+  public long inputDataOffset(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(2));
   }
 
   @Override
-  protected long inputDataLength(final MessageFrame frame) {
+  public long inputDataLength(final MessageFrame frame) {
     return clampedToLong(frame.getStackItem(3));
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/TraceFrame.java
@@ -69,6 +69,7 @@ public class TraceFrame {
   private final Optional<SoftFailureReason> softFailureReason;
   private final OptionalLong gasAvailableForChildCall;
   private final Optional<Bytes> returnData;
+  private final Optional<Bytes> callInputData;
 
   /** Private constructor - only accessible through Builder */
   private TraceFrame(final Builder builder) {
@@ -105,6 +106,7 @@ public class TraceFrame {
     this.softFailureReason = builder.softFailureReason;
     this.gasAvailableForChildCall = builder.gasAvailableForChildCall;
     this.returnData = builder.returnData;
+    this.callInputData = builder.callInputData;
   }
 
   /**
@@ -161,6 +163,7 @@ public class TraceFrame {
     private Optional<SoftFailureReason> softFailureReason = Optional.empty();
     private OptionalLong gasAvailableForChildCall = OptionalLong.empty();
     private Optional<Bytes> returnData = Optional.empty();
+    private Optional<Bytes> callInputData = Optional.empty();
 
     /** Default constructor */
     public Builder() {}
@@ -204,6 +207,7 @@ public class TraceFrame {
       this.softFailureReason = traceFrame.softFailureReason;
       this.gasAvailableForChildCall = traceFrame.gasAvailableForChildCall;
       this.returnData = traceFrame.returnData;
+      this.callInputData = traceFrame.callInputData;
     }
 
     /**
@@ -595,6 +599,17 @@ public class TraceFrame {
     }
 
     /**
+     * Sets the call argument data declared in this frame's memory by a call or create operation.
+     *
+     * @param callInputData the call argument data, or empty if it is not recorded for this opcode
+     * @return this builder instance for method chaining
+     */
+    public Builder setCallInputData(final Optional<Bytes> callInputData) {
+      this.callInputData = callInputData;
+      return this;
+    }
+
+    /**
      * Builds the TraceFrame instance.
      *
      * @return the constructed TraceFrame
@@ -904,6 +919,17 @@ public class TraceFrame {
    */
   public Optional<Bytes> getReturnData() {
     return returnData;
+  }
+
+  /**
+   * The argument data a call or create operation declared in this frame's memory: the callee input
+   * data for CALL/CALLCODE/DELEGATECALL/STATICCALL, or the initcode for CREATE/CREATE2. Only
+   * populated for an operation that never spawned a callee frame to carry them.
+   *
+   * @return the call argument data, or empty if it is not recorded for this opcode
+   */
+  public Optional<Bytes> getCallInputData() {
+    return callInputData;
   }
 
   @Override


### PR DESCRIPTION
Requesting any non-default tracer (callTracer, prestateTracer, 4byteTracer) turned on full memory capture for every traced opcode unless the caller explicitly passed enableMemory/disableMemory. The justification was that the callTracer needs memory to recover CREATE initcode and the input of a call that never spawned a callee frame.

That is a very expensive way to obtain a small amount of data. DebugOperationTracer snapshots memory as one Bytes object per 32-byte word and retains it on the TraceFrame for the whole transaction. The snapshot-reuse fast path only applies while memory is untouched, so every MSTORE/CALLDATACOPY/... forces a fresh full copy: allocation is quadratic in the memory size, the retained set is (memory-writing opcodes x memory size), and each 32-byte word costs roughly 80 bytes of heap. Contracts holding a large memory buffer could exhaust the heap.

Capture the argument range instead. The call and create operations already know where their arguments live, so the tracer asks them for the offset and length before execution, while the stack is intact, and after execution copies just that slice into a new TraceFrame.callInputData.

Two bounds keep that copy cheap. It is skipped when the operation spawned a callee frame, because the callee already carries the arguments and the converter reads them from there. It is also skipped when the range runs past the frame's active memory, since only memory the operation expanded has been paid for - so a declared length the transaction cannot afford can never drive the allocation.

StackExtractor prefers that field, which also removes the need for the special case that captured full memory for soft-failed CREATEs.

This surfaced two bugs in the stack decoding StackExtractor falls back to, both of which the operations now answer authoritatively:

  - CREATE2's initcode offset and size were read from swapped slots
  - the CALL input size was read from the value slot, and DELEGATECALL/STATICCALL were decoded with CALL's stack layout

The fallback is fixed as well, since it still runs when memory tracing is explicitly enabled and a callee frame produced no trace frames. Its constants now all count from the top of the stack, so neighbouring indices no longer mix two conventions.

inputDataOffset/inputDataLength on AbstractCallOperation and the new getInputOffset alongside getInputSize on AbstractCreateOperation are public so the tracer can reach them. Subclasses outside Besu that override the first two as protected will need to widen them.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


