### PR TITLE
jwt stale token: do not log attributes

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
@@ -182,7 +182,7 @@ public class EngineAuthService implements AuthenticationService {
                     lastValidToken.set(new CachedToken(tokenUtf8, iat, r.result()));
                     handler.handle(Optional.of(r.result()));
                   } else {
-                    LOG.warn("Client sent stale token: {}", r.result().attributes());
+                    LOG.warn("Client sent stale Engine API token with iat: {}", iat);
                     handler.handle(Optional.empty());
                   }
                 } else {


### PR DESCRIPTION
## PR description

- **Description**: When the Engine API receives a JWT with an `iat` outside the 60-second freshness window, the full decoded JWT payload (`r.result().attributes()`) is logged at WARN level. For standard Engine API tokens this typically only contains `{"iat": <timestamp>}`, but any additional custom claims in a non-standard CL client's JWT would also be logged. JWT metadata in logs can assist attackers who have log access in understanding token structure and timing for replay attacks.
- **Impact**: Low practical impact for standard HS256 Engine API tokens. Could expose custom claim values if non-standard CL clients include additional JWT claims. Defensive coding quality issue.

