### PR TITLE
update download artifact gha to v22

### DIFF
--- a/.github/workflows/acceptance-tests-timing-reports-update.yml
+++ b/.github/workflows/acceptance-tests-timing-reports-update.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get acceptance test reports from latest merged PR
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@7f871e041ed7fe12467d2d4196da8a466c5311ff # v22
         with:
           workflow: ci.yml
           workflow_conclusion: success

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -48,7 +48,7 @@ jobs:
       # `splitTestsByTime.sh` uses the per-test durations in  these XMLs to distribute tests across parallel runners by historical wall-clock time rather than a naive split.
       # If the artifact is missing # (e.g. first run), splitting falls back to round-robin for all tests.
       - name: Get acceptance test reports
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@7f871e041ed7fe12467d2d4196da8a466c5311ff # v22
         continue-on-error: true
         with:
           branch: main


### PR DESCRIPTION
Follow up to #11249

v6 had a regression - job is currently failing (note it is only run on main, so is not affecting PRs) eg https://github.com/besu-eth/besu/actions/runs/34131991666/job/101774020446
with error:
```
[syncTestReports](https://github.com/besu-eth/besu/actions/runs/34131991666/job/101774020446#step:3:30)
no matching workflow run found with any artifacts?
```

This updates to version 22:
https://github.com/dawidd6/action-download-artifact/releases/tag/v22