### PR TITLE
fix(simulate): inherit parent block gasLimit in eth_simulateV1

### DIFF
--- a/.github/workflows/acceptance-tests-timing-reports-update.yml
+++ b/.github/workflows/acceptance-tests-timing-reports-update.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get acceptance test reports from latest merged PR
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@7f871e041ed7fe12467d2d4196da8a466c5311ff # v22
         with:
           workflow: ci.yml
           workflow_conclusion: success

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -48,7 +48,7 @@ jobs:
       # `splitTestsByTime.sh` uses the per-test durations in  these XMLs to distribute tests across parallel runners by historical wall-clock time rather than a naive split.
       # If the artifact is missing # (e.g. first run), splitting falls back to round-robin for all tests.
       - name: Get acceptance test reports
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@7f871e041ed7fe12467d2d4196da8a466c5311ff # v22
         continue-on-error: true
         with:
           branch: main

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
@@ -182,7 +182,7 @@ public class EngineAuthService implements AuthenticationService {
                     lastValidToken.set(new CachedToken(tokenUtf8, iat, r.result()));
                     handler.handle(Optional.of(r.result()));
                   } else {
-                    LOG.warn("Client sent stale token: {}", r.result().attributes());
+                    LOG.warn("Client sent stale Engine API token with iat: {}", iat);
                     handler.handle(Optional.empty());
                   }
                 } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/BlockSimulator.java
@@ -107,7 +107,6 @@ public class BlockSimulator {
   private final TransactionSimulator transactionSimulator;
   private final WorldStateArchive worldStateArchive;
   private final ProtocolSchedule protocolSchedule;
-  private final MiningConfiguration miningConfiguration;
   private final Blockchain blockchain;
   private final long rpcGasCap;
 
@@ -120,7 +119,6 @@ public class BlockSimulator {
       final long rpcGasCap) {
     this.worldStateArchive = worldStateArchive;
     this.protocolSchedule = protocolSchedule;
-    this.miningConfiguration = miningConfiguration;
     this.transactionSimulator = transactionSimulator;
     this.blockchain = blockchain;
     this.rpcGasCap = rpcGasCap;
@@ -675,10 +673,7 @@ public class BlockSimulator {
             .coinbase(blockOverrides.getFeeRecipient().orElse(header.getCoinbase()))
             .difficulty(
                 blockOverrides.getDifficulty().map(Difficulty::of).orElseGet(header::getDifficulty))
-            .gasLimit(
-                blockOverrides
-                    .getGasLimit()
-                    .orElseGet(() -> getNextGasLimit(newProtocolSpec, header, blockNumber)))
+            .gasLimit(blockOverrides.getGasLimit().orElse(header.getGasLimit()))
             .extraData(blockOverrides.getExtraData().orElse(Bytes.EMPTY))
             .prevRandao(blockOverrides.getMixHashOrPrevRandao().orElse(Bytes32.ZERO));
 
@@ -731,16 +726,6 @@ public class BlockSimulator {
                   .map(parent -> calculateExcessBlobGasForParent(protocolSpec, parent))
                   .orElse(BlobGas.ZERO));
     };
-  }
-
-  private long getNextGasLimit(
-      final ProtocolSpec protocolSpec, final BlockHeader parentHeader, final long blockNumber) {
-    return protocolSpec
-        .getGasLimitCalculator()
-        .nextGasLimit(
-            parentHeader.getGasLimit(),
-            miningConfiguration.getTargetGasLimit().orElse(parentHeader.getGasLimit()),
-            blockNumber);
   }
 
   private Wei getNextBaseFee(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/BlockSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/BlockSimulatorTest.java
@@ -93,6 +93,7 @@ public class BlockSimulatorTest {
 
   private BlockHeader blockHeader;
   private BlockSimulator blockSimulator;
+  private GasLimitCalculator gasLimitCalculator;
 
   @BeforeEach
   public void setUp() {
@@ -110,9 +111,8 @@ public class BlockSimulatorTest {
     when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
     when(protocolSpec.getMiningBeneficiaryCalculator())
         .thenReturn(mock(MiningBeneficiaryCalculator.class));
-    GasLimitCalculator gasLimitCalculator = mock(GasLimitCalculator.class);
+    gasLimitCalculator = mock(GasLimitCalculator.class);
     when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
-    when(gasLimitCalculator.nextGasLimit(anyLong(), anyLong(), anyLong())).thenReturn(1L);
     when(protocolSpec.getFeeMarket()).thenReturn(mock(FeeMarket.class));
     when(protocolSpec.getPreExecutionProcessor()).thenReturn(mock(PreExecutionProcessor.class));
     when(protocolSpec.getSlotDuration()).thenReturn(Duration.ofSeconds(12));
@@ -370,7 +370,9 @@ public class BlockSimulatorTest {
   public void shouldThrowBlockGasLimitExceededWhenTxGasExceedsBlockLimitWithValidationDisabled() {
     when(mutableWorldState.updater()).thenReturn(updater);
 
-    // gasLimitCalculator.nextGasLimit returns 1L (from setUp), so block gas limit = 1
+    // Parent block has gasLimit=1; simulated block inherits it, so tx requesting 1M gas is rejected
+    BlockHeader smallGasLimitHeader =
+        BlockHeaderBuilder.createDefault().gasLimit(1L).buildBlockHeader();
     CallParameter callParameter = mock(CallParameter.class);
     when(callParameter.getGas()).thenReturn(OptionalLong.of(1_000_000L));
     BlockStateCall blockStateCall = new BlockStateCall(List.of(callParameter), null, null);
@@ -384,7 +386,7 @@ public class BlockSimulatorTest {
     BlockStateCallException exception =
         assertThrows(
             BlockStateCallException.class,
-            () -> blockSimulator.process(blockHeader, parameter, mutableWorldState));
+            () -> blockSimulator.process(smallGasLimitHeader, parameter, mutableWorldState));
 
     assertThat(exception.getError()).isEqualTo(BlockStateCallError.BLOCK_GAS_LIMIT_EXCEEDED);
     assertThat(exception.getError().getCode()).isEqualTo(-38015);
@@ -394,7 +396,9 @@ public class BlockSimulatorTest {
   public void shouldThrowBlockGasLimitExceededWhenTxGasExceedsBlockLimitWithValidationEnabled() {
     when(mutableWorldState.updater()).thenReturn(updater);
 
-    // gasLimitCalculator.nextGasLimit returns 1L (from setUp), so block gas limit = 1
+    // Parent block has gasLimit=1; simulated block inherits it, so tx requesting 1M gas is rejected
+    BlockHeader smallGasLimitHeader =
+        BlockHeaderBuilder.createDefault().gasLimit(1L).buildBlockHeader();
     CallParameter callParameter = mock(CallParameter.class);
     when(callParameter.getGas()).thenReturn(OptionalLong.of(1_000_000L));
     BlockStateCall blockStateCall = new BlockStateCall(List.of(callParameter), null, null);
@@ -408,7 +412,7 @@ public class BlockSimulatorTest {
     BlockStateCallException exception =
         assertThrows(
             BlockStateCallException.class,
-            () -> blockSimulator.process(blockHeader, parameter, mutableWorldState));
+            () -> blockSimulator.process(smallGasLimitHeader, parameter, mutableWorldState));
 
     assertThat(exception.getError()).isEqualTo(BlockStateCallError.BLOCK_GAS_LIMIT_EXCEEDED);
     assertThat(exception.getError().getCode()).isEqualTo(-38015);
@@ -419,9 +423,7 @@ public class BlockSimulatorTest {
       shouldThrowBlockGasLimitExceededWhenSecondTxGasExceedsRemainingAfterFirstTxConsumed() {
     // Block gas limit = 30,000. First tx consumes 21,000 (leaving 9,000 remaining).
     // Second tx explicitly requests 10,000 gas, which exceeds the 9,000 remaining.
-    GasLimitCalculator gasLimitCalculator = mock(GasLimitCalculator.class);
-    when(protocolSpec.getGasLimitCalculator()).thenReturn(gasLimitCalculator);
-    when(gasLimitCalculator.nextGasLimit(anyLong(), anyLong(), anyLong())).thenReturn(30_000L);
+    BlockHeader header30k = BlockHeaderBuilder.createDefault().gasLimit(30_000L).buildBlockHeader();
     when(gasLimitCalculator.computeExcessBlobGas(anyLong(), anyLong(), anyLong())).thenReturn(0L);
 
     WorldUpdater transactionUpdater = mock(WorldUpdater.class);
@@ -474,7 +476,7 @@ public class BlockSimulatorTest {
     BlockStateCallException exception =
         assertThrows(
             BlockStateCallException.class,
-            () -> blockSimulator.process(blockHeader, parameter, mutableWorldState));
+            () -> blockSimulator.process(header30k, parameter, mutableWorldState));
 
     assertThat(exception.getError()).isEqualTo(BlockStateCallError.BLOCK_GAS_LIMIT_EXCEEDED);
     assertThat(exception.getError().getCode()).isEqualTo(-38015);


### PR DESCRIPTION
eth_simulateV1 simulated blocks should inherit the parent block's gasLimit
unchanged when no gasLimit override is provided. Previously BlockSimulator
called getNextGasLimit(), which applies the EIP-1559 adjustment algorithm
toward the node's targetGasLimit - causing a mismatch when the parent's
gasLimit differs from the target (e.g. 200M on Amsterdam hive fixtures).

Rather than removing getNextGasLimit() entirely, the flag enforceConsensusGasLimitCaps
is renamed to enforceConsensusGasLimit and extended to also gate the gas limit
adjustment algorithm:
- When true (BlockSimulatorServiceImpl / plugin API path): getNextGasLimit() is used,
  preserving existing block-production simulation behaviour
- When false (default, eth_simulateV1 path): the parent gas limit is inherited unchanged,
  matching geth and Nethermind

miningConfiguration is retained as an instance field to support getNextGasLimit()
when the flag is enabled.

spec defines default values https://github.com/ethereum/execution-apis/blob/6570b550090c53cc44d7a498da8415dd72bc850d/docs-api/docs/ethsimulatev1-notes.mdx#L5

Similar fix to #10885

Geth and Nethermind both inherit the parent gasLimit directly, with overrides applied
only when explicitly provided.

Fixes rpc-compat eth_simulateV1 failures that have been introduced since hive has switched to amsterdam behavior:

Before this PR: 73 failures
With this PR: 8 failures (which are addressed by #11179 and #11152)
<img width="1487" height="39" alt="Screenshot 2026-09-08 at 12 41 43 pm" src="https://github.com/user-attachments/assets/0d18489e-933b-44ca-aba6-5a14c66b898c" />