### PR TITLE
Enable NullAway for consensus/merge

### DIFF
--- a/consensus/merge/build.gradle
+++ b/consensus/merge/build.gradle
@@ -28,6 +28,12 @@ tasks.named('compileTestJava', JavaCompile).configure {
   }
 }
 
+tasks.named('compileJmhJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {

--- a/consensus/merge/build.gradle
+++ b/consensus/merge/build.gradle
@@ -15,6 +15,19 @@
 
 apply plugin: 'java-library'
 
+compileJava {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+    option('NullAway:AnnotatedPackages', 'org.hyperledger.besu.consensus.merge')
+  }
+}
+
+tasks.named('compileTestJava', JavaCompile).configure {
+  options.errorprone {
+    check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+  }
+}
+
 jar {
   archiveBaseName = calculateArtifactId(project)
   manifest {
@@ -31,6 +44,9 @@ jar {
 repositories { mavenCentral() }
 
 dependencies {
+  errorprone 'com.uber.nullaway:nullaway'
+  compileOnly 'org.jspecify:jspecify'
+
   api 'org.slf4j:slf4j-api'
 
   implementation project(':config')

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -92,12 +93,13 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void setIsPostMerge(final Difficulty totalDifficulty) {
-    if (isPostMerge.get().orElse(Boolean.FALSE)) {
+    if (Objects.requireNonNull(isPostMerge.get()).orElse(Boolean.FALSE)) {
       // if we have finalized, we never switch back to a pre-merge once we have transitioned
       // post-TTD.
       return;
     }
-    final boolean newState = terminalTotalDifficulty.get().lessOrEqualThan(totalDifficulty);
+    final boolean newState =
+        Objects.requireNonNull(terminalTotalDifficulty.get()).lessOrEqualThan(totalDifficulty);
     final Optional<Boolean> oldState = isPostMerge.getAndSet(Optional.of(newState));
 
     // if we are past TTD, set it:
@@ -115,7 +117,7 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public boolean isPostMerge() {
-    return isPostMerge.get().orElse(Boolean.FALSE);
+    return Objects.requireNonNull(isPostMerge.get()).orElse(Boolean.FALSE);
   }
 
   @Override
@@ -197,7 +199,7 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public Difficulty getTerminalTotalDifficulty() {
-    return terminalTotalDifficulty.get();
+    return Objects.requireNonNull(terminalTotalDifficulty.get());
   }
 
   @Override
@@ -222,12 +224,12 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public Optional<BlockHeader> getTerminalPoWBlock() {
-    return terminalPoWBlock.get();
+    return Objects.requireNonNull(terminalPoWBlock.get());
   }
 
   @Override
   public void setTerminalPoWBlock(final Optional<BlockHeader> hashAndNumber) {
-    terminalPoWBlock.set(hashAndNumber);
+    terminalPoWBlock.set(Objects.requireNonNull(hashAndNumber));
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -27,9 +27,11 @@ import org.hyperledger.besu.plugin.services.txvalidator.TransactionValidationRul
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +42,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
   private final ProtocolSchedule preMergeProtocolSchedule;
   private final ProtocolSchedule postMergeProtocolSchedule;
   private final MergeContext mergeContext;
-  private ProtocolContext protocolContext;
+  private @Nullable ProtocolContext protocolContext;
 
   /**
    * Instantiates a new Transition protocol schedule.
@@ -113,7 +115,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
 
       // otherwise check to see if this block represents a re-org TTD block:
       Difficulty parentDifficulty =
-          protocolContext
+          Objects.requireNonNull(protocolContext, "Protocol context must be initialized before use")
               .getBlockchain()
               .getTotalDifficultyByHash(blockHeader.getParentHash())
               .orElse(Difficulty.ZERO);


### PR DESCRIPTION
## PR description
Enable NullAway as a compilation error for production code in the `consensus.merge` package and address the nullability issues identified by the checker.

- Add the NullAway checker and compile-only JSpecify annotation dependencies.
- Keep NullAway disabled for test and JMH compilation.
- Add explicit non-null checks for atomic reference values in `PostMergeContext` and reject null values passed to `setTerminalPoWBlock`.
- Mark the lazily initialized `protocolContext` in `TransitionProtocolSchedule` as `@Nullable` and require it to be initialized before accessing the blockchain, with a descriptive error message.

## Fixed Issue(s)
- #10442 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x]  spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


