### PR TITLE
ci(dco): replace tim-actions/dco with actions/github-script

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,18 +2,97 @@ name: DCO
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   dco_check:
     runs-on: ubuntu-latest
     name: DCO
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: DCO Check
-      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+      - name: Verify DCO Sign-off
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const basehead = `${pr.base.sha}...${pr.head.sha}`;
+
+            // pulls.listCommits is hard-capped at 250 commits; repos.compareCommitsWithBasehead
+            // paginates without a cap and uses merge-base (three-dot) semantics, so it yields
+            // exactly the PR's commits. Fork heads resolve because the fork is in the repo network.
+            let totalCommits = 0;
+            const commits = await github.paginate(
+              github.rest.repos.compareCommitsWithBasehead,
+              { owner, repo, basehead, per_page: 100 },
+              (response) => {
+                totalCommits = response.data.total_commits;
+                return response.data.commits;
+              }
+            );
+
+            if (commits.length !== totalCommits) {
+              core.setFailed(
+                `Expected ${totalCommits} commits in ${basehead} but the compare API returned ${commits.length}. ` +
+                `Refusing to validate a partial commit list.`
+              );
+              return;
+            }
+            core.info(`Validating ${commits.length} commit(s) in ${basehead}`);
+
+            const failed = [];
+
+            for (const { sha, commit, parents, author } of commits) {
+              // Skip merge commits (e.g. branch sync from web UI or git merge)
+              if (parents && parents.length > 1) {
+                continue;
+              }
+
+              // Skip bot commits (Dependabot, Renovate, GitHub Actions, etc.)
+              const isBot =
+                (author && author.type === 'Bot') ||
+                (author && author.login && author.login.endsWith('[bot]'));
+              if (isBot) {
+                continue;
+              }
+
+              const regex = /^Signed-off-by:[ \t]+([^<\r\n]+?)[ \t]*<([^>\r\n]+)>[ \t]*$/img;
+              const signoffs = [];
+              let match;
+              while ((match = regex.exec(commit.message)) !== null) {
+                signoffs.push({
+                  name: match[1].trim().toLowerCase(),
+                  email: match[2].trim().toLowerCase()
+                });
+              }
+
+              const authorName = (commit.author?.name || '').trim().toLowerCase();
+              const authorEmail = (commit.author?.email || '').trim().toLowerCase();
+              const committerName = (commit.committer?.name || '').trim().toLowerCase();
+              const committerEmail = (commit.committer?.email || '').trim().toLowerCase();
+
+              const hasValidSignoff = signoffs.some(
+                sig => (sig.name === authorName && sig.email === authorEmail) ||
+                       (sig.name === committerName && sig.email === committerEmail)
+              );
+
+              if (!hasValidSignoff) {
+                failed.push({
+                  sha: sha.substring(0, 7),
+                  title: commit.message.split(/\r?\n/)[0],
+                  author: `${commit.author?.name} <${commit.author?.email}>`
+                });
+              }
+            }
+
+            if (failed.length > 0) {
+              const summary = failed
+                .map(f => `- ${f.sha}: "${f.title}" (${f.author})`)
+                .join('\n');
+              core.setFailed(
+                `The following commit(s) are missing a valid 'Signed-off-by' matching the author or committer:\n\n${summary}\n\n` +
+                `To sign off commits, run: git commit --amend -s`
+              );
+            }


### PR DESCRIPTION
## PR description

Replace the unmaintained `tim-actions/dco` and `tim-actions/get-pr-commits` actions with an in-memory DCO check implemented in `actions/github-script`.

### Background & Problem
When a pull request has a relatively high number of commits (~25+ commits), `tim-actions/get-pr-commits` outputs the entire serialized GitHub API commit list JSON into an action output. The GitHub Actions runner attempts to set this payload as an environment variable (`INPUT_COMMITS`) when invoking `tim-actions/dco`. Because the payload exceeds Linux `ARG_MAX`, the runner fails immediately with:
```
An error occurred trying to start process '/home/runner/.../bin/node' with working directory '...'. Argument list too long
```
This is a known issue upstream: [tim-actions/dco#16](https://github.com/tim-actions/dco/issues/16). Furthermore, `tim-actions/dco` has not been maintained in 5 years and targets deprecated Node versions.

### Solution
- Use `actions/github-script` (`@60a0d83039c74a4aee543508d2ffcb1c3799cdea`, v7.0.1) to fetch and validate PR commits directly in memory via Octokit; no large action outputs or env vars.
- Fetch commits with `repos.compareCommitsWithBasehead` (`GET /repos/{owner}/{repo}/compare/{base.sha}...{head.sha}`, `per_page: 100`) instead of `pulls.listCommits`, which is hard-capped at 250 commits. The compare endpoint paginates without a cap and applies three-dot merge-base semantics server-side, so it returns exactly the PR's commits (fork heads resolve because the fork is in the repository network).
- Fail the check (not warn) if the number of commits returned does not equal the compare response's `total_commits`, so a partial list can never pass.
- Skip merge commits (`parents.length > 1`).
- Skip bot commits using only API-verified fields: `author.type === 'Bot'` or GitHub `author.login` ending in `[bot]`. Git author/committer name and email are never used for the exemption, so a human cannot opt out by putting `[bot]` in their git name.
- Validate that each remaining commit contains a `Signed-off-by:` line, anchored to a full line (`^Signed-off-by:[ \t]+NAME[ \t]*<EMAIL>[ \t]*$`, case-insensitive), whose name and email match either the commit author or the committer.
- Declare least-privilege `permissions: contents: read, pull-requests: read` on the workflow.

### Verification (runs on this PR's head branch)
- **305-commit PR (past the 250 `pulls.listCommits` cap), all signed:** `DCO` passed — log shows `Validating 305 commit(s) in d392849...a2f8c50` ([Run #34437454931](https://github.com/besu-eth/besu/actions/runs/34437454931/job/102745330364)).
- **306th commit unsigned:** `DCO` failed and listed exactly that commit (`464782c: "test: unsigned commit for dco negative check"`), proving commits beyond 250 are validated ([Run #34437509823](https://github.com/besu-eth/besu/actions/runs/34437509823/job/102745529199)).
- **Squashed to the single commit now in this PR:** `DCO` passed — `Validating 1 commit(s)` ([Run #34437554378](https://github.com/besu-eth/besu/actions/runs/34437554378/job/102745684299)).
- Earlier side-by-side against the old action on this branch: new `DCO` passed ([Run #34220974759](https://github.com/besu-eth/besu/actions/runs/34220974759/job/102043751312)) while `tim-actions/dco` failed with `Argument list too long` ([Run #34220974754](https://github.com/besu-eth/besu/actions/runs/34220974754/job/102043751446)). The temporary `old_dco.yml` and filler commits used for these runs have been removed; the PR is now a single commit touching only `.github/workflows/dco.yml`.

### Notes for Maintainers & Questions for Reviewers

1. **Enterprise Allowed Actions List (Node 24 Upgrade):**
   - This PR uses `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea` (`v7.0.1`) because it is the SHA currently permitted by `besu-eth`'s enterprise action allowlist.
   - `v7.0.1` executes successfully under Node 24 on GitHub's hosted runners, but emits an advisory warning that the action's metadata targets Node 20.
   - To eliminate the warning, maintainers can add `actions/github-script@v8` (`ed597411d8f924073f98dfc5c65a23a2325f34cd`) or `v9.0.0` (`3a2844b7e9c422d3c10d287c895573f7108da1b3`) to the enterprise allowed actions list in organization settings, after which this action can be bumped in a follow-up.

2. **Author vs. Committer validation:**
   - The current implementation allows the `Signed-off-by` line to match either the commit **author** or the **committer** (matching the previous `tim-actions/dco` and Probot DCO App behavior to accommodate cherry-picks/rebases).
   - However, `CONTRIBUTING.md` notes that the sign-off should match the commit author. Should we restrict this check to strictly match the **author**, or keep author-or-committer parity with Probot DCO?

## Fixed Issue(s)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
