### PR TITLE
Make size primitive and initialized at build time

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/Code.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/Code.java
@@ -37,7 +37,7 @@ public class Code {
   /** The hash of the code, needed for accessing metadata about the bytecode */
   private Hash codeHash;
 
-  private Integer size;
+  private final int size;
 
   /** Bit mask for jump destinations, used to optimize JUMP/JUMPI operations */
   private long[] jumpDestBitMask = null;
@@ -60,6 +60,7 @@ public class Code {
   public Code(final Bytes byteCode, final Hash codeHash) {
     this.bytes = Bytes.wrap(byteCode.toArrayUnsafe());
     this.codeHash = codeHash;
+    this.size = this.bytes.size();
   }
 
   /**
@@ -88,10 +89,6 @@ public class Code {
    * @return The number of bytes in the code.
    */
   public int getSize() {
-    if (size == null) {
-      size = bytes.size();
-    }
-
     return size;
   }
 


### PR DESCRIPTION
## PR description

Code.size was a lazily initialized boxed Integer. Every getSize() call did a null check and followed a pointer to a separate heap object. getSize() runs on every JUMP/JUMPI validation and on CODESIZE, so it is on a hot EVM path.

This change makes size a final int, set once in the constructor. It removes one Integer allocation per Code object and one pointer chase per jump validation.

Found while profiling the JUMPDEST-CALL spamoor scenario on Glamsterdam devnet 8, where getSize showed heavy time in the flame graph.

**Before**

<img width="1713" height="832" alt="image" src="https://github.com/user-attachments/assets/a4a50110-b671-4457-a3a8-bf7143ccc329" />

**After**

<img width="1713" height="832" alt="image" src="https://github.com/user-attachments/assets/1467e46e-784a-436e-bd5b-15c11addcefb" />

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


