### PR TITLE
snap/2 - integration tests for reorg

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/ReorgBlockchainBuilder.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/ReorgBlockchainBuilder.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.Difficulty;
-import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.snap.SnapTestServing;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
@@ -34,12 +33,12 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
+import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
-import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
 import java.util.ArrayList;
@@ -296,14 +295,6 @@ class ReorgBlockchainBuilder {
     return schedule;
   }
 
-  /** Creates a fresh in-memory Bonsai world state storage. */
-  static BonsaiWorldStateKeyValueStorage newBonsaiStorage() {
-    return new BonsaiWorldStateKeyValueStorage(
-        new InMemoryKeyValueStorageProvider(),
-        new NoOpMetricsSystem(),
-        DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
-  }
-
   /**
    * Returns the account trie root hash from {@code coordinator}'s flat storage, or {@link
    * Hash#EMPTY_TRIE_HASH} if the storage is empty.
@@ -451,6 +442,44 @@ class ReorgBlockchainBuilder {
 
   static Hash slotHash(final UInt256 slotKey) {
     return new StorageSlotKey(slotKey).getSlotHash();
+  }
+
+  static Optional<Bytes> readAccountBytes(
+      final WorldStateStorageCoordinator coordinator, final Address address) {
+    return coordinator.applyForStrategy(
+        bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
+  }
+
+  static PmtStateTrieAccountValue readAccount(
+      final WorldStateStorageCoordinator coordinator, final Address address) {
+    return PmtStateTrieAccountValue.readFrom(
+        RLP.input(readAccountBytes(coordinator, address).orElseThrow()));
+  }
+
+  static boolean accountExists(
+      final WorldStateStorageCoordinator coordinator, final Address address) {
+    return readAccountBytes(coordinator, address).isPresent();
+  }
+
+  static Optional<UInt256> readStorageSlot(
+      final WorldStateStorageCoordinator coordinator,
+      final Address address,
+      final UInt256 slotKey) {
+    return coordinator
+        .applyForStrategy(
+            bonsai ->
+                bonsai.getStorageValueByStorageSlotKey(
+                    address.addressHash(), new StorageSlotKey(slotKey)),
+            forest -> Optional.<Bytes>empty())
+        .map(UInt256::fromBytes);
+  }
+
+  static Optional<Bytes> readCode(
+      final WorldStateStorageCoordinator coordinator, final Address address) {
+    final PmtStateTrieAccountValue account = readAccount(coordinator, address);
+    return coordinator.applyForStrategy(
+        bonsai -> bonsai.getCode(account.getCodeHash(), address.addressHash()),
+        forest -> Optional.<Bytes>empty());
   }
 
   BlockHeader header(final long number) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/ReorgBlockchainBuilder.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/ReorgBlockchainBuilder.java
@@ -25,7 +25,10 @@ import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.ethereum.eth.manager.snap.SnapTestServing;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -33,12 +36,17 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -286,6 +294,60 @@ class ReorgBlockchainBuilder {
     final ProtocolSchedule schedule = Mockito.mock(ProtocolSchedule.class);
     Mockito.when(schedule.getByBlockHeader(Mockito.any())).thenReturn(spec);
     return schedule;
+  }
+
+  /** Creates a fresh in-memory Bonsai world state storage. */
+  static BonsaiWorldStateKeyValueStorage newBonsaiStorage() {
+    return new BonsaiWorldStateKeyValueStorage(
+        new InMemoryKeyValueStorageProvider(),
+        new NoOpMetricsSystem(),
+        DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
+  }
+
+  /**
+   * Returns the account trie root hash from {@code coordinator}'s flat storage, or {@link
+   * Hash#EMPTY_TRIE_HASH} if the storage is empty.
+   */
+  static Hash worldStateRoot(final WorldStateStorageCoordinator coordinator) {
+    return coordinator.getTrieNodeUnsafe(Bytes.EMPTY).map(Hash::hash).orElse(Hash.EMPTY_TRIE_HASH);
+  }
+
+  /**
+   * Returns a {@link DownloadedAccountRangeTracker} that covers the entire address space as a
+   * single already-completed range, simulating a fully-downloaded world state.
+   */
+  static DownloadedAccountRangeTracker fullAccountRange() {
+    final DownloadedAccountRangeTracker tracker = new DownloadedAccountRangeTracker();
+    tracker.registerPending(
+        Bytes32.ZERO,
+        Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        0);
+    return tracker;
+  }
+
+  /** A real reorg fetcher serving from {@code canonicalStorage}, counting calls per seam. */
+  static SnapV2ReorgStateFetcher servingFetcher(
+      final BonsaiWorldStateKeyValueStorage canonicalStorage,
+      final Hash canonicalRoot,
+      final WorldStateStorageCoordinator localCoordinator,
+      final AtomicInteger accountFetches,
+      final AtomicInteger storageFetches,
+      final AtomicInteger codeFetches) {
+    final SnapTestServing serving = new SnapTestServing(canonicalStorage, canonicalRoot);
+    return new SnapV2ReorgStateFetcher(
+        (start, end, pivot) -> {
+          accountFetches.incrementAndGet();
+          return serving.accountRange(start, end, pivot);
+        },
+        (accounts, start, end, pivot) -> {
+          storageFetches.incrementAndGet();
+          return serving.storageRange(accounts, start, end, pivot);
+        },
+        (codeHashes, pivot) -> {
+          codeFetches.incrementAndGet();
+          return serving.byteCodes(codeHashes, pivot);
+        },
+        localCoordinator);
   }
 
   // ---- BAL construction helpers ----

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplierReorgTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2BlockAccessListApplierReorgTest.java
@@ -16,11 +16,14 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.accountExists;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readAccount;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readCode;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readStorageSlot;
 import static org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator.applyForStrategy;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -36,7 +39,6 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.WorldStateKeyValueStorage;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -162,7 +164,7 @@ class SnapV2BlockAccessListApplierReorgTest {
     // Post-orphan flat state: only Alice exists; Grace was never seen on either fork at download
     // time.
     seedAccount(ALICE, Wei.of(50));
-    assertThat(accountExists(GRACE)).isFalse();
+    assertThat(accountExists(coordinator, GRACE)).isFalse();
 
     applier(b)
         .applyBlockAccessLists(
@@ -173,7 +175,7 @@ class SnapV2BlockAccessListApplierReorgTest {
         .commit();
 
     assertThat(readBalance(ALICE)).isEqualTo(Wei.of(80));
-    final PmtStateTrieAccountValue grace = readAccount(GRACE);
+    final PmtStateTrieAccountValue grace = readAccount(coordinator, GRACE);
     assertThat(grace.getBalance()).isEqualTo(Wei.of(50));
     assertThat(grace.getNonce()).isZero();
     assertThat(grace.getCodeHash()).isEqualTo(Hash.EMPTY);
@@ -299,10 +301,10 @@ class SnapV2BlockAccessListApplierReorgTest {
         .commit();
 
     // s1: canonical write applied, and the account's storage root moved off the empty trie.
-    assertThat(readStorageSlot(FRANK, slot1)).hasValue(UInt256.valueOf(111));
-    assertThat(readAccount(FRANK).getStorageRoot()).isNotEqualTo(Hash.EMPTY_TRIE_HASH);
+    assertThat(readStorageSlot(coordinator, FRANK, slot1)).hasValue(UInt256.valueOf(111));
+    assertThat(readAccount(coordinator, FRANK).getStorageRoot()).isNotEqualTo(Hash.EMPTY_TRIE_HASH);
     // s2: diverged — stale orphaned value retained; a later re-fetch step will correct it.
-    assertThat(readStorageSlot(FRANK, slot2)).hasValue(UInt256.valueOf(200));
+    assertThat(readStorageSlot(coordinator, FRANK, slot2)).hasValue(UInt256.valueOf(200));
   }
 
   /**
@@ -339,7 +341,7 @@ class SnapV2BlockAccessListApplierReorgTest {
             new DownloadedStorageRangeTracker())
         .commit();
 
-    assertThat(readStorageSlot(FRANK, slot1)).isEmpty();
+    assertThat(readStorageSlot(coordinator, FRANK, slot1)).isEmpty();
   }
 
   // ---------------------------------------------------------------------------
@@ -382,7 +384,7 @@ class SnapV2BlockAccessListApplierReorgTest {
         .commit();
 
     assertThat(readBalance(ALICE)).isEqualTo(Wei.of(80));
-    assertThat(accountExists(DAVE)).isFalse();
+    assertThat(accountExists(coordinator, DAVE)).isFalse();
   }
 
   // ---------------------------------------------------------------------------
@@ -424,14 +426,14 @@ class SnapV2BlockAccessListApplierReorgTest {
         .commit();
 
     // Alice: nonce applied, balance (untouched by the canonical BAL) preserved.
-    final PmtStateTrieAccountValue alice = readAccount(ALICE);
+    final PmtStateTrieAccountValue alice = readAccount(coordinator, ALICE);
     assertThat(alice.getNonce()).isEqualTo(7L);
     assertThat(alice.getBalance()).isEqualTo(Wei.of(50));
 
     // Charlie: code stored and code hash updated (the "deployed on both forks" case).
-    final PmtStateTrieAccountValue charlie = readAccount(CHARLIE);
+    final PmtStateTrieAccountValue charlie = readAccount(coordinator, CHARLIE);
     assertThat(charlie.getCodeHash()).isEqualTo(Hash.hash(code));
-    assertThat(readCode(CHARLIE)).hasValue(code);
+    assertThat(readCode(coordinator, CHARLIE)).hasValue(code);
   }
 
   // ---------------------------------------------------------------------------
@@ -577,36 +579,6 @@ class SnapV2BlockAccessListApplierReorgTest {
   }
 
   private Wei readBalance(final Address address) {
-    return readAccount(address).getBalance();
-  }
-
-  private PmtStateTrieAccountValue readAccount(final Address address) {
-    return PmtStateTrieAccountValue.readFrom(RLP.input(readAccountBytes(address).orElseThrow()));
-  }
-
-  private boolean accountExists(final Address address) {
-    return readAccountBytes(address).isPresent();
-  }
-
-  private Optional<Bytes> readAccountBytes(final Address address) {
-    return coordinator.applyForStrategy(
-        bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
-  }
-
-  private Optional<UInt256> readStorageSlot(final Address address, final UInt256 slotKey) {
-    return coordinator
-        .applyForStrategy(
-            bonsai ->
-                bonsai.getStorageValueByStorageSlotKey(
-                    address.addressHash(), new StorageSlotKey(slotKey)),
-            forest -> Optional.<Bytes>empty())
-        .map(UInt256::fromBytes);
-  }
-
-  private Optional<Bytes> readCode(final Address address) {
-    final PmtStateTrieAccountValue account = readAccount(address);
-    return coordinator.applyForStrategy(
-        bonsai -> bonsai.getCode(account.getCodeHash(), address.addressHash()),
-        forest -> Optional.<Bytes>empty());
+    return readAccount(coordinator, address).getBalance();
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2ReorgHealerRecoveryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2ReorgHealerRecoveryTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.accountExists;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.fullAccountRange;
 import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readAccount;
 import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readCode;
 import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readStorageSlot;
@@ -479,11 +480,5 @@ class SnapV2ReorgHealerRecoveryTest {
 
   private static Hash worldStateRoot(final WorldStateStorageCoordinator coordinator) {
     return coordinator.getTrieNodeUnsafe(Bytes.EMPTY).map(Hash::hash).orElse(Hash.EMPTY_TRIE_HASH);
-  }
-
-  private static DownloadedAccountRangeTracker fullAccountRange() {
-    final DownloadedAccountRangeTracker tracker = new DownloadedAccountRangeTracker();
-    tracker.registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    return tracker;
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2ReorgHealerRecoveryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2ReorgHealerRecoveryTest.java
@@ -16,10 +16,13 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.accountExists;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readAccount;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readCode;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readStorageSlot;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -27,7 +30,6 @@ import org.hyperledger.besu.ethereum.eth.manager.snap.SnapTestServing;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
-import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
@@ -35,7 +37,6 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -158,27 +159,28 @@ class SnapV2ReorgHealerRecoveryTest {
             block2s.getHeader(), newPivotBlock.getHeader(), accountTracker, storageTracker);
 
     // Accounts the canonical fork touched come from the canonical BALs.
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
-    assertThat(readAccount(FRANK).getBalance()).isEqualTo(Wei.of(140));
-    assertThat(readAccount(GRACE).getBalance()).isEqualTo(Wei.of(50));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, FRANK).getBalance()).isEqualTo(Wei.of(140));
+    assertThat(readAccount(localCoordinator, GRACE).getBalance()).isEqualTo(Wei.of(50));
     // Untouched by either fork.
-    assertThat(readAccount(BOB).getBalance()).isEqualTo(Wei.of(100));
+    assertThat(readAccount(localCoordinator, BOB).getBalance()).isEqualTo(Wei.of(100));
     // Orphaned-fork-only scalar change: restored by the re-fetch.
-    assertThat(readAccount(DAVE).getBalance()).isEqualTo(Wei.of(75));
+    assertThat(readAccount(localCoordinator, DAVE).getBalance()).isEqualTo(Wei.of(75));
     // Orphaned-fork-only code change: record restored; the code was already local.
-    assertThat(readAccount(CAROL).getCodeHash()).isEqualTo(Hash.hash(CAROL_CODE_W));
-    assertThat(readCode(CAROL)).hasValue(CAROL_CODE_W);
+    assertThat(readAccount(localCoordinator, CAROL).getCodeHash())
+        .isEqualTo(Hash.hash(CAROL_CODE_W));
+    assertThat(readCode(localCoordinator, CAROL)).hasValue(CAROL_CODE_W);
     assertThat(codeFetches).hasValue(0);
 
     // Frank's storage: overlapping slot s1 restored, orphaned-only slot s2 removed,
     // canonical-only slot s3 created by the BALs.
-    assertThat(readStorageSlot(FRANK, S1)).hasValue(UInt256.valueOf(7));
-    assertThat(readStorageSlot(FRANK, S2)).isEmpty();
-    assertThat(readStorageSlot(FRANK, S3)).hasValue(UInt256.valueOf(555));
+    assertThat(readStorageSlot(localCoordinator, FRANK, S1)).hasValue(UInt256.valueOf(7));
+    assertThat(readStorageSlot(localCoordinator, FRANK, S2)).isEmpty();
+    assertThat(readStorageSlot(localCoordinator, FRANK, S3)).hasValue(UInt256.valueOf(555));
 
     // The contract created only on the orphaned fork is deleted with its storage.
-    assertThat(accountExists(NEW_CONTRACT)).isFalse();
-    assertThat(readStorageSlot(NEW_CONTRACT, SN)).isEmpty();
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isFalse();
+    assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SN)).isEmpty();
     assertThat(result.deletedAccounts()).containsExactly(NEW_CONTRACT.addressHash());
 
     // Re-fetched surviving accounts report their canonical storage roots.
@@ -235,7 +237,7 @@ class SnapV2ReorgHealerRecoveryTest {
     assertThat(codeFetches).hasValue(0);
     assertThat(result.deletedAccounts()).isEmpty();
     assertThat(result.correctedStorageRoots()).isEmpty();
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -294,8 +296,8 @@ class SnapV2ReorgHealerRecoveryTest {
                 PETE, Map.of(SP1, UInt256.valueOf(10), SP2, UInt256.valueOf(20))),
             3L);
     applyTo(localCoordinator, 3, 3, accountTracker, storageTracker);
-    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(10));
-    assertThat(readStorageSlot(PETE, SP2)).isEmpty();
+    assertThat(readStorageSlot(localCoordinator, PETE, SP1)).hasValue(UInt256.valueOf(10));
+    assertThat(readStorageSlot(localCoordinator, PETE, SP2)).isEmpty();
 
     // Canonical fork: balance only.
     final Block block3c =
@@ -318,9 +320,9 @@ class SnapV2ReorgHealerRecoveryTest {
 
     // Balance from the canonical BAL; the downloaded slot is restored from the re-fetch. sp2 was
     // never downloaded and the canonical fork never touched it, so it is not re-fetched.
-    assertThat(readAccount(PETE).getBalance()).isEqualTo(Wei.of(300));
-    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(1));
-    assertThat(readStorageSlot(PETE, SP2)).isEmpty();
+    assertThat(readAccount(localCoordinator, PETE).getBalance()).isEqualTo(Wei.of(300));
+    assertThat(readStorageSlot(localCoordinator, PETE, SP1)).hasValue(UInt256.valueOf(1));
+    assertThat(readStorageSlot(localCoordinator, PETE, SP2)).isEmpty();
     assertThat(accountFetches).hasValue(1);
     assertThat(storageFetches).hasValue(1);
     assertThat(codeFetches).hasValue(0);
@@ -330,7 +332,8 @@ class SnapV2ReorgHealerRecoveryTest {
     // equality is asserted here: the local storage stays incomplete until sp2's chunk arrives
     // via the ongoing download.
     final PmtStateTrieAccountValue canonicalPete = readAccount(canonicalCoordinator, PETE);
-    assertThat(readAccount(PETE).getStorageRoot()).isEqualTo(canonicalPete.getStorageRoot());
+    assertThat(readAccount(localCoordinator, PETE).getStorageRoot())
+        .isEqualTo(canonicalPete.getStorageRoot());
     assertThat(result.deletedAccounts()).isEmpty();
     assertThat(result.correctedStorageRoots())
         .containsEntry(PETE.addressHash(), Bytes32.wrap(canonicalPete.getStorageRoot().getBytes()));
@@ -370,7 +373,7 @@ class SnapV2ReorgHealerRecoveryTest {
             b.balWithStorageChanges(NEW_CONTRACT, Map.of(SN, UInt256.valueOf(5))));
     final Block block2s = b.appendStale(block1.getHeader(), orphanedBal, 2L);
     applyTo(localCoordinator, 2, 2, accountTracker, storageTracker);
-    assertThat(readStorageSlot(NEW_CONTRACT, SN)).hasValue(UInt256.valueOf(5));
+    assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SN)).hasValue(UInt256.valueOf(5));
 
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
@@ -387,10 +390,10 @@ class SnapV2ReorgHealerRecoveryTest {
         healer.recoverFromReorg(
             block2s.getHeader(), newPivotBlock.getHeader(), accountTracker, storageTracker);
 
-    assertThat(accountExists(NEW_CONTRACT)).isFalse();
-    assertThat(readStorageSlot(NEW_CONTRACT, SN)).isEmpty();
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isFalse();
+    assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SN)).isEmpty();
     assertThat(result.deletedAccounts()).containsExactly(NEW_CONTRACT.addressHash());
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -482,42 +485,5 @@ class SnapV2ReorgHealerRecoveryTest {
     final DownloadedAccountRangeTracker tracker = new DownloadedAccountRangeTracker();
     tracker.registerPending(Bytes32.ZERO, MAX_KEY, 0);
     return tracker;
-  }
-
-  private PmtStateTrieAccountValue readAccount(final Address address) {
-    return readAccount(localCoordinator, address);
-  }
-
-  private static PmtStateTrieAccountValue readAccount(
-      final WorldStateStorageCoordinator coordinator, final Address address) {
-    return PmtStateTrieAccountValue.readFrom(
-        RLP.input(readAccountBytes(coordinator, address).orElseThrow()));
-  }
-
-  private boolean accountExists(final Address address) {
-    return readAccountBytes(localCoordinator, address).isPresent();
-  }
-
-  private static Optional<Bytes> readAccountBytes(
-      final WorldStateStorageCoordinator coordinator, final Address address) {
-    return coordinator.applyForStrategy(
-        bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
-  }
-
-  private Optional<UInt256> readStorageSlot(final Address address, final UInt256 slotKey) {
-    return localCoordinator
-        .applyForStrategy(
-            bonsai ->
-                bonsai.getStorageValueByStorageSlotKey(
-                    address.addressHash(), new StorageSlotKey(slotKey)),
-            forest -> Optional.<Bytes>empty())
-        .map(UInt256::fromBytes);
-  }
-
-  private Optional<Bytes> readCode(final Address address) {
-    final PmtStateTrieAccountValue account = readAccount(address);
-    return localCoordinator.applyForStrategy(
-        bonsai -> bonsai.getCode(account.getCodeHash(), address.addressHash()),
-        forest -> Optional.<Bytes>empty());
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -32,6 +33,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncMetricsManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.rlp.RLP;
@@ -663,6 +665,124 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     // ALICE is not in the persisted range: skipped by planReorg and applyCanonicalBals.
     assertThat(accountExists(ALICE)).isFalse();
     assertThat(accountFetches).hasValue(0); // no re-download triggered
+  }
+
+  // ── Test 14: same-chain advance → BALs [old+1,new] applied, request retargeted, no fetch ──────
+
+  /**
+   * Straight canonical chain: gen ─ 1(ALICE=100) ─ 2(ALICE=50)[old pivot] ─ 3(ALICE=80)[new pivot].
+   * All blocks have HIGH difficulty so all are canonical. {@code areBothBlocksOnCanonicalChain}
+   * returns {@code true} → the same-chain branch runs: apply BALs [3,3], retarget queued account
+   * request to new pivot. No peer fetches because ALICE has no storage (pendingAffected is empty).
+   */
+  @Test
+  void sameChainPivotAdvance_appliesBalsAndRetargets_noReorg() {
+    final Block block1 =
+        b.appendCanonical(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2 =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+
+    // Apply [1,2] to canonical coordinator.
+    applyTo(
+        canonicalCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Build and append block3 (ALICE=80) before applying its BAL so the blockchain holds it.
+    final Block block3 =
+        b.appendCanonical(block2.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 3L);
+
+    // Apply [3,3] to canonical now that block3 is in the blockchain.
+    applyTo(
+        canonicalCoordinator,
+        3,
+        3,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Create download state with block2 as the (old) current pivot.
+    final SnapV2WorldDownloadState state =
+        createDownloadState(
+            block2.getHeader(), ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator));
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    // Queue an account request targeted at block2 — it must be retargeted to block3.
+    final SnapV2AccountRangeRequest accountReq =
+        new SnapV2AccountRangeRequest(
+            block2.getHeader(), RangeManager.MIN_RANGE, RangeManager.MAX_RANGE);
+    state.enqueueRequest(accountReq);
+
+    startCatchupAndAwait(state, block3.getHeader());
+
+    // BAL [3,3] applied: ALICE=80. No re-download (same canonical chain).
+    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(accountFetches).hasValue(0);
+    // Queued account request retargeted to the new pivot.
+    final SnapV2AccountRangeRequest retargetedReq =
+        (SnapV2AccountRangeRequest) state.pendingAccountRequests.asList().get(0);
+    assertThat(retargetedReq.getPivotBlockHeader()).isEqualTo(block3.getHeader());
+    // Local and canonical world states agree.
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator))
+        .isEqualTo(ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator));
+  }
+
+  // ── Test 9: unrecoverable reorg → failure propagated through downloadFuture ─────────────────
+
+  /**
+   * The orphaned block's BAL is NOT stored locally (simulates a pruned orphaned BAL). The healer
+   * cannot plan the reorg → {@link SnapV2ReorgHealer#planReorg} throws {@link
+   * ReorgUnrecoverableException} → {@code startPivotCatchup} completes {@code internalFuture}
+   * exceptionally → {@code downloadFuture} is also completed exceptionally.
+   *
+   * <pre>
+   * gen -- 1() -- 2s(ALICE=50)   orphaned, BAL not stored
+   *            \-- 2c(ALICE=80)  canonical
+   *                  \-- 3c (pins canonicalRoot, new pivot)
+   * </pre>
+   */
+  @Test
+  void unrecoverableReorg_propagatesFailure() {
+    final Block block1 = b.appendBlockWithBal(b.header(0), b.emptyBal(), 1L);
+    // Orphaned block whose BAL header-hash is committed but the BAL itself is NOT stored.
+    final Block block2s =
+        b.appendStaleWithoutStoringBal(
+            block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    // Build canonical world state and compute its root.
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state with the stale (orphaned) block2s as the current pivot.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    // Apply only block1 locally; block2s was never applied (simulates partial download).
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    // Trigger pivot catchup without awaiting — the reorg healer cannot read the orphaned BAL
+    // and must throw ReorgUnrecoverableException synchronously (0 in-flight tasks, pre-completed
+    // listener future → finishPivotCatchup runs on the calling thread).
+    state.startPivotCatchup(newPivot.getHeader());
+
+    assertThat(state.getDownloadFuture()).isCompletedExceptionally();
+    assertThatThrownBy(() -> state.getDownloadFuture().join())
+        .hasRootCauseInstanceOf(ReorgUnrecoverableException.class);
   }
 
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -221,7 +221,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         new SnapV2StorageRangeRequest(
             block2s.getHeader(),
             Bytes32.wrap(NEW_CONTRACT.addressHash().getBytes()),
-            Bytes32.random(),
+            Bytes32.ZERO,
             RangeManager.MIN_RANGE,
             RangeManager.MAX_RANGE,
             RangeManager.MIN_RANGE);
@@ -573,7 +573,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     // Apply only block1 locally; block2s was never applied (simulates partial download).
     seedLocal(state, 1, 1);
 
-    // Orphaned BAL is unreadable → ReorgUnrecoverableException thrown synchronously.
+    // Orphaned BAL is unreadable → startPivotCatchup completes the download future exceptionally.
     state.startPivotCatchup(newPivot.getHeader());
 
     assertThat(state.getDownloadFuture()).isCompletedExceptionally();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -16,6 +16,10 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.accountExists;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readAccount;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readCode;
+import static org.hyperledger.besu.ethereum.eth.sync.snapsync.v2.ReorgBlockchainBuilder.readStorageSlot;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -32,7 +36,6 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTra
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncMetricsManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
-import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountRangeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
@@ -41,6 +44,7 @@ import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.SyncDurationMetrics;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -86,11 +90,17 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private static final UInt256 SLOT_DEFERRED = UInt256.valueOf(102);
 
   private final BonsaiWorldStateKeyValueStorage localStorage =
-      ReorgBlockchainBuilder.newBonsaiStorage();
+      new BonsaiWorldStateKeyValueStorage(
+          new InMemoryKeyValueStorageProvider(),
+          new NoOpMetricsSystem(),
+          DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
   private final WorldStateStorageCoordinator localCoordinator =
       new WorldStateStorageCoordinator(localStorage);
   private final BonsaiWorldStateKeyValueStorage canonicalStorage =
-      ReorgBlockchainBuilder.newBonsaiStorage();
+      new BonsaiWorldStateKeyValueStorage(
+          new InMemoryKeyValueStorageProvider(),
+          new NoOpMetricsSystem(),
+          DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
   private final WorldStateStorageCoordinator canonicalCoordinator =
       new WorldStateStorageCoordinator(canonicalStorage);
 
@@ -125,9 +135,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     seedLocal(state, 1, 2);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80)); // canonical value applied
+    assertThat(readAccount(localCoordinator, ALICE).getBalance())
+        .isEqualTo(Wei.of(80)); // canonical value applied
     assertThat(accountFetches).hasValue(0); // Category YES+YES: no re-download
     assertThat(storageFetches).hasValue(0);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
@@ -155,10 +166,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     seedLocal(state, 1, 2);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     // ORPHAN_EOA was modified by orphaned fork but is absent from canonical BAL → re-downloaded.
-    assertThat(readAccount(ORPHAN_EOA).getBalance()).isEqualTo(Wei.of(75));
+    assertThat(readAccount(localCoordinator, ORPHAN_EOA).getBalance()).isEqualTo(Wei.of(75));
     assertThat(accountFetches.get()).isGreaterThanOrEqualTo(1);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
@@ -187,8 +198,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         new DownloadedStorageRangeTracker());
 
     // Verify NEW_CONTRACT is present locally before the canonical fork arrives.
-    assertThat(readStorageSlot(NEW_CONTRACT, SLOT_BASE)).hasValue(UInt256.valueOf(5));
-    assertThat(accountExists(NEW_CONTRACT)).isTrue();
+    assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SLOT_BASE))
+        .hasValue(UInt256.valueOf(5));
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isTrue();
 
     // Canonical fork (block2c) wins the reorg; NEW_CONTRACT is absent from canonical chain.
     final Block block2c =
@@ -220,16 +232,16 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.enqueueRequest(storageReq);
     state.enqueueRequest(codeReq);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     // NEW_CONTRACT must be gone from local state.
-    assertThat(accountExists(NEW_CONTRACT)).isFalse();
-    assertThat(readStorageSlot(NEW_CONTRACT, SLOT_BASE)).isEmpty();
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isFalse();
+    assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SLOT_BASE)).isEmpty();
     // Queued child requests for the doomed contract must have been purged.
     assertThat(state.pendingStorageRequests.asList()).isEmpty();
     assertThat(state.pendingCodeRequests.asList()).isEmpty();
     // ALICE carries through from the canonical BAL.
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -255,11 +267,11 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
     seedLocal(state, 1, 2);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(CANONICAL_NEW).getBalance())
+    assertThat(readAccount(localCoordinator, CANONICAL_NEW).getBalance())
         .isEqualTo(Wei.of(50)); // created from canonical BAL
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -285,9 +297,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
     seedLocal(state, 1, 2);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(UNTOUCHED).getBalance())
+    assertThat(readAccount(localCoordinator, UNTOUCHED).getBalance())
         .isEqualTo(Wei.of(100)); // untouched by both forks
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
@@ -335,7 +347,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
     // Queue a storage request for STORAGE_ACCT with the (soon-stale) orphaned storage root.
-    final Bytes32 oldRoot = Bytes32.wrap(readAccount(STORAGE_ACCT).getStorageRoot().getBytes());
+    final Bytes32 oldRoot =
+        Bytes32.wrap(readAccount(localCoordinator, STORAGE_ACCT).getStorageRoot().getBytes());
     final SnapV2StorageRangeRequest frankReq =
         new SnapV2StorageRangeRequest(
             block2s.getHeader(),
@@ -346,12 +359,13 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             RangeManager.MIN_RANGE);
     state.enqueueRequest(frankReq);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_BASE))
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_BASE))
         .hasValue(UInt256.valueOf(7)); // restored to base value
-    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_ORPHAN)).isEmpty(); // orphaned-only slot removed
-    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_CANONICAL))
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_ORPHAN))
+        .isEmpty(); // orphaned-only slot removed
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_CANONICAL))
         .hasValue(UInt256.valueOf(555)); // canonical slot applied
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
 
@@ -361,7 +375,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final SnapV2StorageRangeRequest retargeted = (SnapV2StorageRangeRequest) queued.get(0);
     assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
     final Bytes32 canonicalFrankRoot =
-        Bytes32.wrap(readAccount(STORAGE_ACCT).getStorageRoot().getBytes());
+        Bytes32.wrap(readAccount(localCoordinator, STORAGE_ACCT).getStorageRoot().getBytes());
     assertThat(retargeted.getStorageRoot()).isEqualTo(canonicalFrankRoot);
   }
 
@@ -406,9 +420,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
                 Map.of(SLOT_DOWNLOADED, UInt256.valueOf(10), SLOT_DEFERRED, UInt256.valueOf(20))),
             3L);
     applyBals(localCoordinator, 3, 3, seedAccountTracker, seedStorageTracker);
-    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DOWNLOADED))
+    assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DOWNLOADED))
         .hasValue(UInt256.valueOf(10)); // downloaded, rewritten
-    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DEFERRED))
+    assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DEFERRED))
         .isEmpty(); // not downloaded, still absent
 
     // Block 3c (canonical, high difficulty): balance only; reorg makes it canonical at height 3.
@@ -430,7 +444,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             Bytes32.wrap(new StorageSlotKey(SLOT_DOWNLOADED).getSlotHash().getBytes()));
 
     // Queue PENDING_ACCT's in-progress storage request with the stale root.
-    final Bytes32 oldRoot = Bytes32.wrap(readAccount(PENDING_ACCT).getStorageRoot().getBytes());
+    final Bytes32 oldRoot =
+        Bytes32.wrap(readAccount(localCoordinator, PENDING_ACCT).getStorageRoot().getBytes());
     final SnapV2StorageRangeRequest peteReq =
         new SnapV2StorageRangeRequest(
             block3s.getHeader(),
@@ -441,12 +456,13 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             RangeManager.MIN_RANGE);
     state.enqueueRequest(peteReq);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     // SLOT_DOWNLOADED restored; SLOT_DEFERRED stays absent; canonical balance applied.
-    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DOWNLOADED)).hasValue(UInt256.valueOf(1));
-    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DEFERRED)).isEmpty();
-    assertThat(readAccount(PENDING_ACCT).getBalance()).isEqualTo(Wei.of(300));
+    assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DOWNLOADED))
+        .hasValue(UInt256.valueOf(1));
+    assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DEFERRED)).isEmpty();
+    assertThat(readAccount(localCoordinator, PENDING_ACCT).getBalance()).isEqualTo(Wei.of(300));
 
     // Storage root comes from root-patch, not recomputed from the still-incomplete trie.
     final PmtStateTrieAccountValue canonicalPete =
@@ -491,10 +507,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(state.getAccountRangeTracker().isAccountHashPersisted(aliceHash)).isFalse();
 
     // Do NOT apply any local BALs for ALICE — she is not in the persisted range.
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     // ALICE is not in the persisted range: skipped by planReorg and applyCanonicalBals.
-    assertThat(accountExists(ALICE)).isFalse();
+    assertThat(accountExists(localCoordinator, ALICE)).isFalse();
     assertThat(accountFetches).hasValue(0); // no re-download triggered
   }
 
@@ -526,9 +542,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             block2.getHeader(), RangeManager.MIN_RANGE, RangeManager.MAX_RANGE);
     state.enqueueRequest(accountReq);
 
-    startCatchupAndAwait(state, block3.getHeader());
+    state.startPivotCatchup(block3.getHeader());
 
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(accountFetches).hasValue(0);
     // Queued account request retargeted to the new pivot.
     final SnapV2AccountRangeRequest retargetedReq =
@@ -597,12 +613,13 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
     seedLocal(state, 1, 3);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80)); // YES+YES: canonical value
-    assertThat(readAccount(ORPHAN_EOA).getBalance())
+    assertThat(readAccount(localCoordinator, ALICE).getBalance())
+        .isEqualTo(Wei.of(80)); // YES+YES: canonical value
+    assertThat(readAccount(localCoordinator, ORPHAN_EOA).getBalance())
         .isEqualTo(Wei.of(75)); // YES+NO: restored from block1
-    assertThat(readAccount(CANONICAL_NEW).getBalance())
+    assertThat(readAccount(localCoordinator, CANONICAL_NEW).getBalance())
         .isEqualTo(Wei.of(50)); // NO+YES: new canonical account
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
@@ -635,7 +652,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     seedLocal(state, 1, 2);
 
     // Read CAROL's storage root from the local DB after seeding (she is untouched by both forks).
-    final Bytes32 carolRoot = Bytes32.wrap(readAccount(CAROL).getStorageRoot().getBytes());
+    final Bytes32 carolRoot =
+        Bytes32.wrap(readAccount(localCoordinator, CAROL).getStorageRoot().getBytes());
 
     final SnapV2StorageRangeRequest carolReq =
         new SnapV2StorageRangeRequest(
@@ -647,7 +665,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             RangeManager.MIN_RANGE);
     state.enqueueRequest(carolReq);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     final var queued = state.pendingStorageRequests.asList();
     assertThat(queued).hasSize(1);
@@ -686,7 +704,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.enqueueRequest(codeReq);
     state.enqueueRequest(accountReq);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     assertThat(
             ((SnapV2BytecodeRequest) state.pendingCodeRequests.asList().get(0))
@@ -737,10 +755,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     // Apply block 2 (canonical block2c has empty BAL — no-op for CAROL locally).
     seedLocal(state, 2, 2);
 
-    startCatchupAndAwait(state, newPivot.getHeader());
+    state.startPivotCatchup(newPivot.getHeader());
 
     // Code bytes must have been fetched and stored during reorg recovery.
-    assertThat(readCode(CAROL)).hasValue(carolCodeCanonical);
+    assertThat(readCode(localCoordinator, CAROL)).hasValue(carolCodeCanonical);
     assertThat(codeFetches.get()).isGreaterThanOrEqualTo(1);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
@@ -768,7 +786,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         localCoordinator,
         new SnapSyncStatePersistenceManager(new InMemoryKeyValueStorageProvider()),
         new SnapSyncProcessState(stalePivot),
-        new InMemoryTasksPriorityQueues<SnapDataRequest>(),
+        new InMemoryTasksPriorityQueues<>(),
         10,
         50_000L,
         new SnapSyncMetricsManager(new NoOpMetricsSystem(), ethContext),
@@ -809,40 +827,5 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             coordinator, b.blockchain(), ReorgBlockchainBuilder.balEnabledSchedule())
         .applyBlockAccessLists(fromBlock, toBlock, accountTracker, storageTracker)
         .commit();
-  }
-
-  private void startCatchupAndAwait(
-      final SnapV2WorldDownloadState state, final BlockHeader newPivot) {
-    state.startPivotCatchup(newPivot);
-    // finishPivotCatchup runs synchronously here (no in-flight tasks, pre-completed future).
-  }
-
-  private PmtStateTrieAccountValue readAccount(final Address address) {
-    return PmtStateTrieAccountValue.readFrom(RLP.input(readAccountBytes(address).orElseThrow()));
-  }
-
-  private Optional<Bytes> readAccountBytes(final Address address) {
-    return localCoordinator.applyForStrategy(
-        bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
-  }
-
-  private boolean accountExists(final Address address) {
-    return readAccountBytes(address).isPresent();
-  }
-
-  private Optional<UInt256> readStorageSlot(final Address address, final UInt256 slot) {
-    return localCoordinator
-        .applyForStrategy(
-            bonsai ->
-                bonsai.getStorageValueByStorageSlotKey(
-                    address.addressHash(), new StorageSlotKey(slot)),
-            forest -> Optional.<Bytes>empty())
-        .map(UInt256::fromBytes);
-  }
-
-  private Optional<Bytes> readCode(final Address address) {
-    return readAccountBytes(address)
-        .map(bytes -> PmtStateTrieAccountValue.readFrom(RLP.input(bytes)).getCodeHash())
-        .flatMap(codeHash -> localCoordinator.getCode(codeHash, address.addressHash()));
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -57,58 +57,33 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 
-/**
- * Integration tests for the snap/2 reorg recovery pipeline driven through {@link
- * SnapV2WorldDownloadState#startPivotCatchup}. No mocks: a real blockchain, real Bonsai world
- * states (local + canonical), a real {@link SnapV2ReorgHealer} whose fetcher serves the canonical
- * state through a real {@link org.hyperledger.besu.ethereum.eth.manager.snap.SnapTestServing}, and
- * a real {@link EthContext}. Each test asserts the resulting world state, queue, and tracker
- * outcomes.
- */
+/** Integration tests for the snap/2 reorg recovery. */
 class SnapV2WorldDownloadStateReorgIntegrationTest {
 
   private static final Address ALICE =
       Address.fromHexString("0x1111111111111111111111111111111111111111");
-
-  // Test 2 — YES+NO (present in canonical): orphaned fork changed DAVE; canonical fork did not.
-  private static final Address DAVE =
-      Address.fromHexString("0x4444444444444444444444444444444444444444");
-
-  // Test 3 — YES+NO (absent from canonical): contract exists only on orphaned fork.
-  private static final Address NEW_CONTRACT =
-      Address.fromHexString("0x9999999999999999999999999999999999999999");
-
-  private static final Bytes NC_CODE = Bytes.fromHexString("0x60806040523480156010");
-
-  private static final UInt256 S1 = UInt256.valueOf(1);
-  private static final UInt256 S2 = UInt256.valueOf(2);
-  private static final UInt256 S3 = UInt256.valueOf(3);
-
-  // Test 4 — NO+YES: account created only on canonical fork.
-  private static final Address GRACE =
-      Address.fromHexString("0x7777777777777777777777777777777777777777");
-
-  // Test 5 — NO+NO: account exists at block1, neither fork touches it.
-  private static final Address BOB =
-      Address.fromHexString("0x2222222222222222222222222222222222222222");
-
-  // Test 6 — slot-level YES+NO: orphaned fork changes S1+S2, canonical fork sets S3.
-  private static final Address FRANK =
-      Address.fromHexString("0x6666666666666666666666666666666666666666");
-
-  // Tests 7, 8 — download-status rules (PENDING and not-yet-downloaded).
-  private static final Address PETE =
-      Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
-  private static final UInt256 SP1 = UInt256.valueOf(101);
-  private static final UInt256 SP2 = UInt256.valueOf(102);
-
-  private static final Bytes32 MAX_KEY =
-      Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-
-  // Test 11 — unaffected account with storage (not touched by either fork)
   private static final Address CAROL =
       Address.fromHexString("0x3333333333333333333333333333333333333333");
+  private static final Address ORPHAN_EOA =
+      Address.fromHexString("0x4444444444444444444444444444444444444444");
+  private static final Address STORAGE_ACCT =
+      Address.fromHexString("0x6666666666666666666666666666666666666666");
+  private static final Address CANONICAL_NEW =
+      Address.fromHexString("0x7777777777777777777777777777777777777777");
+  private static final Address NEW_CONTRACT =
+      Address.fromHexString("0x9999999999999999999999999999999999999999");
+  private static final Address PENDING_ACCT =
+      Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+  private static final Address UNTOUCHED =
+      Address.fromHexString("0x2222222222222222222222222222222222222222");
+
+  private static final Bytes NEW_CONTRACT_CODE = Bytes.fromHexString("0x60806040523480156010");
+
+  private static final UInt256 SLOT_BASE = UInt256.valueOf(1);
+  private static final UInt256 SLOT_ORPHAN = UInt256.valueOf(2);
+  private static final UInt256 SLOT_CANONICAL = UInt256.valueOf(3);
+  private static final UInt256 SLOT_DOWNLOADED = UInt256.valueOf(101);
+  private static final UInt256 SLOT_DEFERRED = UInt256.valueOf(102);
 
   private final BonsaiWorldStateKeyValueStorage localStorage =
       ReorgBlockchainBuilder.newBonsaiStorage();
@@ -120,6 +95,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
       new WorldStateStorageCoordinator(canonicalStorage);
 
   private final ReorgBlockchainBuilder b = new ReorgBlockchainBuilder();
+
   private final EthContext ethContext =
       EthProtocolManagerTestBuilder.builder().build().ethContext();
 
@@ -127,11 +103,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private final AtomicInteger storageFetches = new AtomicInteger();
   private final AtomicInteger codeFetches = new AtomicInteger();
 
-  // ── Test 1: matrix YES + YES → apply canonical BAL, no re-download ───────────────────────────
-
   @Test
   void modifiedInOrphanedAndNewBlock_appliesNewBalWithoutReDownload() {
-    // Build all blockchain blocks first.
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
     // orphaned (2s): Alice = 50  — appended first so it is initially canonical
@@ -141,32 +114,16 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    // Build canonical world state.
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create download state with stale pivot; then seed trackers and apply local BALs.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
 
-    // Register the full address space as already downloaded.
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
-    // Apply canonical local BALs using the state's trackers so the healer sees a complete picture.
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    seedLocal(state, 1, 2);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
@@ -176,60 +133,38 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
-  // ── Test 2: matrix YES + NO (present in canonical) → re-download and restore ─────────────────
-
   @Test
   void modifiedInOrphanedButNotNewBlock_reDownloadsAndUpdatesWhenPresent() {
-    // Build all blockchain blocks first.
     final Block block1 =
-        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(DAVE, Wei.of(75))), 1L);
-    // orphaned (2s): DAVE = 60 — appended first so it is initially canonical
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ORPHAN_EOA, Wei.of(75))), 1L);
+    // orphaned (2s): ORPHAN_EOA = 60 — appended first so it is initially canonical
     final Block block2s =
-        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(DAVE, Wei.of(60))), 2L);
-    // canonical (2c): ALICE = 80, DAVE untouched — higher difficulty wins the reorg
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ORPHAN_EOA, Wei.of(60))), 2L);
+    // canonical (2c): ALICE = 80, ORPHAN_EOA untouched — higher difficulty wins the reorg
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    // Build canonical world state first so we can pin the state root.
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create download state with stale pivot; then seed trackers and apply local BALs.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
 
-    // Register the full address space as already downloaded.
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
-    // Apply canonical BALs to local using the state's trackers.
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    seedLocal(state, 1, 2);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
-    // DAVE was modified by orphaned fork but is absent from canonical BAL → re-downloaded.
-    assertThat(readAccount(DAVE).getBalance()).isEqualTo(Wei.of(75));
+    // ORPHAN_EOA was modified by orphaned fork but is absent from canonical BAL → re-downloaded.
+    assertThat(readAccount(ORPHAN_EOA).getBalance()).isEqualTo(Wei.of(75));
     assertThat(accountFetches.get()).isGreaterThanOrEqualTo(1);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
-  // ── Test 3: matrix YES + NO (absent from canonical) → delete + purge queued child requests ────
-
   @Test
   void modifiedInOrphanedButNotNewBlock_deletesWhenAbsentFromCanonical() {
-    // Build common-ancestor block.
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 1L);
 
@@ -239,12 +174,12 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             block1.getHeader(),
             b.merge(
                 b.balWithBalances(Map.of(NEW_CONTRACT, Wei.ONE)),
-                b.balWithCodeChange(NEW_CONTRACT, NC_CODE),
-                b.balWithStorageChanges(NEW_CONTRACT, Map.of(S1, UInt256.valueOf(5)))),
+                b.balWithCodeChange(NEW_CONTRACT, NEW_CONTRACT_CODE),
+                b.balWithStorageChanges(NEW_CONTRACT, Map.of(SLOT_BASE, UInt256.valueOf(5)))),
             2L);
 
     // Pre-seed local with the orphaned state while block2s is still canonical at height 2.
-    applyTo(
+    applyBals(
         localCoordinator,
         1,
         2,
@@ -252,33 +187,20 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         new DownloadedStorageRangeTracker());
 
     // Verify NEW_CONTRACT is present locally before the canonical fork arrives.
-    assertThat(readStorageSlot(NEW_CONTRACT, S1)).hasValue(UInt256.valueOf(5));
+    assertThat(readStorageSlot(NEW_CONTRACT, SLOT_BASE)).hasValue(UInt256.valueOf(5));
     assertThat(accountExists(NEW_CONTRACT)).isTrue();
 
     // Canonical fork (block2c) wins the reorg; NEW_CONTRACT is absent from canonical chain.
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    // Build canonical world state and compute its root.
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create the download state with the orphaned block as its starting pivot.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
     // Queue a storage-range and a bytecode request for the doomed contract so the purge is tested.
     final SnapV2StorageRangeRequest storageReq =
@@ -293,7 +215,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         new SnapV2BytecodeRequest(
             block2s.getHeader(),
             Bytes32.wrap(NEW_CONTRACT.addressHash().getBytes()),
-            Bytes32.wrap(Hash.hash(NC_CODE).getBytes()),
+            Bytes32.wrap(Hash.hash(NEW_CONTRACT_CODE).getBytes()),
             RangeManager.MIN_RANGE);
     state.enqueueRequest(storageReq);
     state.enqueueRequest(codeReq);
@@ -302,7 +224,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     // NEW_CONTRACT must be gone from local state.
     assertThat(accountExists(NEW_CONTRACT)).isFalse();
-    assertThat(readStorageSlot(NEW_CONTRACT, S1)).isEmpty();
+    assertThat(readStorageSlot(NEW_CONTRACT, SLOT_BASE)).isEmpty();
     // Queued child requests for the doomed contract must have been purged.
     assertThat(state.pendingStorageRequests.asList()).isEmpty();
     assertThat(state.pendingCodeRequests.asList()).isEmpty();
@@ -310,8 +232,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
-
-  // ── Test 4: matrix NO + YES → new account created from canonical BAL ─────────────────────────
 
   @Test
   void notModifiedInOrphanedButModifiedInNewBlock_appliesNewBal() {
@@ -324,37 +244,24 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             block1.getHeader(),
             b.merge(
                 b.balWithBalances(Map.of(ALICE, Wei.of(80))),
-                b.balWithBalances(Map.of(GRACE, Wei.of(50)))),
+                b.balWithBalances(Map.of(CANONICAL_NEW, Wei.of(50)))),
             2L);
 
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 2);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
-    assertThat(readAccount(GRACE).getBalance()).isEqualTo(Wei.of(50)); // created from canonical BAL
+    assertThat(readAccount(CANONICAL_NEW).getBalance())
+        .isEqualTo(Wei.of(50)); // created from canonical BAL
     assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
-
-  // ── Test 5: matrix NO + NO → untouched account is left intact ────────────────────────────────
 
   @Test
   void notModifiedInOrphanedOrNewBlock_skipsEntirely() {
@@ -363,103 +270,76 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             b.header(0),
             b.merge(
                 b.balWithBalances(Map.of(ALICE, Wei.of(100))),
-                b.balWithBalances(Map.of(BOB, Wei.of(100)))),
+                b.balWithBalances(Map.of(UNTOUCHED, Wei.of(100)))),
             1L);
     final Block block2s =
         b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 2);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
-    assertThat(readAccount(BOB).getBalance()).isEqualTo(Wei.of(100)); // untouched by both forks
+    assertThat(readAccount(UNTOUCHED).getBalance())
+        .isEqualTo(Wei.of(100)); // untouched by both forks
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
-  // ── Test 6: slot-level YES+NO → orphaned-only slots restored, canonical slot applied ──────────
-
   @Test
   void slotsModifiedInOrphanedButNotNewBlock_reDownloadsSlots() {
-    // Block 1: FRANK has balance + S1=7 (base state).
+    // Block 1: STORAGE_ACCT has balance + SLOT_BASE=7 (base state).
     final var baseBal =
         b.merge(
-            b.balWithBalances(Map.of(FRANK, Wei.of(200))),
-            b.balWithStorageChanges(FRANK, Map.of(S1, UInt256.valueOf(7))));
+            b.balWithBalances(Map.of(STORAGE_ACCT, Wei.of(200))),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_BASE, UInt256.valueOf(7))));
     final Block block1 = b.appendBlockWithBal(b.header(0), baseBal, 1L);
 
-    // Block 2s (orphaned, lower difficulty): FRANK S1=100, S2=200 — canonical at height 2
-    // initially.
+    // Block 2s (orphaned): SLOT_BASE=100, SLOT_ORPHAN=200.
     final Block block2s =
         b.appendStale(
             block1.getHeader(),
             b.balWithStorageChanges(
-                FRANK, Map.of(S1, UInt256.valueOf(100), S2, UInt256.valueOf(200))),
+                STORAGE_ACCT,
+                Map.of(SLOT_BASE, UInt256.valueOf(100), SLOT_ORPHAN, UInt256.valueOf(200))),
             2L);
 
     // Pre-seed local with the orphaned state while block2s is still canonical at height 2.
-    applyTo(
+    applyBals(
         localCoordinator,
         1,
         2,
         ReorgBlockchainBuilder.fullAccountRange(),
         new DownloadedStorageRangeTracker());
 
-    // Block 2c (canonical, higher difficulty): FRANK S3=555 — triggers reorg.
+    // Block 2c (canonical, higher difficulty): STORAGE_ACCT SLOT_CANONICAL=555 — triggers reorg.
     final Block block2c =
         b.appendCanonical(
             block1.getHeader(),
-            b.balWithStorageChanges(FRANK, Map.of(S3, UInt256.valueOf(555))),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_CANONICAL, UInt256.valueOf(555))),
             2L);
 
-    // Build canonical world state (block2c is now canonical at height 2).
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create download state with the stale (orphaned) pivot.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    // Completing the full account range (initialChildCount=0) makes
-    // isAccountHashDownloaded(FRANK)=true so that computeSlotsToRefetch detects the
-    // diverged orphaned slots S1 and S2.
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    // initialChildCount=0 → isAccountHashDownloaded(STORAGE_ACCT)=true → computeSlotsToRefetch
+    // detects diverged orphaned slots SLOT_BASE and SLOT_ORPHAN.
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
-    // Queue a storage request for FRANK with the (soon-stale) orphaned storage root.
-    final Bytes32 oldRoot = Bytes32.wrap(readAccount(FRANK).getStorageRoot().getBytes());
+    // Queue a storage request for STORAGE_ACCT with the (soon-stale) orphaned storage root.
+    final Bytes32 oldRoot = Bytes32.wrap(readAccount(STORAGE_ACCT).getStorageRoot().getBytes());
     final SnapV2StorageRangeRequest frankReq =
         new SnapV2StorageRangeRequest(
             block2s.getHeader(),
-            Bytes32.wrap(FRANK.addressHash().getBytes()),
+            Bytes32.wrap(STORAGE_ACCT.addressHash().getBytes()),
             oldRoot,
             RangeManager.MIN_RANGE,
             RangeManager.MAX_RANGE,
@@ -468,122 +348,93 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
-    assertThat(readStorageSlot(FRANK, S1)).hasValue(UInt256.valueOf(7)); // restored to base value
-    assertThat(readStorageSlot(FRANK, S2)).isEmpty(); // orphaned-only slot removed
-    assertThat(readStorageSlot(FRANK, S3)).hasValue(UInt256.valueOf(555)); // canonical slot applied
+    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_BASE))
+        .hasValue(UInt256.valueOf(7)); // restored to base value
+    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_ORPHAN)).isEmpty(); // orphaned-only slot removed
+    assertThat(readStorageSlot(STORAGE_ACCT, SLOT_CANONICAL))
+        .hasValue(UInt256.valueOf(555)); // canonical slot applied
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
 
-    // The queued storage request was retargeted to the new pivot with FRANK's canonical root.
+    // Queued request retargeted to new pivot with STORAGE_ACCT's canonical root.
     final var queued = state.pendingStorageRequests.asList();
     assertThat(queued).hasSize(1);
     final SnapV2StorageRangeRequest retargeted = (SnapV2StorageRangeRequest) queued.get(0);
     assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
-    final Bytes32 canonicalFrankRoot = Bytes32.wrap(readAccount(FRANK).getStorageRoot().getBytes());
+    final Bytes32 canonicalFrankRoot =
+        Bytes32.wrap(readAccount(STORAGE_ACCT).getStorageRoot().getBytes());
     assertThat(retargeted.getStorageRoot()).isEqualTo(canonicalFrankRoot);
   }
 
-  // ── Test 7: PENDING range — fix downloaded slot, defer not-downloaded slot ───────────────────
-
-  /**
-   * Account range is PENDING (has one outstanding child). PETE's slot SP1 is downloaded but SP2 is
-   * not. The orphaned fork rewrites both slots. After recovery:
-   *
-   * <ul>
-   *   <li>SP1 is re-fetched from the canonical peer and restored to its canonical value (1).
-   *   <li>SP2 remains absent (never downloaded, never re-fetched).
-   *   <li>The queued storage request is retargeted to the new pivot with PETE's canonical storage
-   *       root (installed via root-patch, not recomputed from the incomplete trie).
-   * </ul>
-   *
-   * <pre>
-   * gen -- 1(PETE=100, SP1=1) -- 2(SP2=2) -- 3s(SP1=10, SP2=20)   orphaned
-   *                                        \-- 3c(PETE=300 bal)     canonical
-   *                                              \-- 4c (pins canonicalRoot, new pivot)
-   * </pre>
-   */
   @Test
   void pendingRange_appliesToDownloadedSlotsAndDefersRest() {
-    // Throwaway trackers for local seeding: PENDING range, only SP1 slot downloaded.
+    // Seed trackers: PENDING range, SLOT_DOWNLOADED only.
     final DownloadedAccountRangeTracker seedAccountTracker = new DownloadedAccountRangeTracker();
-    seedAccountTracker.registerPending(Bytes32.ZERO, MAX_KEY, 1);
+    seedAccountTracker.registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 1);
     final DownloadedStorageRangeTracker seedStorageTracker = new DownloadedStorageRangeTracker();
     seedStorageTracker.registerSlotRange(
-        Bytes32.wrap(PETE.addressHash().getBytes()),
-        Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()),
-        Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()));
+        Bytes32.wrap(PENDING_ACCT.addressHash().getBytes()),
+        Bytes32.wrap(new StorageSlotKey(SLOT_DOWNLOADED).getSlotHash().getBytes()),
+        Bytes32.wrap(new StorageSlotKey(SLOT_DOWNLOADED).getSlotHash().getBytes()));
 
-    // Block 1 (shared): creates PETE with balance 100 and SP1=1.
-    // PETE is new (existingAccount == null) so isAccountCompleted=true; SP1 applied in full.
+    // Block 1: PENDING_ACCT=100 + SLOT_DOWNLOADED=1.
     final Block block1 =
         b.appendBlockWithBal(
             b.header(0),
             b.merge(
-                b.balWithBalances(Map.of(PETE, Wei.of(100))),
-                b.balWithStorageChanges(PETE, Map.of(SP1, UInt256.valueOf(1)))),
+                b.balWithBalances(Map.of(PENDING_ACCT, Wei.of(100))),
+                b.balWithStorageChanges(PENDING_ACCT, Map.of(SLOT_DOWNLOADED, UInt256.valueOf(1)))),
             1L);
-    applyTo(localCoordinator, 1, 1, seedAccountTracker, seedStorageTracker);
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    applyBals(localCoordinator, 1, 1, seedAccountTracker, seedStorageTracker);
+    seedCanonical(1, 1);
 
-    // Block 2 (shared): SP2 appears on the canonical side; SP2 is NOT downloaded locally
-    // (not in seedStorageTracker), so the slot-guard blocks it.
+    // Block 2: SLOT_DEFERRED added; not in seedStorageTracker so the slot-guard blocks it.
     final Block block2 =
         b.appendBlockWithBal(
-            block1.getHeader(), b.balWithStorageChanges(PETE, Map.of(SP2, UInt256.valueOf(2))), 2L);
-    applyTo(localCoordinator, 2, 2, seedAccountTracker, seedStorageTracker);
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+            block1.getHeader(),
+            b.balWithStorageChanges(PENDING_ACCT, Map.of(SLOT_DEFERRED, UInt256.valueOf(2))),
+            2L);
+    applyBals(localCoordinator, 2, 2, seedAccountTracker, seedStorageTracker);
+    seedCanonical(2, 2);
 
-    // Block 3s (orphaned, low difficulty): rewrites both slots; only SP1 lands locally.
+    // Block 3s (orphaned, low difficulty): rewrites both slots; only SLOT_DOWNLOADED lands locally.
     // appendStale uses LOW difficulty, so it is initially canonical at height 3.
     final Block block3s =
         b.appendStale(
             block2.getHeader(),
             b.balWithStorageChanges(
-                PETE, Map.of(SP1, UInt256.valueOf(10), SP2, UInt256.valueOf(20))),
+                PENDING_ACCT,
+                Map.of(SLOT_DOWNLOADED, UInt256.valueOf(10), SLOT_DEFERRED, UInt256.valueOf(20))),
             3L);
-    applyTo(localCoordinator, 3, 3, seedAccountTracker, seedStorageTracker);
-    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(10)); // downloaded, rewritten
-    assertThat(readStorageSlot(PETE, SP2)).isEmpty(); // not downloaded, still absent
+    applyBals(localCoordinator, 3, 3, seedAccountTracker, seedStorageTracker);
+    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DOWNLOADED))
+        .hasValue(UInt256.valueOf(10)); // downloaded, rewritten
+    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DEFERRED))
+        .isEmpty(); // not downloaded, still absent
 
     // Block 3c (canonical, high difficulty): balance only; reorg makes it canonical at height 3.
     final Block block3c =
-        b.appendCanonical(block2.getHeader(), b.balWithBalances(Map.of(PETE, Wei.of(300))), 3L);
-    applyTo(
-        canonicalCoordinator,
-        3,
-        3,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+        b.appendCanonical(
+            block2.getHeader(), b.balWithBalances(Map.of(PENDING_ACCT, Wei.of(300))), 3L);
+    seedCanonical(3, 3);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block3c.getHeader(), b.emptyBal(), 4L, canonicalRoot);
 
-    // Create download state; register the same PENDING+SP1 configuration on state's trackers
-    // (the healer reads these during planReorg / applyReorgCorrections).
     final SnapV2WorldDownloadState state = createDownloadState(block3s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 1);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 1);
     state
         .getStorageRangeTracker()
         .registerSlotRange(
-            Bytes32.wrap(PETE.addressHash().getBytes()),
-            Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()),
-            Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()));
+            Bytes32.wrap(PENDING_ACCT.addressHash().getBytes()),
+            Bytes32.wrap(new StorageSlotKey(SLOT_DOWNLOADED).getSlotHash().getBytes()),
+            Bytes32.wrap(new StorageSlotKey(SLOT_DOWNLOADED).getSlotHash().getBytes()));
 
-    // Queue PETE's still-in-progress storage request with the stale (orphaned) storage root.
-    final Bytes32 oldRoot = Bytes32.wrap(readAccount(PETE).getStorageRoot().getBytes());
+    // Queue PENDING_ACCT's in-progress storage request with the stale root.
+    final Bytes32 oldRoot = Bytes32.wrap(readAccount(PENDING_ACCT).getStorageRoot().getBytes());
     final SnapV2StorageRangeRequest peteReq =
         new SnapV2StorageRangeRequest(
             block3s.getHeader(),
-            Bytes32.wrap(PETE.addressHash().getBytes()),
+            Bytes32.wrap(PENDING_ACCT.addressHash().getBytes()),
             oldRoot,
             RangeManager.MIN_RANGE,
             RangeManager.MAX_RANGE,
@@ -592,19 +443,18 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
-    // Downloaded SP1 restored; not-downloaded SP2 stays absent; canonical balance applied.
-    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(1));
-    assertThat(readStorageSlot(PETE, SP2)).isEmpty();
-    assertThat(readAccount(PETE).getBalance()).isEqualTo(Wei.of(300));
+    // SLOT_DOWNLOADED restored; SLOT_DEFERRED stays absent; canonical balance applied.
+    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DOWNLOADED)).hasValue(UInt256.valueOf(1));
+    assertThat(readStorageSlot(PENDING_ACCT, SLOT_DEFERRED)).isEmpty();
+    assertThat(readAccount(PENDING_ACCT).getBalance()).isEqualTo(Wei.of(300));
 
-    // Pending account: retargeted storage request carries PETE's canonical storage root
-    // (installed via root-patch, not recomputed from the still-incomplete local trie).
+    // Storage root comes from root-patch, not recomputed from the still-incomplete trie.
     final PmtStateTrieAccountValue canonicalPete =
         PmtStateTrieAccountValue.readFrom(
             RLP.input(
                 canonicalCoordinator
                     .applyForStrategy(
-                        bonsai -> bonsai.getAccount(PETE.addressHash()),
+                        bonsai -> bonsai.getAccount(PENDING_ACCT.addressHash()),
                         forest -> Optional.<Bytes>empty())
                     .orElseThrow()));
     final SnapV2StorageRangeRequest retargeted =
@@ -614,19 +464,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .isEqualTo(Bytes32.wrap(canonicalPete.getStorageRoot().getBytes()));
   }
 
-  // ── Test 8: not-yet-downloaded range → account deferred entirely ─────────────────────────────
-
-  /**
-   * ALICE's account hash lies outside the registered downloaded range (only [ZERO, ZERO] is
-   * persisted). The orphaned fork modified ALICE, but since her range is not persisted, recovery
-   * must skip her entirely — no re-download, no local change.
-   *
-   * <pre>
-   * gen -- 1(ALICE=100) -- 2s(ALICE=50)   orphaned
-   *                     \-- 2c(ALICE=80)  canonical
-   *                           \-- 3c (newPivot, canonicalRoot)
-   * </pre>
-   */
   @Test
   void notYetDownloadedRange_defersToLaterCycle() {
     // Verify that ALICE is NOT covered by the degenerate [ZERO, ZERO] range.
@@ -642,18 +479,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
     // Seed canonical coordinator only; ALICE is not applied to local (her range is not persisted).
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
@@ -672,14 +498,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(accountFetches).hasValue(0); // no re-download triggered
   }
 
-  // ── Test 14: same-chain advance → BALs [old+1,new] applied, request retargeted, no fetch ──────
-
-  /**
-   * Straight canonical chain: gen ─ 1(ALICE=100) ─ 2(ALICE=50)[old pivot] ─ 3(ALICE=80)[new pivot].
-   * All blocks have HIGH difficulty so all are canonical. {@code areBothBlocksOnCanonicalChain}
-   * returns {@code true} → the same-chain branch runs: apply BALs [3,3], retarget queued account
-   * request to new pivot. No peer fetches because ALICE has no storage (pendingAffected is empty).
-   */
   @Test
   void sameChainPivotAdvance_appliesBalsAndRetargets_noReorg() {
     final Block block1 =
@@ -687,32 +505,20 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final Block block2 =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
 
-    // Apply [1,2] to canonical coordinator.
-    applyTo(
-        canonicalCoordinator,
-        1,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     // Build and append block3 (ALICE=80) before applying its BAL so the blockchain holds it.
     final Block block3 =
         b.appendCanonical(block2.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 3L);
 
-    // Apply [3,3] to canonical now that block3 is in the blockchain.
-    applyTo(
-        canonicalCoordinator,
-        3,
-        3,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    // block3 must be in the blockchain before applying its BAL.
+    seedCanonical(3, 3);
 
-    // Create download state with block2 as the (old) current pivot.
     final SnapV2WorldDownloadState state =
         createDownloadState(
             block2.getHeader(), ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator));
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 2);
 
     // Queue an account request targeted at block2 — it must be retargeted to block3.
     final SnapV2AccountRangeRequest accountReq =
@@ -722,7 +528,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     startCatchupAndAwait(state, block3.getHeader());
 
-    // BAL [3,3] applied: ALICE=80. No re-download (same canonical chain).
     assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(accountFetches).hasValue(0);
     // Queued account request retargeted to the new pivot.
@@ -734,20 +539,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .isEqualTo(ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator));
   }
 
-  // ── Test 9: unrecoverable reorg → failure propagated through downloadFuture ─────────────────
-
-  /**
-   * The orphaned block's BAL is NOT stored locally (simulates a pruned orphaned BAL). The healer
-   * cannot plan the reorg → {@link SnapV2ReorgHealer#planReorg} throws {@link
-   * ReorgUnrecoverableException} → {@code startPivotCatchup} completes {@code internalFuture}
-   * exceptionally → {@code downloadFuture} is also completed exceptionally.
-   *
-   * <pre>
-   * gen -- 1() -- 2s(ALICE=50)   orphaned, BAL not stored
-   *            \-- 2c(ALICE=80)  canonical
-   *                  \-- 3c (pins canonicalRoot, new pivot)
-   * </pre>
-   */
   @Test
   void unrecoverableReorg_propagatesFailure() {
     final Block block1 = b.appendBlockWithBal(b.header(0), b.emptyBal(), 1L);
@@ -758,31 +549,16 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    // Build canonical world state and compute its root.
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create download state with the stale (orphaned) block2s as the current pivot.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
     // Apply only block1 locally; block2s was never applied (simulates partial download).
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    seedLocal(state, 1, 1);
 
-    // Trigger pivot catchup without awaiting — the reorg healer cannot read the orphaned BAL
-    // and must throw ReorgUnrecoverableException synchronously (0 in-flight tasks, pre-completed
-    // listener future → finishPivotCatchup runs on the calling thread).
+    // Orphaned BAL is unreadable → ReorgUnrecoverableException thrown synchronously.
     state.startPivotCatchup(newPivot.getHeader());
 
     assertThat(state.getDownloadFuture()).isCompletedExceptionally();
@@ -790,24 +566,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .hasRootCauseInstanceOf(ReorgUnrecoverableException.class);
   }
 
-  // ── Test 10: multi-block reorg recovery ──────────────────────────────────────────────────────
-
-  /**
-   * Multi-block orphaned fork (block2s, block3s) and multi-block canonical fork (block2c, block3c).
-   * Exercises {@code collectOrphanedTouches} and {@code collectCanonicalTouches} walking multiple
-   * blocks and a 2-step ancestor walk. Common ancestor is block1.
-   *
-   * <pre>
-   * gen -- 1(ALICE=100, DAVE=75) -+- 2s(ALICE=50) -- 3s(DAVE=60)  [old pivot, orphaned]
-   *                               \- 2c(ALICE=80) -- 3c(GRACE=50) -- 4c(pins root) [new pivot]
-   * </pre>
-   *
-   * <ul>
-   *   <li>ALICE (YES+YES): apply canonical BAL → 80.
-   *   <li>DAVE (YES+NO): orphaned-only change → re-fetched from canonical → restored to 75.
-   *   <li>GRACE (NO+YES): canonical-only new account → applied from canonical BAL → 50.
-   * </ul>
-   */
   @Test
   void multiBlockReorg_recoversAcrossSeveralOrphanedAndCanonicalBlocks() {
     final Block block1 =
@@ -815,104 +573,66 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
             b.header(0),
             b.merge(
                 b.balWithBalances(Map.of(ALICE, Wei.of(100))),
-                b.balWithBalances(Map.of(DAVE, Wei.of(75)))),
+                b.balWithBalances(Map.of(ORPHAN_EOA, Wei.of(75)))),
             1L);
 
     // Orphaned fork: two blocks.
     final Block block2s =
         b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
     final Block block3s =
-        b.appendStale(block2s.getHeader(), b.balWithBalances(Map.of(DAVE, Wei.of(60))), 3L);
+        b.appendStale(block2s.getHeader(), b.balWithBalances(Map.of(ORPHAN_EOA, Wei.of(60))), 3L);
 
     // Canonical fork: two blocks + pivot pinner.
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
     final Block block3c =
-        b.appendCanonical(block2c.getHeader(), b.balWithBalances(Map.of(GRACE, Wei.of(50))), 3L);
+        b.appendCanonical(
+            block2c.getHeader(), b.balWithBalances(Map.of(CANONICAL_NEW, Wei.of(50))), 3L);
 
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        3,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 3);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block3c.getHeader(), b.emptyBal(), 4L, canonicalRoot);
 
     final SnapV2WorldDownloadState state = createDownloadState(block3s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 3, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 3);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
     assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80)); // YES+YES: canonical value
-    assertThat(readAccount(DAVE).getBalance())
+    assertThat(readAccount(ORPHAN_EOA).getBalance())
         .isEqualTo(Wei.of(75)); // YES+NO: restored from block1
-    assertThat(readAccount(GRACE).getBalance())
+    assertThat(readAccount(CANONICAL_NEW).getBalance())
         .isEqualTo(Wei.of(50)); // NO+YES: new canonical account
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
-  // ── Test 11: unaffected account storage root kept, request retargeted
-  // ───────────────────────────
-
-  /**
-   * A queued storage request for CAROL — an account NOT touched by either fork — is retargeted to
-   * the new pivot while keeping CAROL's existing (unchanged) storage root. The root is read from
-   * the local DB after seeding; it must NOT be replaced by the {@code correctedRoots} map (which
-   * only contains accounts whose canonical storage root differs from the orphaned one).
-   *
-   * <pre>
-   * gen -- 1(FRANK+CAROL have storage, S1 set) -+- 2s(FRANK adds S2=200)  orphaned
-   *                                              \- 2c(FRANK adds S3=555)  canonical
-   *                                                   \- 3c (pins canonicalRoot, new pivot)
-   * </pre>
-   */
   @Test
   void queuedStorageRequestForUnaffectedAccount_retargetedKeepingExistingRoot() {
     final var baseBal =
         b.merge(
-            b.balWithBalances(Map.of(FRANK, Wei.of(200), CAROL, Wei.of(10))),
-            b.balWithStorageChanges(FRANK, Map.of(S1, UInt256.valueOf(7))),
-            b.balWithStorageChanges(CAROL, Map.of(S1, UInt256.valueOf(9))));
+            b.balWithBalances(Map.of(STORAGE_ACCT, Wei.of(200), CAROL, Wei.of(10))),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_BASE, UInt256.valueOf(7))),
+            b.balWithStorageChanges(CAROL, Map.of(SLOT_BASE, UInt256.valueOf(9))));
     final Block block1 = b.appendBlockWithBal(b.header(0), baseBal, 1L);
     final Block block2s =
         b.appendStale(
             block1.getHeader(),
-            b.balWithStorageChanges(FRANK, Map.of(S2, UInt256.valueOf(200))),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_ORPHAN, UInt256.valueOf(200))),
             2L);
     final Block block2c =
         b.appendCanonical(
             block1.getHeader(),
-            b.balWithStorageChanges(FRANK, Map.of(S3, UInt256.valueOf(555))),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_CANONICAL, UInt256.valueOf(555))),
             2L);
 
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 2);
 
     // Read CAROL's storage root from the local DB after seeding (she is untouched by both forks).
     final Bytes32 carolRoot = Bytes32.wrap(readAccount(CAROL).getStorageRoot().getBytes());
@@ -937,18 +657,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(retargeted.getStorageRoot()).isEqualTo(carolRoot);
   }
 
-  // ── Test 12: queued code and account requests retargeted to new pivot ─────────────────────────
-
-  /**
-   * A queued bytecode request and a queued account-range request — both originally targeted at the
-   * stale (orphaned) pivot — are retargeted to the new pivot after the reorg completes.
-   *
-   * <pre>
-   * gen -- 1(ALICE=100) -+- 2s(ALICE=50)  orphaned
-   *                      \- 2c(ALICE=80)  canonical
-   *                           \- 3c (pins canonicalRoot, new pivot)
-   * </pre>
-   */
   @Test
   void queuedCodeAndAccountRequests_retargetedToNewPivot() {
     final Block block1 =
@@ -958,31 +666,19 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final Block block2c =
         b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
 
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+    seedLocal(state, 1, 2);
 
     final SnapV2BytecodeRequest codeReq =
         new SnapV2BytecodeRequest(
             block2s.getHeader(),
             Bytes32.wrap(ALICE.addressHash().getBytes()),
-            Bytes32.wrap(Hash.hash(NC_CODE).getBytes()),
+            Bytes32.wrap(Hash.hash(NEW_CONTRACT_CODE).getBytes()),
             RangeManager.MIN_RANGE);
     final SnapV2AccountRangeRequest accountReq =
         new SnapV2AccountRangeRequest(
@@ -1002,23 +698,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .isEqualTo(newPivot.getHeader());
   }
 
-  // ── Test 13: account with missing code bytes → code fetched during reorg recovery ───────────
-
-  /**
-   * Forces the code-fetch path: CAROL's canonical code hash ({@code carolCodeCanonical}) is stored
-   * in her account record but the corresponding code bytes are absent locally. The healer detects
-   * CAROL as Category B (YES+NO): she appears in block2s (orphaned nonce change) but is absent from
-   * block2c (canonical fork has an empty BAL). On re-fetch, {@code collectMissingCodeHashes} sees
-   * that CAROL's code hash is not locally available and schedules a {@code fetchCodes} call. After
-   * recovery the code bytes must be present, {@code codeFetches >= 1}, and the local state root
-   * must match {@code canonicalRoot}.
-   *
-   * <pre>
-   * gen -- 1(CAROL balance=100, code=carolCodeCanonical) -+- 2s(CAROL nonce=5)  orphaned
-   *                                                       \- 2c(empty BAL)      canonical
-   *                                                            \- 3c (pins canonicalRoot, newPivot)
-   * </pre>
-   */
   @Test
   void accountWithNewCanonicalCode_fetchesAndStoresCode() {
     final Bytes carolCodeCanonical = Bytes.fromHexString("0x6080604052348015600f");
@@ -1038,41 +717,25 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     // Block 2c (canonical, high difficulty): empty BAL → CAROL absent from canonical touches.
     final Block block2c = b.appendCanonical(block1.getHeader(), b.emptyBal(), 2L);
 
-    // Build canonical world state (block2c is now canonical at height 2).
-    applyTo(
-        canonicalCoordinator,
-        1,
-        1,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
-    applyTo(
-        canonicalCoordinator,
-        2,
-        2,
-        ReorgBlockchainBuilder.fullAccountRange(),
-        new DownloadedStorageRangeTracker());
+    seedCanonical(1, 2);
 
     final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
     final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
 
-    // Create download state with the orphaned block2s as pivot.
     final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
-    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
 
     // Apply block 1 to local: stores CAROL's account record + carolCodeCanonical bytes.
-    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    seedLocal(state, 1, 1);
 
-    // Delete CAROL's code bytes from local storage so hasCodeLocally() returns false.
-    // BonsaiWorldStateKeyValueStorage uses CodeHashCodeStorageStrategy when "code stored using
-    // code hash" is enabled; its removeFlatCode() is a no-op, so we delete the code entry
-    // directly from the underlying CODE_STORAGE segment instead.
+    // removeFlatCode() is a no-op on CodeHashCodeStorageStrategy; delete directly.
     final Hash carolCodeHash = Hash.hash(carolCodeCanonical);
     final var codeTx = localStorage.getComposedWorldStateStorage().startTransaction();
     codeTx.remove(KeyValueSegmentIdentifier.CODE_STORAGE, carolCodeHash.getBytes().toArrayUnsafe());
     codeTx.commit();
 
     // Apply block 2 (canonical block2c has empty BAL — no-op for CAROL locally).
-    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    seedLocal(state, 2, 2);
 
     startCatchupAndAwait(state, newPivot.getHeader());
 
@@ -1081,8 +744,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(codeFetches.get()).isGreaterThanOrEqualTo(1);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
-
-  // ── shared helpers ────────────────────────────────────────────────────────────────────────────
 
   /**
    * Builds a real {@link SnapV2WorldDownloadState} with the stale block as its starting pivot. The
@@ -1123,12 +784,27 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         1000L);
   }
 
-  private void applyTo(
+  private void seedCanonical(final long from, final long to) {
+    applyBals(
+        canonicalCoordinator,
+        from,
+        to,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+  }
+
+  private void seedLocal(final SnapV2WorldDownloadState state, final long from, final long to) {
+    applyBals(
+        localCoordinator, from, to, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+  }
+
+  private void applyBals(
       final WorldStateStorageCoordinator coordinator,
       final long fromBlock,
       final long toBlock,
       final DownloadedAccountRangeTracker accountTracker,
       final DownloadedStorageRangeTracker storageTracker) {
+
     new SnapV2BlockAccessListApplier(
             coordinator, b.blockchain(), ReorgBlockchainBuilder.balEnabledSchedule())
         .applyBlockAccessLists(fromBlock, toBlock, accountTracker, storageTracker)
@@ -1138,8 +814,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private void startCatchupAndAwait(
       final SnapV2WorldDownloadState state, final BlockHeader newPivot) {
     state.startPivotCatchup(newPivot);
-    // finishPivotCatchup runs synchronously (pre-completed listener future + 0 in-flight tasks);
-    // guard against a future refactor by joining the download future if it already resolved.
+    // finishPivotCatchup runs synchronously here (no in-flight tasks, pre-completed future).
   }
 
   private PmtStateTrieAccountValue readAccount(final Address address) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -139,7 +139,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     assertThat(readAccount(localCoordinator, ALICE).getBalance())
         .isEqualTo(Wei.of(80)); // canonical value applied
-    assertThat(accountFetches).hasValue(0); // Category YES+YES: no re-download
+    assertThat(accountFetches)
+        .hasValue(
+            0); // touched on both forks: canonical BAL applied directly, no re-download needed
     assertThat(storageFetches).hasValue(0);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
@@ -171,6 +173,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     // ORPHAN_EOA was modified by orphaned fork but is absent from canonical BAL → re-downloaded.
     assertThat(readAccount(localCoordinator, ORPHAN_EOA).getBalance()).isEqualTo(Wei.of(75));
     assertThat(accountFetches.get()).isGreaterThanOrEqualTo(1);
+    assertThat(storageFetches).hasValue(0); // ORPHAN_EOA has no storage; no storage fetch expected
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -301,6 +304,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     assertThat(readAccount(localCoordinator, UNTOUCHED).getBalance())
         .isEqualTo(Wei.of(100)); // untouched by both forks
+    assertThat(accountFetches).hasValue(0); // no account was orphaned-only; nothing to re-fetch
+    assertThat(storageFetches).hasValue(0);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -546,6 +551,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(accountFetches).hasValue(0);
+    assertThat(storageFetches).hasValue(0);
+    assertThat(codeFetches).hasValue(0);
     // Queued account request retargeted to the new pivot.
     final SnapV2AccountRangeRequest retargetedReq =
         (SnapV2AccountRangeRequest) state.pendingAccountRequests.asList().get(0);
@@ -616,11 +623,11 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     state.startPivotCatchup(newPivot.getHeader());
 
     assertThat(readAccount(localCoordinator, ALICE).getBalance())
-        .isEqualTo(Wei.of(80)); // YES+YES: canonical value
+        .isEqualTo(Wei.of(80)); // touched on both forks: canonical BAL applied directly
     assertThat(readAccount(localCoordinator, ORPHAN_EOA).getBalance())
-        .isEqualTo(Wei.of(75)); // YES+NO: restored from block1
+        .isEqualTo(Wei.of(75)); // touched only on orphaned fork: re-fetched from canonical network
     assertThat(readAccount(localCoordinator, CANONICAL_NEW).getBalance())
-        .isEqualTo(Wei.of(50)); // NO+YES: new canonical account
+        .isEqualTo(Wei.of(50)); // touched only on canonical fork: created from canonical BAL
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
@@ -706,6 +713,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(
             ((SnapV2BytecodeRequest) state.pendingCodeRequests.asList().get(0))
                 .getPivotBlockHeader())

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -114,7 +114,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private final AtomicInteger codeFetches = new AtomicInteger();
 
   @Test
-  void modifiedInOrphanedAndNewBlock_appliesNewBalWithoutReDownload() {
+  void accountModifiedInOrphanedAndNewBlock_appliesCanonicalBalWithoutReDownload() {
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
     // orphaned (2s): Alice = 50  — appended first so it is initially canonical
@@ -137,8 +137,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(localCoordinator, ALICE).getBalance())
-        .isEqualTo(Wei.of(80)); // canonical value applied
+    assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(accountFetches)
         .hasValue(
             0); // touched on both forks: canonical BAL applied directly, no re-download needed
@@ -147,7 +146,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   }
 
   @Test
-  void modifiedInOrphanedButNotNewBlock_reDownloadsAndUpdatesWhenPresent() {
+  void accountModifiedInOrphanedButNotNewBlock_reDownloadsWhenPresent() {
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ORPHAN_EOA, Wei.of(75))), 1L);
     // orphaned (2s): ORPHAN_EOA = 60 — appended first so it is initially canonical
@@ -178,7 +177,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   }
 
   @Test
-  void modifiedInOrphanedButNotNewBlock_deletesWhenAbsentFromCanonical() {
+  void accountModifiedInOrphanedButNotNewBlock_deletesWhenAbsentFromCanonical() {
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 1L);
 
@@ -237,19 +236,17 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
-    // NEW_CONTRACT must be gone from local state.
     assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isFalse();
     assertThat(readStorageSlot(localCoordinator, NEW_CONTRACT, SLOT_BASE)).isEmpty();
     // Queued child requests for the doomed contract must have been purged.
     assertThat(state.pendingStorageRequests.asList()).isEmpty();
     assertThat(state.pendingCodeRequests.asList()).isEmpty();
-    // ALICE carries through from the canonical BAL.
     assertThat(readAccount(localCoordinator, ALICE).getBalance()).isEqualTo(Wei.of(80));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
   @Test
-  void notModifiedInOrphanedButModifiedInNewBlock_appliesNewBal() {
+  void accountNotModifiedInOrphanedButModifiedInNewBlock_appliesCanonicalBal() {
     final Block block1 =
         b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
     final Block block2s =
@@ -279,7 +276,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   }
 
   @Test
-  void notModifiedInOrphanedOrNewBlock_skipsEntirely() {
+  void accountNotModifiedInOrphanedOrNewBlock_skipsEntirely() {
     final Block block1 =
         b.appendBlockWithBal(
             b.header(0),
@@ -302,8 +299,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
-    assertThat(readAccount(localCoordinator, UNTOUCHED).getBalance())
-        .isEqualTo(Wei.of(100)); // untouched by both forks
+    assertThat(readAccount(localCoordinator, UNTOUCHED).getBalance()).isEqualTo(Wei.of(100));
     assertThat(accountFetches).hasValue(0); // no account was orphaned-only; nothing to re-fetch
     assertThat(storageFetches).hasValue(0);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
@@ -371,7 +367,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_ORPHAN))
         .isEmpty(); // orphaned-only slot removed
     assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_CANONICAL))
-        .hasValue(UInt256.valueOf(555)); // canonical slot applied
+        .hasValue(UInt256.valueOf(555));
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
 
     // Queued request retargeted to new pivot with STORAGE_ACCT's canonical root.
@@ -463,7 +459,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
-    // SLOT_DOWNLOADED restored; SLOT_DEFERRED stays absent; canonical balance applied.
     assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DOWNLOADED))
         .hasValue(UInt256.valueOf(1));
     assertThat(readStorageSlot(localCoordinator, PENDING_ACCT, SLOT_DEFERRED)).isEmpty();
@@ -532,7 +527,6 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     final Block block3 =
         b.appendCanonical(block2.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 3L);
 
-    // block3 must be in the blockchain before applying its BAL.
     seedCanonical(3, 3);
 
     final SnapV2WorldDownloadState state =
@@ -553,11 +547,9 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(accountFetches).hasValue(0);
     assertThat(storageFetches).hasValue(0);
     assertThat(codeFetches).hasValue(0);
-    // Queued account request retargeted to the new pivot.
     final SnapV2AccountRangeRequest retargetedReq =
         (SnapV2AccountRangeRequest) state.pendingAccountRequests.asList().get(0);
     assertThat(retargetedReq.getPivotBlockHeader()).isEqualTo(block3.getHeader());
-    // Local and canonical world states agree.
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator))
         .isEqualTo(ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator));
   }
@@ -725,7 +717,7 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   }
 
   @Test
-  void accountWithNewCanonicalCode_fetchesAndStoresCode() {
+  void codeModifiedInOrphanedButNotNewBlock_fetchesCanonicalCode() {
     final Bytes carolCodeCanonical = Bytes.fromHexString("0x6080604052348015600f");
 
     // Block 1: CAROL gets balance + carolCodeCanonical.
@@ -765,9 +757,179 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     state.startPivotCatchup(newPivot.getHeader());
 
-    // Code bytes must have been fetched and stored during reorg recovery.
     assertThat(readCode(localCoordinator, CAROL)).hasValue(carolCodeCanonical);
     assertThat(codeFetches.get()).isGreaterThanOrEqualTo(1);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  @Test
+  void slotsModifiedInOrphanedAndNewBlock_appliesCanonicalSlotWithoutRefetch() {
+    final Block block1 =
+        b.appendBlockWithBal(
+            b.header(0),
+            b.merge(
+                b.balWithBalances(Map.of(STORAGE_ACCT, Wei.of(200))),
+                b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_BASE, UInt256.valueOf(7)))),
+            1L);
+    final Block block2s =
+        b.appendStale(
+            block1.getHeader(),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_BASE, UInt256.valueOf(100))),
+            2L);
+
+    // Apply orphaned BALs locally while block2s is still canonical.
+    applyBals(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_BASE))
+        .hasValue(UInt256.valueOf(100));
+
+    // Block 2c (canonical): also modifies SLOT_BASE — same slot as the orphaned fork.
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_BASE, UInt256.valueOf(999))),
+            2L);
+
+    seedCanonical(1, 2);
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+
+    state.startPivotCatchup(newPivot.getHeader());
+
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_BASE))
+        .hasValue(UInt256.valueOf(999));
+    assertThat(accountFetches).hasValue(0);
+    assertThat(storageFetches).hasValue(0);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  @Test
+  void slotsNotModifiedInOrphanedButModifiedInNewBlock_appliesCanonicalSlot() {
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+
+    // Apply orphaned BALs locally while block2s is still canonical.
+    applyBals(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    assertThat(accountExists(localCoordinator, STORAGE_ACCT)).isFalse();
+
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.merge(
+                b.balWithBalances(Map.of(ALICE, Wei.of(80))),
+                b.balWithBalances(Map.of(STORAGE_ACCT, Wei.of(100))),
+                b.balWithStorageChanges(STORAGE_ACCT, Map.of(SLOT_CANONICAL, UInt256.valueOf(42)))),
+            2L);
+
+    seedCanonical(1, 2);
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+
+    state.startPivotCatchup(newPivot.getHeader());
+
+    assertThat(accountExists(localCoordinator, STORAGE_ACCT)).isTrue();
+    assertThat(readStorageSlot(localCoordinator, STORAGE_ACCT, SLOT_CANONICAL))
+        .hasValue(UInt256.valueOf(42));
+    assertThat(accountFetches).hasValue(0);
+    assertThat(storageFetches).hasValue(0);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  @Test
+  void codeModifiedInOrphanedAndNewBlock_appliesCanonicalCodeWithoutFetch() {
+    final Bytes codeV1 = Bytes.fromHexString("0xdeadbeef");
+    final Bytes codeV2 = Bytes.fromHexString("0xcafebabe");
+
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(CAROL, Wei.of(100))), 1L);
+    final Block block2s = b.appendStale(block1.getHeader(), b.balWithCodeChange(CAROL, codeV1), 2L);
+
+    // Apply orphaned BALs locally while block2s is still canonical.
+    applyBals(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    assertThat(readCode(localCoordinator, CAROL)).hasValue(codeV1);
+
+    // Block 2c (canonical): deploys different code to the same contract.
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithCodeChange(CAROL, codeV2), 2L);
+
+    seedCanonical(1, 2);
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+
+    state.startPivotCatchup(newPivot.getHeader());
+
+    // codeV2 is written by the canonical BAL, not fetched from the network.
+    assertThat(readCode(localCoordinator, CAROL)).hasValue(codeV2);
+    assertThat(accountFetches).hasValue(0);
+    assertThat(codeFetches).hasValue(0);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  @Test
+  void codeNotModifiedInOrphanedButModifiedInNewBlock_appliesCanonicalCode() {
+    final Bytes canonicalCode = Bytes.fromHexString("0x60806040");
+
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+
+    // Apply orphaned BALs locally while block2s is still canonical.
+    applyBals(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isFalse();
+
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.merge(
+                b.balWithBalances(Map.of(ALICE, Wei.of(80))),
+                b.balWithBalances(Map.of(NEW_CONTRACT, Wei.ONE)),
+                b.balWithCodeChange(NEW_CONTRACT, canonicalCode)),
+            2L);
+
+    seedCanonical(1, 2);
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, RangeManager.MAX_RANGE, 0);
+
+    state.startPivotCatchup(newPivot.getHeader());
+
+    assertThat(accountExists(localCoordinator, NEW_CONTRACT)).isTrue();
+    assertThat(readCode(localCoordinator, NEW_CONTRACT)).hasValue(canonicalCode);
+    assertThat(accountFetches).hasValue(0);
+    assertThat(codeFetches).hasValue(0);
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -785,6 +785,76 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .hasRootCauseInstanceOf(ReorgUnrecoverableException.class);
   }
 
+  // ── Test 10: multi-block reorg recovery ──────────────────────────────────────────────────────
+
+  /**
+   * Multi-block orphaned fork (block2s, block3s) and multi-block canonical fork (block2c, block3c).
+   * Exercises {@code collectOrphanedTouches} and {@code collectCanonicalTouches} walking multiple
+   * blocks and a 2-step ancestor walk. Common ancestor is block1.
+   *
+   * <pre>
+   * gen -- 1(ALICE=100, DAVE=75) -+- 2s(ALICE=50) -- 3s(DAVE=60)  [old pivot, orphaned]
+   *                               \- 2c(ALICE=80) -- 3c(GRACE=50) -- 4c(pins root) [new pivot]
+   * </pre>
+   *
+   * <ul>
+   *   <li>ALICE (YES+YES): apply canonical BAL → 80.
+   *   <li>DAVE (YES+NO): orphaned-only change → re-fetched from canonical → restored to 75.
+   *   <li>GRACE (NO+YES): canonical-only new account → applied from canonical BAL → 50.
+   * </ul>
+   */
+  @Test
+  void multiBlockReorg_recoversAcrossSeveralOrphanedAndCanonicalBlocks() {
+    final Block block1 =
+        b.appendBlockWithBal(
+            b.header(0),
+            b.merge(
+                b.balWithBalances(Map.of(ALICE, Wei.of(100))),
+                b.balWithBalances(Map.of(DAVE, Wei.of(75)))),
+            1L);
+
+    // Orphaned fork: two blocks.
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block3s =
+        b.appendStale(block2s.getHeader(), b.balWithBalances(Map.of(DAVE, Wei.of(60))), 3L);
+
+    // Canonical fork: two blocks + pivot pinner.
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+    final Block block3c =
+        b.appendCanonical(block2c.getHeader(), b.balWithBalances(Map.of(GRACE, Wei.of(50))), 3L);
+
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        3,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block3c.getHeader(), b.emptyBal(), 4L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block3s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 3, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80)); // YES+YES: canonical value
+    assertThat(readAccount(DAVE).getBalance())
+        .isEqualTo(Wei.of(75)); // YES+NO: restored from block1
+    assertThat(readAccount(GRACE).getBalance())
+        .isEqualTo(Wei.of(50)); // NO+YES: new canonical account
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────
 
   /**

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.snapsync.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestBuilder;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedAccountRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.DownloadedStorageRangeTracker;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncMetricsManager;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
+import org.hyperledger.besu.metrics.SyncDurationMetrics;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.services.tasks.InMemoryTasksPriorityQueues;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the snap/2 reorg recovery pipeline driven through {@link
+ * SnapV2WorldDownloadState#startPivotCatchup}. No mocks: a real blockchain, real Bonsai world
+ * states (local + canonical), a real {@link SnapV2ReorgHealer} whose fetcher serves the canonical
+ * state through a real {@link org.hyperledger.besu.ethereum.eth.manager.snap.SnapTestServing}, and
+ * a real {@link EthContext}. Each test asserts the resulting world state, queue, and tracker
+ * outcomes.
+ */
+class SnapV2WorldDownloadStateReorgIntegrationTest {
+
+  private static final Address ALICE =
+      Address.fromHexString("0x1111111111111111111111111111111111111111");
+
+  private static final Bytes32 MAX_KEY =
+      Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+  private final BonsaiWorldStateKeyValueStorage localStorage =
+      ReorgBlockchainBuilder.newBonsaiStorage();
+  private final WorldStateStorageCoordinator localCoordinator =
+      new WorldStateStorageCoordinator(localStorage);
+  private final BonsaiWorldStateKeyValueStorage canonicalStorage =
+      ReorgBlockchainBuilder.newBonsaiStorage();
+  private final WorldStateStorageCoordinator canonicalCoordinator =
+      new WorldStateStorageCoordinator(canonicalStorage);
+
+  private final ReorgBlockchainBuilder b = new ReorgBlockchainBuilder();
+  private final EthContext ethContext =
+      EthProtocolManagerTestBuilder.builder().build().ethContext();
+
+  private final AtomicInteger accountFetches = new AtomicInteger();
+  private final AtomicInteger storageFetches = new AtomicInteger();
+  private final AtomicInteger codeFetches = new AtomicInteger();
+
+  // ── Test 1: matrix YES + YES → apply canonical BAL, no re-download ───────────────────────────
+
+  @Test
+  void modifiedInOrphanedAndNewBlock_appliesNewBalWithoutReDownload() {
+    // Build all blockchain blocks first.
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    // orphaned (2s): Alice = 50  — appended first so it is initially canonical
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    // canonical (2c): Alice = 80 — higher difficulty wins the reorg
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    // Build canonical world state.
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state with stale pivot; then seed trackers and apply local BALs.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+
+    // Register the full address space as already downloaded.
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+
+    // Apply canonical local BALs using the state's trackers so the healer sees a complete picture.
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80)); // canonical value applied
+    assertThat(accountFetches).hasValue(0); // Category YES+YES: no re-download
+    assertThat(storageFetches).hasValue(0);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── shared helpers ────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Builds a real {@link SnapV2WorldDownloadState} with the stale block as its starting pivot. The
+   * healer serves from the canonical world state; the pivot-catchup listener returns an immediately
+   * completed future (the blockchain already holds every block and BAL, so there is no chain gap).
+   */
+  private SnapV2WorldDownloadState createDownloadState(
+      final BlockHeader stalePivot, final Hash canonicalRoot) {
+    final DefaultBlockchain blockchain = b.blockchain();
+    final SnapV2ReorgStateFetcher fetcher =
+        ReorgBlockchainBuilder.servingFetcher(
+            canonicalStorage,
+            canonicalRoot,
+            localCoordinator,
+            accountFetches,
+            storageFetches,
+            codeFetches);
+    final SnapV2ReorgHealer healer =
+        new SnapV2ReorgHealer(
+            blockchain, localCoordinator, ReorgBlockchainBuilder.balEnabledSchedule(), fetcher);
+    return new SnapV2WorldDownloadState(
+        localCoordinator,
+        new SnapSyncStatePersistenceManager(new InMemoryKeyValueStorageProvider()),
+        new SnapSyncProcessState(stalePivot),
+        new InMemoryTasksPriorityQueues<SnapDataRequest>(),
+        10,
+        50_000L,
+        new SnapSyncMetricsManager(new NoOpMetricsSystem(), ethContext),
+        Clock.systemUTC(),
+        SyncDurationMetrics.NO_OP_SYNC_DURATION_METRICS,
+        null,
+        (current, next) -> CompletableFuture.completedFuture(null),
+        new SnapV2BlockAccessListApplier(
+            localCoordinator, blockchain, ReorgBlockchainBuilder.balEnabledSchedule()),
+        healer,
+        blockchain,
+        ethContext,
+        1000L);
+  }
+
+  private void applyTo(
+      final WorldStateStorageCoordinator coordinator,
+      final long fromBlock,
+      final long toBlock,
+      final DownloadedAccountRangeTracker accountTracker,
+      final DownloadedStorageRangeTracker storageTracker) {
+    new SnapV2BlockAccessListApplier(
+            coordinator, b.blockchain(), ReorgBlockchainBuilder.balEnabledSchedule())
+        .applyBlockAccessLists(fromBlock, toBlock, accountTracker, storageTracker)
+        .commit();
+  }
+
+  private void startCatchupAndAwait(
+      final SnapV2WorldDownloadState state, final BlockHeader newPivot) {
+    state.startPivotCatchup(newPivot);
+    // finishPivotCatchup runs synchronously (pre-completed listener future + 0 in-flight tasks);
+    // guard against a future refactor by joining the download future if it already resolved.
+  }
+
+  private PmtStateTrieAccountValue readAccount(final Address address) {
+    return PmtStateTrieAccountValue.readFrom(RLP.input(readAccountBytes(address).orElseThrow()));
+  }
+
+  private Optional<Bytes> readAccountBytes(final Address address) {
+    return localCoordinator.applyForStrategy(
+        bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2AccountR
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
@@ -1001,6 +1002,86 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
         .isEqualTo(newPivot.getHeader());
   }
 
+  // ── Test 13: account with missing code bytes → code fetched during reorg recovery ───────────
+
+  /**
+   * Forces the code-fetch path: CAROL's canonical code hash ({@code carolCodeCanonical}) is stored
+   * in her account record but the corresponding code bytes are absent locally. The healer detects
+   * CAROL as Category B (YES+NO): she appears in block2s (orphaned nonce change) but is absent from
+   * block2c (canonical fork has an empty BAL). On re-fetch, {@code collectMissingCodeHashes} sees
+   * that CAROL's code hash is not locally available and schedules a {@code fetchCodes} call. After
+   * recovery the code bytes must be present, {@code codeFetches >= 1}, and the local state root
+   * must match {@code canonicalRoot}.
+   *
+   * <pre>
+   * gen -- 1(CAROL balance=100, code=carolCodeCanonical) -+- 2s(CAROL nonce=5)  orphaned
+   *                                                       \- 2c(empty BAL)      canonical
+   *                                                            \- 3c (pins canonicalRoot, newPivot)
+   * </pre>
+   */
+  @Test
+  void accountWithNewCanonicalCode_fetchesAndStoresCode() {
+    final Bytes carolCodeCanonical = Bytes.fromHexString("0x6080604052348015600f");
+
+    // Block 1: CAROL gets balance + carolCodeCanonical.
+    final Block block1 =
+        b.appendBlockWithBal(
+            b.header(0),
+            b.merge(
+                b.balWithBalances(Map.of(CAROL, Wei.of(100))),
+                b.balWithCodeChange(CAROL, carolCodeCanonical)),
+            1L);
+
+    // Block 2s (orphaned, low difficulty): CAROL nonce changes → she's in orphaned touches.
+    final Block block2s = b.appendStale(block1.getHeader(), b.balWithNonceChange(CAROL, 5L), 2L);
+
+    // Block 2c (canonical, high difficulty): empty BAL → CAROL absent from canonical touches.
+    final Block block2c = b.appendCanonical(block1.getHeader(), b.emptyBal(), 2L);
+
+    // Build canonical world state (block2c is now canonical at height 2).
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state with the orphaned block2s as pivot.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+
+    // Apply block 1 to local: stores CAROL's account record + carolCodeCanonical bytes.
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    // Delete CAROL's code bytes from local storage so hasCodeLocally() returns false.
+    // BonsaiWorldStateKeyValueStorage uses CodeHashCodeStorageStrategy when "code stored using
+    // code hash" is enabled; its removeFlatCode() is a no-op, so we delete the code entry
+    // directly from the underlying CODE_STORAGE segment instead.
+    final Hash carolCodeHash = Hash.hash(carolCodeCanonical);
+    final var codeTx = localStorage.getComposedWorldStateStorage().startTransaction();
+    codeTx.remove(KeyValueSegmentIdentifier.CODE_STORAGE, carolCodeHash.getBytes().toArrayUnsafe());
+    codeTx.commit();
+
+    // Apply block 2 (canonical block2c has empty BAL — no-op for CAROL locally).
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    // Code bytes must have been fetched and stored during reorg recovery.
+    assertThat(readCode(CAROL)).hasValue(carolCodeCanonical);
+    assertThat(codeFetches.get()).isGreaterThanOrEqualTo(1);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────
 
   /**
@@ -1082,5 +1163,11 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
                     address.addressHash(), new StorageSlotKey(slot)),
             forest -> Optional.<Bytes>empty())
         .map(UInt256::fromBytes);
+  }
+
+  private Optional<Bytes> readCode(final Address address) {
+    return readAccountBytes(address)
+        .map(bytes -> PmtStateTrieAccountValue.readFrom(RLP.input(bytes)).getCodeHash())
+        .flatMap(codeHash -> localCoordinator.getCode(codeHash, address.addressHash()));
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -105,6 +105,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private static final Bytes32 MAX_KEY =
       Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
+  // Test 11 — unaffected account with storage (not touched by either fork)
+  private static final Address CAROL =
+      Address.fromHexString("0x3333333333333333333333333333333333333333");
+
   private final BonsaiWorldStateKeyValueStorage localStorage =
       ReorgBlockchainBuilder.newBonsaiStorage();
   private final WorldStateStorageCoordinator localCoordinator =
@@ -853,6 +857,148 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(readAccount(GRACE).getBalance())
         .isEqualTo(Wei.of(50)); // NO+YES: new canonical account
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── Test 11: unaffected account storage root kept, request retargeted
+  // ───────────────────────────
+
+  /**
+   * A queued storage request for CAROL — an account NOT touched by either fork — is retargeted to
+   * the new pivot while keeping CAROL's existing (unchanged) storage root. The root is read from
+   * the local DB after seeding; it must NOT be replaced by the {@code correctedRoots} map (which
+   * only contains accounts whose canonical storage root differs from the orphaned one).
+   *
+   * <pre>
+   * gen -- 1(FRANK+CAROL have storage, S1 set) -+- 2s(FRANK adds S2=200)  orphaned
+   *                                              \- 2c(FRANK adds S3=555)  canonical
+   *                                                   \- 3c (pins canonicalRoot, new pivot)
+   * </pre>
+   */
+  @Test
+  void queuedStorageRequestForUnaffectedAccount_retargetedKeepingExistingRoot() {
+    final var baseBal =
+        b.merge(
+            b.balWithBalances(Map.of(FRANK, Wei.of(200), CAROL, Wei.of(10))),
+            b.balWithStorageChanges(FRANK, Map.of(S1, UInt256.valueOf(7))),
+            b.balWithStorageChanges(CAROL, Map.of(S1, UInt256.valueOf(9))));
+    final Block block1 = b.appendBlockWithBal(b.header(0), baseBal, 1L);
+    final Block block2s =
+        b.appendStale(
+            block1.getHeader(),
+            b.balWithStorageChanges(FRANK, Map.of(S2, UInt256.valueOf(200))),
+            2L);
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.balWithStorageChanges(FRANK, Map.of(S3, UInt256.valueOf(555))),
+            2L);
+
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    // Read CAROL's storage root from the local DB after seeding (she is untouched by both forks).
+    final Bytes32 carolRoot = Bytes32.wrap(readAccount(CAROL).getStorageRoot().getBytes());
+
+    final SnapV2StorageRangeRequest carolReq =
+        new SnapV2StorageRangeRequest(
+            block2s.getHeader(),
+            Bytes32.wrap(CAROL.addressHash().getBytes()),
+            carolRoot,
+            RangeManager.MIN_RANGE,
+            RangeManager.MAX_RANGE,
+            RangeManager.MIN_RANGE);
+    state.enqueueRequest(carolReq);
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    final var queued = state.pendingStorageRequests.asList();
+    assertThat(queued).hasSize(1);
+    final SnapV2StorageRangeRequest retargeted = (SnapV2StorageRangeRequest) queued.get(0);
+    assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
+    // CAROL is absent from correctedRoots — storage root must be preserved as-is.
+    assertThat(retargeted.getStorageRoot()).isEqualTo(carolRoot);
+  }
+
+  // ── Test 12: queued code and account requests retargeted to new pivot ─────────────────────────
+
+  /**
+   * A queued bytecode request and a queued account-range request — both originally targeted at the
+   * stale (orphaned) pivot — are retargeted to the new pivot after the reorg completes.
+   *
+   * <pre>
+   * gen -- 1(ALICE=100) -+- 2s(ALICE=50)  orphaned
+   *                      \- 2c(ALICE=80)  canonical
+   *                           \- 3c (pins canonicalRoot, new pivot)
+   * </pre>
+   */
+  @Test
+  void queuedCodeAndAccountRequests_retargetedToNewPivot() {
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    final SnapV2BytecodeRequest codeReq =
+        new SnapV2BytecodeRequest(
+            block2s.getHeader(),
+            Bytes32.wrap(ALICE.addressHash().getBytes()),
+            Bytes32.wrap(Hash.hash(NC_CODE).getBytes()),
+            RangeManager.MIN_RANGE);
+    final SnapV2AccountRangeRequest accountReq =
+        new SnapV2AccountRangeRequest(
+            block2s.getHeader(), RangeManager.MIN_RANGE, RangeManager.MAX_RANGE);
+    state.enqueueRequest(codeReq);
+    state.enqueueRequest(accountReq);
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(
+            ((SnapV2BytecodeRequest) state.pendingCodeRequests.asList().get(0))
+                .getPivotBlockHeader())
+        .isEqualTo(newPivot.getHeader());
+    assertThat(
+            ((SnapV2AccountRangeRequest) state.pendingAccountRequests.asList().get(0))
+                .getPivotBlockHeader())
+        .isEqualTo(newPivot.getHeader());
   }
 
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -93,6 +93,13 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private static final Address FRANK =
       Address.fromHexString("0x6666666666666666666666666666666666666666");
 
+  // Tests 7, 8 — download-status rules (PENDING and not-yet-downloaded).
+  private static final Address PETE =
+      Address.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+  private static final UInt256 SP1 = UInt256.valueOf(101);
+  private static final UInt256 SP2 = UInt256.valueOf(102);
+
   private static final Bytes32 MAX_KEY =
       Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
@@ -466,6 +473,196 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
     final Bytes32 canonicalFrankRoot = Bytes32.wrap(readAccount(FRANK).getStorageRoot().getBytes());
     assertThat(retargeted.getStorageRoot()).isEqualTo(canonicalFrankRoot);
+  }
+
+  // ── Test 7: PENDING range — fix downloaded slot, defer not-downloaded slot ───────────────────
+
+  /**
+   * Account range is PENDING (has one outstanding child). PETE's slot SP1 is downloaded but SP2 is
+   * not. The orphaned fork rewrites both slots. After recovery:
+   *
+   * <ul>
+   *   <li>SP1 is re-fetched from the canonical peer and restored to its canonical value (1).
+   *   <li>SP2 remains absent (never downloaded, never re-fetched).
+   *   <li>The queued storage request is retargeted to the new pivot with PETE's canonical storage
+   *       root (installed via root-patch, not recomputed from the incomplete trie).
+   * </ul>
+   *
+   * <pre>
+   * gen -- 1(PETE=100, SP1=1) -- 2(SP2=2) -- 3s(SP1=10, SP2=20)   orphaned
+   *                                        \-- 3c(PETE=300 bal)     canonical
+   *                                              \-- 4c (pins canonicalRoot, new pivot)
+   * </pre>
+   */
+  @Test
+  void pendingRange_appliesToDownloadedSlotsAndDefersRest() {
+    // Throwaway trackers for local seeding: PENDING range, only SP1 slot downloaded.
+    final DownloadedAccountRangeTracker seedAccountTracker = new DownloadedAccountRangeTracker();
+    seedAccountTracker.registerPending(Bytes32.ZERO, MAX_KEY, 1);
+    final DownloadedStorageRangeTracker seedStorageTracker = new DownloadedStorageRangeTracker();
+    seedStorageTracker.registerSlotRange(
+        Bytes32.wrap(PETE.addressHash().getBytes()),
+        Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()),
+        Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()));
+
+    // Block 1 (shared): creates PETE with balance 100 and SP1=1.
+    // PETE is new (existingAccount == null) so isAccountCompleted=true; SP1 applied in full.
+    final Block block1 =
+        b.appendBlockWithBal(
+            b.header(0),
+            b.merge(
+                b.balWithBalances(Map.of(PETE, Wei.of(100))),
+                b.balWithStorageChanges(PETE, Map.of(SP1, UInt256.valueOf(1)))),
+            1L);
+    applyTo(localCoordinator, 1, 1, seedAccountTracker, seedStorageTracker);
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Block 2 (shared): SP2 appears on the canonical side; SP2 is NOT downloaded locally
+    // (not in seedStorageTracker), so the slot-guard blocks it.
+    final Block block2 =
+        b.appendBlockWithBal(
+            block1.getHeader(), b.balWithStorageChanges(PETE, Map.of(SP2, UInt256.valueOf(2))), 2L);
+    applyTo(localCoordinator, 2, 2, seedAccountTracker, seedStorageTracker);
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Block 3s (orphaned, low difficulty): rewrites both slots; only SP1 lands locally.
+    // appendStale uses LOW difficulty, so it is initially canonical at height 3.
+    final Block block3s =
+        b.appendStale(
+            block2.getHeader(),
+            b.balWithStorageChanges(
+                PETE, Map.of(SP1, UInt256.valueOf(10), SP2, UInt256.valueOf(20))),
+            3L);
+    applyTo(localCoordinator, 3, 3, seedAccountTracker, seedStorageTracker);
+    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(10)); // downloaded, rewritten
+    assertThat(readStorageSlot(PETE, SP2)).isEmpty(); // not downloaded, still absent
+
+    // Block 3c (canonical, high difficulty): balance only; reorg makes it canonical at height 3.
+    final Block block3c =
+        b.appendCanonical(block2.getHeader(), b.balWithBalances(Map.of(PETE, Wei.of(300))), 3L);
+    applyTo(
+        canonicalCoordinator,
+        3,
+        3,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block3c.getHeader(), b.emptyBal(), 4L, canonicalRoot);
+
+    // Create download state; register the same PENDING+SP1 configuration on state's trackers
+    // (the healer reads these during planReorg / applyReorgCorrections).
+    final SnapV2WorldDownloadState state = createDownloadState(block3s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 1);
+    state
+        .getStorageRangeTracker()
+        .registerSlotRange(
+            Bytes32.wrap(PETE.addressHash().getBytes()),
+            Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()),
+            Bytes32.wrap(new StorageSlotKey(SP1).getSlotHash().getBytes()));
+
+    // Queue PETE's still-in-progress storage request with the stale (orphaned) storage root.
+    final Bytes32 oldRoot = Bytes32.wrap(readAccount(PETE).getStorageRoot().getBytes());
+    final SnapV2StorageRangeRequest peteReq =
+        new SnapV2StorageRangeRequest(
+            block3s.getHeader(),
+            Bytes32.wrap(PETE.addressHash().getBytes()),
+            oldRoot,
+            RangeManager.MIN_RANGE,
+            RangeManager.MAX_RANGE,
+            RangeManager.MIN_RANGE);
+    state.enqueueRequest(peteReq);
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    // Downloaded SP1 restored; not-downloaded SP2 stays absent; canonical balance applied.
+    assertThat(readStorageSlot(PETE, SP1)).hasValue(UInt256.valueOf(1));
+    assertThat(readStorageSlot(PETE, SP2)).isEmpty();
+    assertThat(readAccount(PETE).getBalance()).isEqualTo(Wei.of(300));
+
+    // Pending account: retargeted storage request carries PETE's canonical storage root
+    // (installed via root-patch, not recomputed from the still-incomplete local trie).
+    final PmtStateTrieAccountValue canonicalPete =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(
+                canonicalCoordinator
+                    .applyForStrategy(
+                        bonsai -> bonsai.getAccount(PETE.addressHash()),
+                        forest -> Optional.<Bytes>empty())
+                    .orElseThrow()));
+    final SnapV2StorageRangeRequest retargeted =
+        (SnapV2StorageRangeRequest) state.pendingStorageRequests.asList().get(0);
+    assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
+    assertThat(retargeted.getStorageRoot())
+        .isEqualTo(Bytes32.wrap(canonicalPete.getStorageRoot().getBytes()));
+  }
+
+  // ── Test 8: not-yet-downloaded range → account deferred entirely ─────────────────────────────
+
+  /**
+   * ALICE's account hash lies outside the registered downloaded range (only [ZERO, ZERO] is
+   * persisted). The orphaned fork modified ALICE, but since her range is not persisted, recovery
+   * must skip her entirely — no re-download, no local change.
+   *
+   * <pre>
+   * gen -- 1(ALICE=100) -- 2s(ALICE=50)   orphaned
+   *                     \-- 2c(ALICE=80)  canonical
+   *                           \-- 3c (newPivot, canonicalRoot)
+   * </pre>
+   */
+  @Test
+  void notYetDownloadedRange_defersToLaterCycle() {
+    // Verify that ALICE is NOT covered by the degenerate [ZERO, ZERO] range.
+    final Bytes32 aliceHash = Bytes32.wrap(ALICE.addressHash().getBytes());
+    assertThat(aliceHash).isNotEqualTo(Bytes32.ZERO);
+
+    // Build chain: block1 (shared), block2s (orphaned low), block2c (canonical high).
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    // Seed canonical coordinator only; ALICE is not applied to local (her range is not persisted).
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state: only [ZERO, ZERO] is persisted; ALICE's hash is NOT covered.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, Bytes32.ZERO, 0);
+    // ALICE's hash is outside [ZERO, ZERO] → isAccountHashPersisted returns false.
+    assertThat(state.getAccountRangeTracker().isAccountHashPersisted(aliceHash)).isFalse();
+
+    // Do NOT apply any local BALs for ALICE — she is not in the persisted range.
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    // ALICE is not in the persisted range: skipped by planReorg and applyCanonicalBals.
+    assertThat(accountExists(ALICE)).isFalse();
+    assertThat(accountFetches).hasValue(0); // no re-download triggered
   }
 
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -31,7 +32,10 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncMetricsManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapSyncProcessState;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.context.SnapSyncStatePersistenceManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2BytecodeRequest;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.v2.SnapV2StorageRangeRequest;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
@@ -47,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -61,6 +66,18 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
   private static final Address ALICE =
       Address.fromHexString("0x1111111111111111111111111111111111111111");
+
+  // Test 2 — YES+NO (present in canonical): orphaned fork changed DAVE; canonical fork did not.
+  private static final Address DAVE =
+      Address.fromHexString("0x4444444444444444444444444444444444444444");
+
+  // Test 3 — YES+NO (absent from canonical): contract exists only on orphaned fork.
+  private static final Address NEW_CONTRACT =
+      Address.fromHexString("0x9999999999999999999999999999999999999999");
+
+  private static final Bytes NC_CODE = Bytes.fromHexString("0x60806040523480156010");
+
+  private static final UInt256 S1 = UInt256.valueOf(1);
 
   private static final Bytes32 MAX_KEY =
       Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -131,6 +148,141 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 
+  // ── Test 2: matrix YES + NO (present in canonical) → re-download and restore ─────────────────
+
+  @Test
+  void modifiedInOrphanedButNotNewBlock_reDownloadsAndUpdatesWhenPresent() {
+    // Build all blockchain blocks first.
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(DAVE, Wei.of(75))), 1L);
+    // orphaned (2s): DAVE = 60 — appended first so it is initially canonical
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(DAVE, Wei.of(60))), 2L);
+    // canonical (2c): ALICE = 80, DAVE untouched — higher difficulty wins the reorg
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    // Build canonical world state first so we can pin the state root.
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state with stale pivot; then seed trackers and apply local BALs.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+
+    // Register the full address space as already downloaded.
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+
+    // Apply canonical BALs to local using the state's trackers.
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    // DAVE was modified by orphaned fork but is absent from canonical BAL → re-downloaded.
+    assertThat(readAccount(DAVE).getBalance()).isEqualTo(Wei.of(75));
+    assertThat(accountFetches.get()).isGreaterThanOrEqualTo(1);
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── Test 3: matrix YES + NO (absent from canonical) → delete + purge queued child requests ────
+
+  @Test
+  void modifiedInOrphanedButNotNewBlock_deletesWhenAbsentFromCanonical() {
+    // Build common-ancestor block.
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 1L);
+
+    // Orphaned block creates NEW_CONTRACT with balance, code, and storage.
+    final Block block2s =
+        b.appendStale(
+            block1.getHeader(),
+            b.merge(
+                b.balWithBalances(Map.of(NEW_CONTRACT, Wei.ONE)),
+                b.balWithCodeChange(NEW_CONTRACT, NC_CODE),
+                b.balWithStorageChanges(NEW_CONTRACT, Map.of(S1, UInt256.valueOf(5)))),
+            2L);
+
+    // Pre-seed local with the orphaned state while block2s is still canonical at height 2.
+    applyTo(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Verify NEW_CONTRACT is present locally before the canonical fork arrives.
+    assertThat(readStorageSlot(NEW_CONTRACT, S1)).hasValue(UInt256.valueOf(5));
+    assertThat(accountExists(NEW_CONTRACT)).isTrue();
+
+    // Canonical fork (block2c) wins the reorg; NEW_CONTRACT is absent from canonical chain.
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    // Build canonical world state and compute its root.
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create the download state with the orphaned block as its starting pivot.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+
+    // Queue a storage-range and a bytecode request for the doomed contract so the purge is tested.
+    final SnapV2StorageRangeRequest storageReq =
+        new SnapV2StorageRangeRequest(
+            block2s.getHeader(),
+            Bytes32.wrap(NEW_CONTRACT.addressHash().getBytes()),
+            Bytes32.random(),
+            RangeManager.MIN_RANGE,
+            RangeManager.MAX_RANGE,
+            RangeManager.MIN_RANGE);
+    final SnapV2BytecodeRequest codeReq =
+        new SnapV2BytecodeRequest(
+            block2s.getHeader(),
+            Bytes32.wrap(NEW_CONTRACT.addressHash().getBytes()),
+            Bytes32.wrap(Hash.hash(NC_CODE).getBytes()),
+            RangeManager.MIN_RANGE);
+    state.enqueueRequest(storageReq);
+    state.enqueueRequest(codeReq);
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    // NEW_CONTRACT must be gone from local state.
+    assertThat(accountExists(NEW_CONTRACT)).isFalse();
+    assertThat(readStorageSlot(NEW_CONTRACT, S1)).isEmpty();
+    // Queued child requests for the doomed contract must have been purged.
+    assertThat(state.pendingStorageRequests.asList()).isEmpty();
+    assertThat(state.pendingCodeRequests.asList()).isEmpty();
+    // ALICE carries through from the canonical BAL.
+    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────
 
   /**
@@ -198,5 +350,19 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private Optional<Bytes> readAccountBytes(final Address address) {
     return localCoordinator.applyForStrategy(
         bonsai -> bonsai.getAccount(address.addressHash()), forest -> Optional.<Bytes>empty());
+  }
+
+  private boolean accountExists(final Address address) {
+    return readAccountBytes(address).isPresent();
+  }
+
+  private Optional<UInt256> readStorageSlot(final Address address, final UInt256 slot) {
+    return localCoordinator
+        .applyForStrategy(
+            bonsai ->
+                bonsai.getStorageValueByStorageSlotKey(
+                    address.addressHash(), new StorageSlotKey(slot)),
+            forest -> Optional.<Bytes>empty())
+        .map(UInt256::fromBytes);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -78,6 +78,8 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   private static final Bytes NC_CODE = Bytes.fromHexString("0x60806040523480156010");
 
   private static final UInt256 S1 = UInt256.valueOf(1);
+  private static final UInt256 S2 = UInt256.valueOf(2);
+  private static final UInt256 S3 = UInt256.valueOf(3);
 
   // Test 4 — NO+YES: account created only on canonical fork.
   private static final Address GRACE =
@@ -86,6 +88,10 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
   // Test 5 — NO+NO: account exists at block1, neither fork touches it.
   private static final Address BOB =
       Address.fromHexString("0x2222222222222222222222222222222222222222");
+
+  // Test 6 — slot-level YES+NO: orphaned fork changes S1+S2, canonical fork sets S3.
+  private static final Address FRANK =
+      Address.fromHexString("0x6666666666666666666666666666666666666666");
 
   private static final Bytes32 MAX_KEY =
       Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -374,6 +380,92 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
     assertThat(readAccount(BOB).getBalance()).isEqualTo(Wei.of(100)); // untouched by both forks
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── Test 6: slot-level YES+NO → orphaned-only slots restored, canonical slot applied ──────────
+
+  @Test
+  void slotsModifiedInOrphanedButNotNewBlock_reDownloadsSlots() {
+    // Block 1: FRANK has balance + S1=7 (base state).
+    final var baseBal =
+        b.merge(
+            b.balWithBalances(Map.of(FRANK, Wei.of(200))),
+            b.balWithStorageChanges(FRANK, Map.of(S1, UInt256.valueOf(7))));
+    final Block block1 = b.appendBlockWithBal(b.header(0), baseBal, 1L);
+
+    // Block 2s (orphaned, lower difficulty): FRANK S1=100, S2=200 — canonical at height 2
+    // initially.
+    final Block block2s =
+        b.appendStale(
+            block1.getHeader(),
+            b.balWithStorageChanges(
+                FRANK, Map.of(S1, UInt256.valueOf(100), S2, UInt256.valueOf(200))),
+            2L);
+
+    // Pre-seed local with the orphaned state while block2s is still canonical at height 2.
+    applyTo(
+        localCoordinator,
+        1,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+
+    // Block 2c (canonical, higher difficulty): FRANK S3=555 — triggers reorg.
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.balWithStorageChanges(FRANK, Map.of(S3, UInt256.valueOf(555))),
+            2L);
+
+    // Build canonical world state (block2c is now canonical at height 2).
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    // Create download state with the stale (orphaned) pivot.
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    // Completing the full account range (initialChildCount=0) makes
+    // isAccountHashDownloaded(FRANK)=true so that computeSlotsToRefetch detects the
+    // diverged orphaned slots S1 and S2.
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+
+    // Queue a storage request for FRANK with the (soon-stale) orphaned storage root.
+    final Bytes32 oldRoot = Bytes32.wrap(readAccount(FRANK).getStorageRoot().getBytes());
+    final SnapV2StorageRangeRequest frankReq =
+        new SnapV2StorageRangeRequest(
+            block2s.getHeader(),
+            Bytes32.wrap(FRANK.addressHash().getBytes()),
+            oldRoot,
+            RangeManager.MIN_RANGE,
+            RangeManager.MAX_RANGE,
+            RangeManager.MIN_RANGE);
+    state.enqueueRequest(frankReq);
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(readStorageSlot(FRANK, S1)).hasValue(UInt256.valueOf(7)); // restored to base value
+    assertThat(readStorageSlot(FRANK, S2)).isEmpty(); // orphaned-only slot removed
+    assertThat(readStorageSlot(FRANK, S3)).hasValue(UInt256.valueOf(555)); // canonical slot applied
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+
+    // The queued storage request was retargeted to the new pivot with FRANK's canonical root.
+    final var queued = state.pendingStorageRequests.asList();
+    assertThat(queued).hasSize(1);
+    final SnapV2StorageRangeRequest retargeted = (SnapV2StorageRangeRequest) queued.get(0);
+    assertThat(retargeted.getPivotBlockHeader()).isEqualTo(newPivot.getHeader());
+    final Bytes32 canonicalFrankRoot = Bytes32.wrap(readAccount(FRANK).getStorageRoot().getBytes());
+    assertThat(retargeted.getStorageRoot()).isEqualTo(canonicalFrankRoot);
   }
 
   // ── shared helpers ────────────────────────────────────────────────────────────────────────────

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/v2/SnapV2WorldDownloadStateReorgIntegrationTest.java
@@ -79,6 +79,14 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
 
   private static final UInt256 S1 = UInt256.valueOf(1);
 
+  // Test 4 — NO+YES: account created only on canonical fork.
+  private static final Address GRACE =
+      Address.fromHexString("0x7777777777777777777777777777777777777777");
+
+  // Test 5 — NO+NO: account exists at block1, neither fork touches it.
+  private static final Address BOB =
+      Address.fromHexString("0x2222222222222222222222222222222222222222");
+
   private static final Bytes32 MAX_KEY =
       Bytes32.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
@@ -280,6 +288,91 @@ class SnapV2WorldDownloadStateReorgIntegrationTest {
     assertThat(state.pendingCodeRequests.asList()).isEmpty();
     // ALICE carries through from the canonical BAL.
     assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── Test 4: matrix NO + YES → new account created from canonical BAL ─────────────────────────
+
+  @Test
+  void notModifiedInOrphanedButModifiedInNewBlock_appliesNewBal() {
+    final Block block1 =
+        b.appendBlockWithBal(b.header(0), b.balWithBalances(Map.of(ALICE, Wei.of(100))), 1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block2c =
+        b.appendCanonical(
+            block1.getHeader(),
+            b.merge(
+                b.balWithBalances(Map.of(ALICE, Wei.of(80))),
+                b.balWithBalances(Map.of(GRACE, Wei.of(50)))),
+            2L);
+
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(readAccount(GRACE).getBalance()).isEqualTo(Wei.of(50)); // created from canonical BAL
+    assertThat(readAccount(ALICE).getBalance()).isEqualTo(Wei.of(80));
+    assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
+  }
+
+  // ── Test 5: matrix NO + NO → untouched account is left intact ────────────────────────────────
+
+  @Test
+  void notModifiedInOrphanedOrNewBlock_skipsEntirely() {
+    final Block block1 =
+        b.appendBlockWithBal(
+            b.header(0),
+            b.merge(
+                b.balWithBalances(Map.of(ALICE, Wei.of(100))),
+                b.balWithBalances(Map.of(BOB, Wei.of(100)))),
+            1L);
+    final Block block2s =
+        b.appendStale(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(50))), 2L);
+    final Block block2c =
+        b.appendCanonical(block1.getHeader(), b.balWithBalances(Map.of(ALICE, Wei.of(80))), 2L);
+
+    applyTo(
+        canonicalCoordinator,
+        1,
+        1,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    applyTo(
+        canonicalCoordinator,
+        2,
+        2,
+        ReorgBlockchainBuilder.fullAccountRange(),
+        new DownloadedStorageRangeTracker());
+    final Hash canonicalRoot = ReorgBlockchainBuilder.worldStateRoot(canonicalCoordinator);
+    final Block newPivot = b.appendCanonical(block2c.getHeader(), b.emptyBal(), 3L, canonicalRoot);
+
+    final SnapV2WorldDownloadState state = createDownloadState(block2s.getHeader(), canonicalRoot);
+    state.getAccountRangeTracker().registerPending(Bytes32.ZERO, MAX_KEY, 0);
+    applyTo(localCoordinator, 1, 1, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+    applyTo(localCoordinator, 2, 2, state.getAccountRangeTracker(), state.getStorageRangeTracker());
+
+    startCatchupAndAwait(state, newPivot.getHeader());
+
+    assertThat(readAccount(BOB).getBalance()).isEqualTo(Wei.of(100)); // untouched by both forks
     assertThat(ReorgBlockchainBuilder.worldStateRoot(localCoordinator)).isEqualTo(canonicalRoot);
   }
 


### PR DESCRIPTION
Add integration tests for snap/2 reorgs. I did this as an integration test using `SnapV2WorldDownloadState` instead an acceptance test as the acceptance test approach resulted in slow flaky tests.

## Summary

- Adds `SnapV2WorldDownloadStateReorgIntegrationTest` — a new end-to-end integration test class for the snap/2 reorg recovery path, covering the full pipeline from BAL construction through pivot catch-up and world-state assertion against a real in-memory Bonsai store.
- Extends `ReorgBlockchainBuilder` with multi-block chain helpers and refactors `SnapV2BlockAccessListApplierReorgTest` and `SnapV2ReorgHealerRecoveryTest` to share the builder, removing ~100 lines of duplicated harness setup.

### Scenarios covered

For each of accounts, storage slots, and code: touched on both forks (apply canonical BAL), orphaned only (re-fetch from peer / delete if absent), canonical only (apply BAL), untouched (skip).

Also covers: partially-downloaded and not-yet-reached account ranges, in-flight queue retargeting and purging, multi-block reorgs, straight pivot advance, and unrecoverable reorg failure propagation.

## Test plan

- [ ] All existing `SnapV2BlockAccessListApplierReorgTest` and `SnapV2ReorgHealerRecoveryTest` tests pass (refactor is behaviour-preserving)
- [ ] All new integration tests pass