### PR TITLE
Fix/sync signal reporting bugs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
@@ -80,6 +80,16 @@ public class ReadinessCheck implements HealthService.HealthCheck {
       }
     }
 
+    // A snap syncing node is not ready until its chain download, world state download, trie heal
+    // and flat database heal have all finished — it cannot serve state before then. Checked
+    // separately from the block distance below, which is skipped entirely while the sync reports
+    // no status at all (snap sync's stage 1 does not report progress).
+    final boolean initialSyncDone = synchronizer.isInitialSyncPhaseDone();
+    if (!initialSyncDone) {
+      checks.put("initialSync", new JsonObject().put("status", false).put("complete", false));
+      healthy = false;
+    }
+
     final Optional<SyncStatus> syncStatusOpt = synchronizer.getSyncStatus();
     if (syncStatusOpt.isPresent()) {
       final SyncStatus syncStatus = syncStatusOpt.get();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ReadinessCheckTest {
@@ -40,6 +41,57 @@ public class ReadinessCheckTest {
   private final HealthService.ParamSource paramSource = params::get;
 
   private final ReadinessCheck readinessCheck = new ReadinessCheck(p2pNetwork, synchronizer);
+
+  @BeforeEach
+  public void setUp() {
+    // Most cases here are about the peer and block-distance checks; default to a node past its
+    // initial sync phase so that gate does not mask them.
+    when(synchronizer.isInitialSyncPhaseDone()).thenReturn(true);
+  }
+
+  @Test
+  public void shouldNotBeReadyWhileInitialSyncPhaseIsNotDone() {
+    // Covers the world state download, the trie heal and the flat database heal: a snap syncing
+    // node cannot serve state until all of them have finished.
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.isInitialSyncPhaseDone()).thenReturn(false);
+    when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1000));
+
+    final HealthService.HealthCheckResult result = readinessCheck.checkHealth(paramSource);
+
+    assertThat(result.isHealthy()).isFalse();
+    final JsonObject initialSync = result.getDetails().getJsonObject("initialSync");
+    assertThat(initialSync.getBoolean("status")).isFalse();
+    assertThat(initialSync.getBoolean("complete")).isFalse();
+  }
+
+  @Test
+  public void shouldNotBeReadyWhileInitialSyncPhaseIsNotDoneAndNoSyncStatusIsReported() {
+    // Snap sync's stage 1 reports no progress at all, which leaves the block-distance check
+    // skipped. Without the initial sync gate the node would report ready on the peer check alone.
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.isInitialSyncPhaseDone()).thenReturn(false);
+    when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
+
+    final HealthService.HealthCheckResult result = readinessCheck.checkHealth(paramSource);
+
+    assertThat(result.isHealthy()).isFalse();
+    assertThat(result.getDetails().containsKey("sync")).isFalse();
+  }
+
+  @Test
+  public void shouldOmitInitialSyncDetailOnceInitialSyncPhaseIsDone() {
+    when(p2pNetwork.isP2pEnabled()).thenReturn(true);
+    when(p2pNetwork.getPeerCount()).thenReturn(5);
+    when(synchronizer.getSyncStatus()).thenReturn(createSyncStatus(1000, 1000));
+
+    final HealthService.HealthCheckResult result = readinessCheck.checkHealth(paramSource);
+
+    assertThat(result.isHealthy()).isTrue();
+    assertThat(result.getDetails().containsKey("initialSync")).isFalse();
+  }
 
   @Test
   public void shouldBeReadyWhenDefaultLimitsUsedAndReached() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
@@ -49,6 +49,15 @@ public interface Synchronizer {
   boolean isInSync();
 
   /**
+   * Whether the initial sync phase has finished. For a snap syncing node this stays false until the
+   * chain download, the world state download, the trie heal and the flat database heal have all
+   * completed; a node with no initial sync phase reports true from start-up.
+   *
+   * @return true once the initial sync phase is done
+   */
+  boolean isInitialSyncPhaseDone();
+
+  /**
    * Returns the best known block height of the network.
    *
    * @return the best known block height of the network, or empty if not known

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/DummySynchronizer.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/DummySynchronizer.java
@@ -48,6 +48,11 @@ public class DummySynchronizer implements Synchronizer {
   }
 
   @Override
+  public boolean isInitialSyncPhaseDone() {
+    return true;
+  }
+
+  @Override
   public Optional<Long> getBestPeerChainHead() {
     return Optional.empty();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -293,6 +293,11 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
     return syncState.isInSync();
   }
 
+  @Override
+  public boolean isInitialSyncPhaseDone() {
+    return syncState.isInitialSyncPhaseDone();
+  }
+
   /**
    * Returns the best known block height of the network.
    *

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -177,13 +177,31 @@ public class BackwardSyncContext {
     return status.currentFuture;
   }
 
+  /**
+   * The current backward sync session, starting one when there is none in flight.
+   *
+   * <p>A session whose future has already completed is not reused: {@code
+   * BackwardSyncAlgorithm.pickNextStep()} can finish a session on the calling thread, in which case
+   * the completion handler in {@link #prepareBackwardSyncFutureWithRetry()} clears the status
+   * before it is even published. Handing that finished session back would make every later {@code
+   * syncBackwardsUntil} return an already-completed future, so no backward sync would ever start
+   * again.
+   */
   private Status getOrStartSyncSession() {
-    Optional<Status> maybeCurrentStatus = Optional.ofNullable(this.currentBackwardSyncStatus.get());
+    Optional<Status> maybeCurrentStatus =
+        Optional.ofNullable(this.currentBackwardSyncStatus.get())
+            .filter(status -> !status.currentFuture.isDone());
     return maybeCurrentStatus.orElseGet(
         () -> {
           LOG.info("Starting a new backward sync session");
           Status newStatus = new Status(prepareBackwardSyncFutureWithRetry());
-          this.currentBackwardSyncStatus.set(newStatus);
+          // Only publish a session that is still running. A synchronously completed one has
+          // already had the status cleared by its own handler, and publishing it would park a
+          // finished session in the field for other readers — getStatus() hands it to
+          // BackwardSyncStep's progress logging, and maybeUpdateTargetHeight would mutate it.
+          if (!newStatus.currentFuture.isDone()) {
+            this.currentBackwardSyncStatus.set(newStatus);
+          }
           return newStatus;
         });
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -111,9 +111,20 @@ public class BackwardSyncContext {
     this.maxBadChainEventEntries = maxBadChainEventEntries;
   }
 
+  /**
+   * Whether a backward sync session is currently in flight.
+   *
+   * <p>A session is represented by a non-null {@code currentBackwardSyncStatus} whose future has
+   * not yet completed. The status is cleared from within the completion handler of that same future
+   * (see {@link #prepareBackwardSyncFutureWithRetry()}), so the {@code isDone} check also guards
+   * the case where a synchronously completing future is overwritten by {@link
+   * #getOrStartSyncSession()} after the handler has already cleared the status.
+   *
+   * @return true while a backward sync session is running, false otherwise
+   */
   public synchronized boolean isSyncing() {
     return Optional.ofNullable(currentBackwardSyncStatus.get())
-        .map(status -> status.currentFuture.isDone())
+        .map(status -> !status.currentFuture.isDone())
         .orElse(Boolean.FALSE);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -201,6 +201,13 @@ public class BackwardSyncContext {
           // BackwardSyncStep's progress logging, and maybeUpdateTargetHeight would mutate it.
           if (!newStatus.currentFuture.isDone()) {
             this.currentBackwardSyncStatus.set(newStatus);
+            // The future can complete between the check above and the publish, in which case its
+            // handler has already cleared the field and we have just re-published a finished
+            // session. compareAndSet retracts only our own status, so a session started in the
+            // meantime is left alone.
+            if (newStatus.currentFuture.isDone()) {
+              this.currentBackwardSyncStatus.compareAndSet(newStatus, null);
+            }
           }
           return newStatus;
         });

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStep.java
@@ -63,7 +63,7 @@ public class ImportSyncBlocksStep implements Consumer<List<SyncBlockWithReceipts
         .unsafeImportSyncBodiesAndReceipts(blocksWithReceipts, transactionIndexingEnabled);
     final long lastBlock = blocksWithReceipts.getLast().getNumber();
 
-    syncState.setSyncProgress(startBlock, lastBlock, pivotHeaderNumber);
+    syncState.setSyncProgress(startBlock, lastBlock);
 
     if (isTimeToUpdate.get()) {
       int peerCount = -1; // ethContext is not available in tests

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -69,6 +69,10 @@ public class SyncState implements NewPayloadListener {
   private volatile long lastPayloadBlockNumber = 0L;
   private volatile boolean payloadReceived = false;
 
+  // Progress reported by a sync that does not use a sync target, i.e. snap sync. Retained so that
+  // eth_syncing can report progress during the initial sync phase; cleared once that phase ends.
+  private volatile Optional<SyncStatus> targetlessSyncProgress = Optional.empty();
+
   public SyncState(final Blockchain blockchain, final EthPeers ethPeers) {
     this(blockchain, ethPeers, false, Optional.empty());
   }
@@ -161,8 +165,18 @@ public class SyncState implements NewPayloadListener {
     return completionListenerSubscribers.unsubscribe(listenerId);
   }
 
+  /**
+   * The current sync status, or empty when this node is not syncing.
+   *
+   * <p>Falls back to {@link #setSyncProgress(long, long, long)} reporting when no sync target is
+   * set. Snap sync does not use a sync target — only {@code PipelineChainDownloader}, used by full
+   * sync, sets one — so without this fallback {@code eth_syncing} reports "not syncing" for the
+   * whole of a snap sync.
+   *
+   * @return the current sync status, or empty when not syncing
+   */
   public Optional<SyncStatus> syncStatus() {
-    return syncStatus(syncTarget);
+    return syncStatus(syncTarget).or(() -> targetlessSyncProgress);
   }
 
   public Optional<SyncTarget> syncTarget() {
@@ -179,6 +193,7 @@ public class SyncState implements NewPayloadListener {
     final SyncStatus status =
         new DefaultSyncStatus(
             startingBlock, currentBlock, highestBlock, Optional.empty(), Optional.empty());
+    targetlessSyncProgress = Optional.of(status);
     syncStatusListeners.forEach(c -> c.onSyncStatusChanged(Optional.of(status)));
   }
 
@@ -358,6 +373,9 @@ public class SyncState implements NewPayloadListener {
   public void markInitialSyncPhaseAsDone() {
     isInitialSyncPhaseDone = true;
     isResyncNeeded = false;
+    // Otherwise the last progress reported by snap sync would be returned by syncStatus() forever,
+    // making eth_syncing report a permanently in-progress sync.
+    targetlessSyncProgress = Optional.empty();
     completionListenerSubscribers.forEach(InitialSyncCompletionListener::onInitialSyncCompleted);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -71,7 +71,19 @@ public class SyncState implements NewPayloadListener {
 
   // Progress reported by a sync that does not use a sync target, i.e. snap sync. Retained so that
   // eth_syncing can report progress during the initial sync phase; cleared once that phase ends.
-  private volatile Optional<SyncStatus> targetlessSyncProgress = Optional.empty();
+  // Null until the first report. Only the blocks are retained: the highest block is resolved per
+  // read, see targetlessSyncStatus().
+  private volatile TargetlessSyncProgress targetlessSyncProgress;
+
+  // Set once markInitialSyncPhaseAsDone() has run, so that any later progress report can be
+  // dropped rather than reinstating targetlessSyncProgress. Tracked separately from
+  // isInitialSyncPhaseDone, which is already true from construction on a node that has no initial
+  // sync phase.
+  private boolean initialSyncPhaseCompleted;
+
+  // Guards the two fields above together, so that a progress report cannot interleave with
+  // markInitialSyncPhaseAsDone() clearing the progress.
+  private final Object targetlessSyncProgressLock = new Object();
 
   public SyncState(final Blockchain blockchain, final EthPeers ethPeers) {
     this(blockchain, ethPeers, false, Optional.empty());
@@ -168,15 +180,36 @@ public class SyncState implements NewPayloadListener {
   /**
    * The current sync status, or empty when this node is not syncing.
    *
-   * <p>Falls back to {@link #setSyncProgress(long, long, long)} reporting when no sync target is
-   * set. Snap sync does not use a sync target — only {@code PipelineChainDownloader}, used by full
-   * sync, sets one — so without this fallback {@code eth_syncing} reports "not syncing" for the
-   * whole of a snap sync.
+   * <p>Falls back to {@link #setSyncProgress(long, long)} reporting when no sync target is set.
+   * Snap sync does not use a sync target — only {@code PipelineChainDownloader}, used by full sync,
+   * sets one — so without this fallback {@code eth_syncing} reports "not syncing" for the whole of
+   * a snap sync.
    *
    * @return the current sync status, or empty when not syncing
    */
   public Optional<SyncStatus> syncStatus() {
-    return syncStatus(syncTarget).or(() -> targetlessSyncProgress);
+    return syncStatus(syncTarget).or(this::targetlessSyncStatus);
+  }
+
+  /**
+   * The status of a sync that does not use a sync target, built from the last reported progress.
+   *
+   * <p>The highest block is resolved on every read rather than stored, because snap sync reports
+   * progress only while a stage 2 pipeline is running. Between cycles — in particular while the
+   * chain download waits for the world state heal to finish — no report arrives, and a stored
+   * height would stay frozen at the pivot the last cycle reached, making the node look fully caught
+   * up.
+   */
+  private Optional<SyncStatus> targetlessSyncStatus() {
+    return Optional.ofNullable(targetlessSyncProgress)
+        .map(
+            progress ->
+                new DefaultSyncStatus(
+                    progress.startingBlock(),
+                    progress.currentBlock(),
+                    bestChainHeight(),
+                    Optional.empty(),
+                    Optional.empty()));
   }
 
   public Optional<SyncTarget> syncTarget() {
@@ -188,13 +221,27 @@ public class SyncState implements NewPayloadListener {
     replaceSyncTarget(Optional.of(syncTarget));
   }
 
-  public void setSyncProgress(
-      final long startingBlock, final long currentBlock, final long highestBlock) {
-    final SyncStatus status =
-        new DefaultSyncStatus(
-            startingBlock, currentBlock, highestBlock, Optional.empty(), Optional.empty());
-    targetlessSyncProgress = Optional.of(status);
-    syncStatusListeners.forEach(c -> c.onSyncStatusChanged(Optional.of(status)));
+  /**
+   * Reports the progress of a sync that does not use a sync target, i.e. snap sync.
+   *
+   * <p>Progress reported after {@link #markInitialSyncPhaseAsDone()} is ignored: only that method
+   * clears the retained progress, so a later report would make {@code syncStatus()} non-empty for
+   * the rest of the process lifetime, leaving {@code eth_syncing} claiming an in-progress sync with
+   * no way to recover short of a restart. Callers are expected to report only while the initial
+   * sync phase is running; this guard keeps the consequence of getting that wrong proportionate.
+   *
+   * @param startingBlock the block the sync started from
+   * @param currentBlock the block the sync has reached
+   */
+  public void setSyncProgress(final long startingBlock, final long currentBlock) {
+    synchronized (targetlessSyncProgressLock) {
+      if (initialSyncPhaseCompleted) {
+        return;
+      }
+      targetlessSyncProgress = new TargetlessSyncProgress(startingBlock, currentBlock);
+    }
+    final Optional<SyncStatus> status = targetlessSyncStatus();
+    syncStatusListeners.forEach(c -> c.onSyncStatusChanged(status));
   }
 
   public void setWorldStateDownloadStatus(final WorldStateDownloadStatus worldStateDownloadStatus) {
@@ -373,9 +420,12 @@ public class SyncState implements NewPayloadListener {
   public void markInitialSyncPhaseAsDone() {
     isInitialSyncPhaseDone = true;
     isResyncNeeded = false;
-    // Otherwise the last progress reported by snap sync would be returned by syncStatus() forever,
-    // making eth_syncing report a permanently in-progress sync.
-    targetlessSyncProgress = Optional.empty();
+    synchronized (targetlessSyncProgressLock) {
+      initialSyncPhaseCompleted = true;
+      // Otherwise the last progress reported by snap sync would be returned by syncStatus()
+      // forever, making eth_syncing report a permanently in-progress sync.
+      targetlessSyncProgress = null;
+    }
     completionListenerSubscribers.forEach(InitialSyncCompletionListener::onInitialSyncCompleted);
   }
 
@@ -389,6 +439,17 @@ public class SyncState implements NewPayloadListener {
 
   public void markInitialSyncRestart() {
     isInitialSyncPhaseDone = false;
+    synchronized (targetlessSyncProgressLock) {
+      initialSyncPhaseCompleted = false;
+    }
     completionListenerSubscribers.forEach(InitialSyncCompletionListener::onInitialSyncRestart);
   }
+
+  /**
+   * The blocks last reported by a sync that does not use a sync target.
+   *
+   * @param startingBlock the block the sync started from
+   * @param currentBlock the block the sync had reached when it last reported
+   */
+  private record TargetlessSyncProgress(long startingBlock, long currentBlock) {}
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
@@ -339,6 +339,38 @@ public class BackwardSyncContextTest {
   }
 
   @Test
+  public void shouldStartNewSessionAfterAPreviousSessionCompletedSynchronously() throws Exception {
+    // A session can finish on the calling thread, which clears the status before it is published.
+    // Reusing that finished session would return an already-completed future from every later
+    // call, so backward sync would never run again.
+    when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
+        .thenReturn(backwardSyncAlgorithm);
+    when(backwardSyncAlgorithm.executeBackwardsSync(null))
+        .thenReturn(CompletableFuture.completedFuture(null))
+        .thenReturn(new CompletableFuture<>());
+
+    context.syncBackwardsUntil(getRemoteBlockByNumber(REMOTE_HEIGHT)).get();
+
+    final CompletableFuture<Void> secondFuture =
+        context.syncBackwardsUntil(getRemoteBlockByNumber(REMOTE_HEIGHT));
+
+    assertThat(secondFuture.isDone()).isFalse();
+    assertThat(context.isSyncing()).isTrue();
+  }
+
+  @Test
+  public void shouldNotPublishASessionThatCompletedSynchronously() throws Exception {
+    when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
+        .thenReturn(backwardSyncAlgorithm);
+    when(backwardSyncAlgorithm.executeBackwardsSync(null))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    context.syncBackwardsUntil(getRemoteBlockByNumber(REMOTE_HEIGHT)).get();
+
+    assertThat(context.getStatus()).isNull();
+  }
+
+  @Test
   public void shouldQueueHashForSyncWhenNotReady() throws Exception {
     doReturn(false).when(context).isReady();
     when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
@@ -401,7 +433,11 @@ public class BackwardSyncContextTest {
     final CompletableFuture<Void> future = context.syncBackwardsUntil(lowerBlock);
     final CompletableFuture<Void> secondFuture = context.syncBackwardsUntil(higherBlock);
 
-    assertThat(future).isSameAs(secondFuture);
+    // The stubbed algorithm completes each session on the calling thread, so the first session is
+    // already finished by the time the second call arrives and a fresh session is started for it.
+    // An in-flight session is still shared between calls, which is what coalesces real forkchoice
+    // updates.
+    assertThat(future).isNotSameAs(secondFuture);
     future.orTimeout(30, TimeUnit.SECONDS);
 
     future.get();
@@ -434,8 +470,10 @@ public class BackwardSyncContextTest {
     // Given
     when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
         .thenReturn(backwardSyncAlgorithm);
-    when(backwardSyncAlgorithm.executeBackwardsSync(null))
-        .thenReturn(CompletableFuture.completedFuture(null));
+    // A future that never completes keeps the session in flight, which is the case this covers:
+    // the target height of a running session is updated. A session that completed on the calling
+    // thread is never published, so there would be no status to update.
+    when(backwardSyncAlgorithm.executeBackwardsSync(null)).thenReturn(new CompletableFuture<>());
 
     BlockHeader unknownBlockHeader = Mockito.mock(BlockHeader.class);
     when(unknownBlockHeader.getParentHash()).thenReturn(Hash.fromHexStringLenient("0x41"));

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
@@ -307,6 +307,38 @@ public class BackwardSyncContextTest {
   }
 
   @Test
+  public void isSyncingReturnsTrueWhileBackwardSyncSessionIsInFlight() {
+    when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
+        .thenReturn(backwardSyncAlgorithm);
+    // A future that never completes keeps the sync session in flight for the test's duration.
+    when(backwardSyncAlgorithm.executeBackwardsSync(null)).thenReturn(new CompletableFuture<>());
+
+    context.syncBackwardsUntil(getRemoteBlockByNumber(REMOTE_HEIGHT));
+
+    assertThat(context.isSyncing()).isTrue();
+  }
+
+  @Test
+  public void isSyncingReturnsFalseWhenNoSessionHasStarted() {
+    assertThat(context.isSyncing()).isFalse();
+  }
+
+  @Test
+  public void isSyncingReturnsFalseAfterBackwardSyncSessionCompletes() throws Exception {
+    when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))
+        .thenReturn(backwardSyncAlgorithm);
+    when(backwardSyncAlgorithm.executeBackwardsSync(null))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final CompletableFuture<Void> future =
+        context.syncBackwardsUntil(getRemoteBlockByNumber(REMOTE_HEIGHT));
+    future.orTimeout(30, TimeUnit.SECONDS);
+    future.get();
+
+    assertThat(context.isSyncing()).isFalse();
+  }
+
+  @Test
   public void shouldQueueHashForSyncWhenNotReady() throws Exception {
     doReturn(false).when(context).isReady();
     when(backwardSyncAlgorithmFactory.createBackwardSyncAlgorithm(context))

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/common/ImportSyncBlocksStepTest.java
@@ -73,6 +73,6 @@ public class ImportSyncBlocksStepTest {
     importSyncBlocksStep.accept(blocksWithReceipts);
 
     verify(blockchain).unsafeImportSyncBodiesAndReceipts(blocksWithReceipts, false);
-    verify(syncState).setSyncProgress(0L, blocksWithReceipts.getLast().getNumber(), 10L);
+    verify(syncState).setSyncProgress(0L, blocksWithReceipts.getLast().getNumber());
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
@@ -455,19 +455,50 @@ public class SyncStateTest {
   @Test
   public void syncStatus_reportsProgressWhileSnapSyncingWithNoSyncTarget() {
     // Snap sync never sets a sync target; it reports progress via setSyncProgress instead.
-    syncState.setSyncProgress(10L, 42L, 100L);
+    updateChainState(syncTargetPeer.getEthPeer(), TARGET_CHAIN_HEIGHT, TARGET_DIFFICULTY);
+    doReturn(Optional.of(syncTargetPeer.getEthPeer())).when(ethPeers).bestPeerWithHeightEstimate();
+
+    syncState.setSyncProgress(10L, 42L);
 
     final Optional<SyncStatus> syncStatus = syncState.syncStatus();
 
     assertThat(syncStatus).isPresent();
     assertThat(syncStatus.get().getStartingBlock()).isEqualTo(10L);
     assertThat(syncStatus.get().getCurrentBlock()).isEqualTo(42L);
-    assertThat(syncStatus.get().getHighestBlock()).isEqualTo(100L);
+    // The highest block comes from the same height that backs the blocks-behind signal, not from
+    // the pivot the reporting cycle was targeting.
+    assertThat(syncStatus.get().getHighestBlock()).isEqualTo(TARGET_CHAIN_HEIGHT);
+  }
+
+  @Test
+  public void syncStatus_reportsPayloadHeightAsHighestBlockOnceDrivenByConsensusLayer() {
+    syncState.setSyncProgress(10L, 42L);
+    syncState.onNewPayload(
+        new BlockHeaderTestFixture().number(TARGET_CHAIN_HEIGHT + 50).buildHeader());
+
+    assertThat(syncState.syncStatus()).isPresent();
+    assertThat(syncState.syncStatus().get().getHighestBlock()).isEqualTo(TARGET_CHAIN_HEIGHT + 50);
+  }
+
+  @Test
+  public void syncStatus_highestBlockAdvancesWithoutAFurtherProgressReport() {
+    // Snap sync reports progress only while a stage 2 pipeline runs. Between cycles — notably
+    // while the chain download waits for the world state heal — nothing reports, so the highest
+    // block must be resolved per read or the node looks fully caught up.
+    syncState.setSyncProgress(10L, 42L);
+    syncState.onNewPayload(new BlockHeaderTestFixture().number(200L).buildHeader());
+    assertThat(syncState.syncStatus().get().getHighestBlock()).isEqualTo(200L);
+
+    syncState.onNewPayload(new BlockHeaderTestFixture().number(400L).buildHeader());
+
+    final Optional<SyncStatus> syncStatus = syncState.syncStatus();
+    assertThat(syncStatus.get().getCurrentBlock()).isEqualTo(42L);
+    assertThat(syncStatus.get().getHighestBlock()).isEqualTo(400L);
   }
 
   @Test
   public void syncStatus_isEmptyOnceInitialSyncPhaseIsDone() {
-    syncState.setSyncProgress(10L, 42L, 100L);
+    syncState.setSyncProgress(10L, 42L);
     assertThat(syncState.syncStatus()).isPresent();
 
     syncState.markInitialSyncPhaseAsDone();
@@ -476,8 +507,41 @@ public class SyncStateTest {
   }
 
   @Test
+  public void syncStatus_staysEmptyWhenProgressIsReportedAfterInitialSyncPhaseIsDone() {
+    // markInitialSyncPhaseAsDone() is the only thing that clears the retained progress, so a later
+    // report must not reinstate it: that would wedge eth_syncing at "syncing" for the rest of the
+    // process lifetime.
+    syncState.setSyncProgress(10L, 42L);
+    syncState.markInitialSyncPhaseAsDone();
+
+    syncState.setSyncProgress(10L, 43L);
+
+    assertThat(syncState.syncStatus()).isEmpty();
+  }
+
+  @Test
+  public void syncStatusListener_isNotNotifiedOfProgressReportedAfterInitialSyncPhaseIsDone() {
+    syncState.markInitialSyncPhaseAsDone();
+
+    syncState.setSyncProgress(10L, 42L);
+
+    verify(syncStatusListener, never()).onSyncStatusChanged(any());
+  }
+
+  @Test
+  public void syncStatus_reportsProgressAgainAfterInitialSyncRestart() {
+    syncState.markInitialSyncPhaseAsDone();
+    syncState.markInitialSyncRestart();
+
+    syncState.setSyncProgress(10L, 42L);
+
+    assertThat(syncState.syncStatus()).isPresent();
+    assertThat(syncState.syncStatus().get().getCurrentBlock()).isEqualTo(42L);
+  }
+
+  @Test
   public void syncStatus_prefersSyncTargetOverReportedProgress() {
-    syncState.setSyncProgress(10L, 42L, 100L);
+    syncState.setSyncProgress(10L, 42L);
     syncState.setSyncTarget(syncTargetPeer.getEthPeer(), blockchain.getBlockHeader(3L).get());
 
     final Optional<SyncStatus> syncStatus = syncState.syncStatus();
@@ -492,7 +556,7 @@ public class SyncStateTest {
   public void syncStatusListener_stillReceivesEmptyOnClearedTargetDespiteReportedProgress() {
     // The syncStatus() fallback must not leak into listener notifications: an empty event is how
     // subscribers learn that the sync target is gone.
-    syncState.setSyncProgress(10L, 42L, 100L);
+    syncState.setSyncProgress(10L, 42L);
     syncState.setSyncTarget(syncTargetPeer.getEthPeer(), blockchain.getBlockHeader(3L).get());
     syncState.clearSyncTarget();
 
@@ -829,9 +893,9 @@ public class SyncStateTest {
     SyncStatusListener listener = mock(SyncStatusListener.class);
     syncState.subscribeSyncStatus(listener);
 
-    syncState.setSyncProgress(0, 10, 100);
-    syncState.setSyncProgress(0, 50, 100);
-    syncState.setSyncProgress(0, 100, 100);
+    syncState.setSyncProgress(0, 10);
+    syncState.setSyncProgress(0, 50);
+    syncState.setSyncProgress(0, 100);
 
     verify(listener, times(3)).onSyncStatusChanged(syncStatusCaptor.capture());
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncStateTest.java
@@ -453,6 +453,55 @@ public class SyncStateTest {
   }
 
   @Test
+  public void syncStatus_reportsProgressWhileSnapSyncingWithNoSyncTarget() {
+    // Snap sync never sets a sync target; it reports progress via setSyncProgress instead.
+    syncState.setSyncProgress(10L, 42L, 100L);
+
+    final Optional<SyncStatus> syncStatus = syncState.syncStatus();
+
+    assertThat(syncStatus).isPresent();
+    assertThat(syncStatus.get().getStartingBlock()).isEqualTo(10L);
+    assertThat(syncStatus.get().getCurrentBlock()).isEqualTo(42L);
+    assertThat(syncStatus.get().getHighestBlock()).isEqualTo(100L);
+  }
+
+  @Test
+  public void syncStatus_isEmptyOnceInitialSyncPhaseIsDone() {
+    syncState.setSyncProgress(10L, 42L, 100L);
+    assertThat(syncState.syncStatus()).isPresent();
+
+    syncState.markInitialSyncPhaseAsDone();
+
+    assertThat(syncState.syncStatus()).isEmpty();
+  }
+
+  @Test
+  public void syncStatus_prefersSyncTargetOverReportedProgress() {
+    syncState.setSyncProgress(10L, 42L, 100L);
+    syncState.setSyncTarget(syncTargetPeer.getEthPeer(), blockchain.getBlockHeader(3L).get());
+
+    final Optional<SyncStatus> syncStatus = syncState.syncStatus();
+
+    assertThat(syncStatus).isPresent();
+    assertThat(syncStatus.get().getStartingBlock()).isEqualTo(3L);
+    assertThat(syncStatus.get().getCurrentBlock()).isEqualTo(OUR_CHAIN_HEAD_NUMBER);
+    assertThat(syncStatus.get().getHighestBlock()).isEqualTo(TARGET_CHAIN_HEIGHT);
+  }
+
+  @Test
+  public void syncStatusListener_stillReceivesEmptyOnClearedTargetDespiteReportedProgress() {
+    // The syncStatus() fallback must not leak into listener notifications: an empty event is how
+    // subscribers learn that the sync target is gone.
+    syncState.setSyncProgress(10L, 42L, 100L);
+    syncState.setSyncTarget(syncTargetPeer.getEthPeer(), blockchain.getBlockHeader(3L).get());
+    syncState.clearSyncTarget();
+
+    verify(syncStatusListener, times(3)).onSyncStatusChanged(syncStatusCaptor.capture());
+
+    assertThat(syncStatusCaptor.getAllValues().getLast()).isEmpty();
+  }
+
+  @Test
   public void syncStatusListener_receivesEventWhenSyncTargetSet() {
     syncState.setSyncTarget(syncTargetPeer.getEthPeer(), blockchain.getBlockHeader(3L).get());
 

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -434,7 +434,9 @@ public class EthStatsService {
     final WebSocket activeWebSocket = requireWebSocket();
     final EnodeURL localEnodeURL = requireEnodeURL();
     final boolean isMiningEnabled = miningCoordinator.isMining();
-    final boolean isSyncing = syncState.isInSync();
+    // The ethstats "syncing" field means the node is still catching up, which is the negation of
+    // SyncState.isInSync().
+    final boolean isSyncing = !syncState.isInSync();
     final long gasPrice = suggestGasPrice(blockchainQueries.getBlockchain().getChainHeadBlock());
     // safe to cast to int since it isn't realistic to have more than max int peers
     final int peersNumber =

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -18,20 +18,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -44,11 +48,13 @@ import org.hyperledger.besu.ethstats.util.EthStatsConnectOptions;
 import org.hyperledger.besu.ethstats.util.ImmutableEthStatsConnectOptions;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -312,6 +318,57 @@ public class EthStatsServiceTest {
     final Field field = EthStatsService.class.getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(ethStatsService, value);
+  }
+
+  @Test
+  public void nodeStatsReportsSyncingTrueWhenNodeIsNotInSync() throws Exception {
+    when(syncState.isInSync()).thenReturn(false);
+
+    assertThat(reportedSyncingField()).isTrue();
+  }
+
+  @Test
+  public void nodeStatsReportsSyncingFalseWhenNodeIsInSync() throws Exception {
+    when(syncState.isInSync()).thenReturn(true);
+
+    assertThat(reportedSyncingField()).isFalse();
+  }
+
+  /**
+   * Drives a node stats report and returns the {@code syncing} field of the emitted ethstats
+   * message, so the assertion is made against the real serialized protocol message.
+   */
+  private boolean reportedSyncingField() throws Exception {
+    final EthPeers ethPeers = mock(EthPeers.class);
+    when(ethPeers.streamAvailablePeers()).thenReturn(Stream.empty());
+    when(ethContext.getEthPeers()).thenReturn(ethPeers);
+
+    final Blockchain blockchain = mock(Blockchain.class);
+    when(blockchain.getChainHeadBlock()).thenReturn(new BlockDataGenerator().block());
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(miningCoordinator.getMinTransactionGasPrice()).thenReturn(Wei.ONE);
+    when(miningCoordinator.isMining()).thenReturn(false);
+    when(p2PNetwork.getLocalEnode()).thenReturn(Optional.of(node));
+
+    ethStatsService.start();
+
+    final Method sendNodeStatsReport =
+        EthStatsService.class.getDeclaredMethod("sendNodeStatsReport");
+    sendNodeStatsReport.setAccessible(true);
+    sendNodeStatsReport.invoke(ethStatsService);
+
+    final ArgumentCaptor<String> messagesCaptor = ArgumentCaptor.forClass(String.class);
+    verify(webSocket, times(2)).writeTextMessage(messagesCaptor.capture());
+
+    final String statsMessage = messagesCaptor.getAllValues().getLast();
+    final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+    return objectMapper
+        .readTree(statsMessage)
+        .get("emit")
+        .get(1)
+        .get("stats")
+        .get("syncing")
+        .asBoolean();
   }
 
   @Test

--- a/plugins/health/build.gradle
+++ b/plugins/health/build.gradle
@@ -28,6 +28,7 @@ jar {
 
 dependencies {
   api project(':plugin-api')
+  api project(':ethereum:eth:plugin-api-sync')
   api 'org.slf4j:slf4j-api'
 
   testImplementation project(':testutil')

--- a/plugins/health/src/main/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPlugin.java
+++ b/plugins/health/src/main/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPlugin.java
@@ -87,7 +87,7 @@ public class ReadinessCheckPlugin implements BesuPlugin {
   // because the completion event fires when the synchronizer starts and would be missed by a
   // listener on a node whose synchronizer never starts (P2P disabled). Empty when the service is
   // unavailable, in which case the check is skipped.
-  private Optional<SynchronizationService> synchronizationService = Optional.empty();
+  private volatile Optional<SynchronizationService> synchronizationService = Optional.empty();
 
   @Override
   public void register(final ServiceManager context) {

--- a/plugins/health/src/main/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPlugin.java
+++ b/plugins/health/src/main/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPlugin.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.HealthCheckService;
 import org.hyperledger.besu.plugin.services.p2p.P2PService;
+import org.hyperledger.besu.plugin.services.sync.SynchronizationService;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -82,6 +83,11 @@ public class ReadinessCheckPlugin implements BesuPlugin {
   // (node treated as sync-healthy) to avoid a false-negative at startup.
   private volatile Optional<SyncStatus> cachedSyncStatus = Optional.empty();
   private long syncListenerId = -1;
+  // Pull model: the initial sync phase is queried per check rather than tracked from an event,
+  // because the completion event fires when the synchronizer starts and would be missed by a
+  // listener on a node whose synchronizer never starts (P2P disabled). Empty when the service is
+  // unavailable, in which case the check is skipped.
+  private Optional<SynchronizationService> synchronizationService = Optional.empty();
 
   @Override
   public void register(final ServiceManager context) {
@@ -108,6 +114,7 @@ public class ReadinessCheckPlugin implements BesuPlugin {
             .orElseThrow(() -> new IllegalStateException("Required service missing: BesuEvents"));
 
     syncListenerId = besuEvents.addSyncStatusListener(status -> cachedSyncStatus = status);
+    synchronizationService = context.getService(SynchronizationService.class);
   }
 
   private HealthCheckService.HealthCheckResult checkReadiness(
@@ -142,6 +149,18 @@ public class ReadinessCheckPlugin implements BesuPlugin {
         healthy = false;
       }
     }
+    // A snap syncing node is not ready until its chain download, world state download, trie heal
+    // and flat database heal have all finished — it cannot serve state before then. Checked
+    // separately from the block distance below, which is skipped entirely while no sync status has
+    // been reported (snap sync's stage 1 reports no progress).
+    if (synchronizationService.filter(service -> !service.isInitialSyncPhaseDone()).isPresent()) {
+      final Map<String, Object> initialSyncDetail = new LinkedHashMap<>();
+      initialSyncDetail.put("status", false);
+      initialSyncDetail.put("complete", false);
+      checks.put("initialSync", initialSyncDetail);
+      healthy = false;
+    }
+
     final String maxBlocksStr = params.getParam("maxBlocksBehind");
     final Optional<Long> maxBlocksBehind =
         parseNonNegativeLong(maxBlocksStr, DEFAULT_MAX_BLOCKS_BEHIND);

--- a/plugins/health/src/test/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPluginTest.java
+++ b/plugins/health/src/test/java/org/hyperledger/besu/plugin/services/health/ReadinessCheckPluginTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.HealthCheckService;
 import org.hyperledger.besu.plugin.services.p2p.P2PService;
+import org.hyperledger.besu.plugin.services.sync.SynchronizationService;
 
 import java.util.Optional;
 
@@ -38,6 +39,7 @@ public class ReadinessCheckPluginTest {
   private HealthCheckService healthCheckService;
   private P2PService p2pService;
   private BesuEvents besuEvents;
+  private SynchronizationService synchronizationService;
 
   @BeforeEach
   void setUp() {
@@ -49,6 +51,72 @@ public class ReadinessCheckPluginTest {
         .thenReturn(java.util.Optional.of(healthCheckService));
     when(serviceManager.getService(P2PService.class)).thenReturn(java.util.Optional.of(p2pService));
     when(serviceManager.getService(BesuEvents.class)).thenReturn(java.util.Optional.of(besuEvents));
+    synchronizationService = mock(SynchronizationService.class);
+    when(serviceManager.getService(SynchronizationService.class))
+        .thenReturn(java.util.Optional.of(synchronizationService));
+    // Most cases here are about the peer and block-distance checks; default to a node past its
+    // initial sync phase so that gate does not mask them.
+    when(synchronizationService.isInitialSyncPhaseDone()).thenReturn(true);
+  }
+
+  @Test
+  void shouldFailWhileInitialSyncPhaseIsNotDone() {
+    // Covers the world state download, the trie heal and the flat database heal: a snap syncing
+    // node cannot serve state until all of them have finished.
+    final ReadinessCheckPlugin plugin = new ReadinessCheckPlugin();
+    plugin.register(serviceManager);
+    plugin.start();
+
+    final var captor =
+        org.mockito.ArgumentCaptor.forClass(HealthCheckService.HealthCheckProvider.class);
+    verify(healthCheckService).registerHealthCheck(eq("/readiness"), captor.capture());
+
+    final HealthCheckService.HealthCheckProvider provider = captor.getValue();
+
+    when(synchronizationService.isInitialSyncPhaseDone()).thenReturn(false);
+    final SyncStatus syncStatus = mock(SyncStatus.class);
+    when(syncStatus.getCurrentBlock()).thenReturn(100L);
+    when(syncStatus.getHighestBlock()).thenReturn(100L);
+    triggerSyncStatusUpdate(syncStatus);
+
+    final HealthCheckService.ParamSource params = mock(HealthCheckService.ParamSource.class);
+    when(params.getParam("minPeers")).thenReturn("1");
+    when(params.getParam("maxBlocksBehind")).thenReturn("2");
+    when(p2pService.isP2pEnabled()).thenReturn(true);
+    when(p2pService.getPeerCount()).thenReturn(1);
+
+    final var result = provider.check(params);
+    assertThat(result.isHealthy()).isFalse();
+    final var initialSync = (java.util.Map<?, ?>) result.getDetails().get("initialSync");
+    assertThat(initialSync.get("status")).isEqualTo(false);
+    assertThat(initialSync.get("complete")).isEqualTo(false);
+  }
+
+  @Test
+  void shouldFailWhileInitialSyncPhaseIsNotDoneAndNoSyncStatusIsReported() {
+    // Snap sync's stage 1 reports no progress at all, which leaves the block-distance check
+    // skipped. Without the initial sync gate the node would report ready on the peer check alone.
+    final ReadinessCheckPlugin plugin = new ReadinessCheckPlugin();
+    plugin.register(serviceManager);
+    plugin.start();
+
+    final var captor =
+        org.mockito.ArgumentCaptor.forClass(HealthCheckService.HealthCheckProvider.class);
+    verify(healthCheckService).registerHealthCheck(eq("/readiness"), captor.capture());
+
+    final HealthCheckService.HealthCheckProvider provider = captor.getValue();
+
+    when(synchronizationService.isInitialSyncPhaseDone()).thenReturn(false);
+
+    final HealthCheckService.ParamSource params = mock(HealthCheckService.ParamSource.class);
+    when(params.getParam("minPeers")).thenReturn("1");
+    when(params.getParam("maxBlocksBehind")).thenReturn("2");
+    when(p2pService.isP2pEnabled()).thenReturn(true);
+    when(p2pService.getPeerCount()).thenReturn(1);
+
+    final var result = provider.check(params);
+    assertThat(result.isHealthy()).isFalse();
+    assertThat(result.getDetails()).doesNotContainKey("sync");
   }
 
   @Test


### PR DESCRIPTION
## PR description
Fixes three sync-signal reporting bugs (#11260): `eth_syncing` reported "not syncing" for the whole of a snap sync, because `syncStatus()` derived entirely from a sync  target that only full sync ever sets, while `EthStatsService`'s `syncing` field and `BackwardSyncContext.isSyncing()` each reported the exact inverse of their intended meaning. It also corrects the reported progress to use the same best-chain height that backs the blocks-behind signal (the latest `engine_newPayload` head under PoS) rather than a pivot that froze between download cycles, stops `/readiness` reporting ready while the world state download, trie heal or flat database heal is still in progress, and stops a backward sync session that completed synchronously from being parked and handed back to every later `syncBackwardsUntil` call. 

fixes #11260 



