### PR TITLE
Add missing INVALID_BLOCK_ACCESS_LIST engine error mapping

### DIFF
--- a/ethereum/referencetests/src/main/resources/block-exception-mapping.json
+++ b/ethereum/referencetests/src/main/resources/block-exception-mapping.json
@@ -130,7 +130,10 @@
       "TransactionException.TYPE_3_TX_ZERO_BLOBS":               "Failed to decode transactions from block parameter",
 
       "_comment_versioned_hash": "VersionedHash rejects a version byte other than 0x01 while the payload's transaction list is being decoded, and EngineNewPayloadV1 appends that cause to the decode failure above — so the message identifies the versioned hash rather than only the element that failed to decode.",
-      "TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH": "Invalid versionedHash"
+      "TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH": "Invalid versionedHash",
+
+      "_comment_bal": "EngineNewPayloadV5 decodes the payload's blockAccessList field; an undecodable list is an invalid payload, so it never reaches the BAL validation the block-import messages above come from",
+      "BlockException.INVALID_BLOCK_ACCESS_LIST":                "Failed to decode block access list payload parameter"
     },
 
     "regex": {


### PR DESCRIPTION
## PR description

Adds the missing engine-API error mapping for `BlockException.INVALID_BLOCK_ACCESS_LIST` to `block-exception-mapping.json`.

`EngineNewPayloadV5` decodes the payload's `blockAccessList` field, so an undecodable list is rejected as an invalid payload before it ever reaches the BAL validation that the block-import messages in this file come from. The expected message is therefore the decode failure (`Failed to decode block access list payload parameter`) rather than a validation message.

## Fixed Issue(s)
N/A

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [x] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog). (test-resource only, no changelog entry needed)
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)
