### PR TITLE
fix(rocksdb): guard column-family handle lifecycle with ReadWriteLock

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
 
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Function;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -39,6 +40,7 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
   private final Transaction innerTx;
   private final WriteOptions options;
   private final Function<SegmentIdentifier, ColumnFamilyHandle> columnFamilyMapper;
+  private final ReadWriteLock columnFamilyResetLock;
 
   /**
    * Instantiates a new RocksDb transaction.
@@ -52,15 +54,18 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
       final Function<SegmentIdentifier, ColumnFamilyHandle> columnFamilyMapper,
       final Transaction innerTx,
       final WriteOptions options,
-      final RocksDBMetrics metrics) {
+      final RocksDBMetrics metrics,
+      final ReadWriteLock columnFamilyResetLock) {
     this.columnFamilyMapper = columnFamilyMapper;
     this.innerTx = innerTx;
     this.options = options;
     this.metrics = metrics;
+    this.columnFamilyResetLock = columnFamilyResetLock;
   }
 
   @Override
   public void put(final SegmentIdentifier segmentId, final byte[] key, final byte[] value) {
+    columnFamilyResetLock.readLock().lock();
     try (final OperationTimer.TimingContext ignored = metrics.getWriteLatency().startTimer()) {
       innerTx.put(columnFamilyMapper.apply(segmentId), key, value);
     } catch (final RocksDBException e) {
@@ -69,11 +74,14 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
         System.exit(DISK_FULL_EXIT_CODE);
       }
       throw new StorageException(e);
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 
   @Override
   public void remove(final SegmentIdentifier segmentId, final byte[] key) {
+    columnFamilyResetLock.readLock().lock();
     try (final OperationTimer.TimingContext ignored = metrics.getRemoveLatency().startTimer()) {
       innerTx.delete(columnFamilyMapper.apply(segmentId), key);
     } catch (final RocksDBException e) {
@@ -82,6 +90,8 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
         System.exit(DISK_FULL_EXIT_CODE);
       }
       throw new StorageException(e);
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
@@ -85,7 +85,11 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, this.metrics),
+            this::safeColumnHandle,
+            db.beginTransaction(writeOptions),
+            writeOptions,
+            this.metrics,
+            columnFamilyResetLock),
         this.closed::get);
   }
 
@@ -97,7 +101,11 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     writeOptions.setLowPri(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, this.metrics),
+            this::safeColumnHandle,
+            db.beginTransaction(writeOptions),
+            writeOptions,
+            this.metrics,
+            columnFamilyResetLock),
         this.closed::get);
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -106,7 +106,7 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
    * lock while reset() drops, recreates, and closes the old native handle — ensuring no in-flight
    * reader holds a stale pointer when the native object is freed.
    */
-  private final ReadWriteLock columnFamilyResetLock = new ReentrantReadWriteLock();
+  protected final ReadWriteLock columnFamilyResetLock = new ReentrantReadWriteLock();
 
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -97,6 +99,14 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   /** atomic boolean to track if the storage is closed */
   protected final AtomicBoolean closed = new AtomicBoolean(false);
+
+  /**
+   * Guards column-family handle lifecycle. All operations that load and use a ColumnFamilyHandle
+   * across a JNI boundary hold the read lock for the duration of that call. clear() holds the write
+   * lock while reset() drops, recreates, and closes the old native handle — ensuring no in-flight
+   * reader holds a stale pointer when the native object is freed.
+   */
+  private final ReadWriteLock columnFamilyResetLock = new ReentrantReadWriteLock();
 
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
@@ -423,10 +433,13 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       throws StorageException {
     throwIfClosed();
 
+    columnFamilyResetLock.readLock().lock();
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
       return Optional.ofNullable(getDB().get(safeColumnHandle(segment), readOptions, key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 
@@ -434,12 +447,15 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   public Optional<NearestKeyValue> getNearestBefore(
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
 
+    columnFamilyResetLock.readLock().lock();
     try (final RocksIterator rocksIterator =
         getDB().newIterator(safeColumnHandle(segmentIdentifier))) {
       rocksIterator.seekForPrev(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
           .map(it -> new NearestKeyValue(Bytes.of(it.key()), Optional.of(it.value())));
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 
@@ -447,50 +463,85 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   public Optional<NearestKeyValue> getNearestAfter(
       final SegmentIdentifier segmentIdentifier, final Bytes key) throws StorageException {
 
+    columnFamilyResetLock.readLock().lock();
     try (final RocksIterator rocksIterator =
         getDB().newIterator(safeColumnHandle(segmentIdentifier))) {
       rocksIterator.seek(key.toArrayUnsafe());
       return Optional.of(rocksIterator)
           .filter(AbstractRocksIterator::isValid)
           .map(it -> new NearestKeyValue(Bytes.of(it.key()), Optional.of(it.value())));
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 
   @Override
   public Stream<Pair<byte[], byte[]>> stream(final SegmentIdentifier segmentIdentifier) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
-    rocksIterator.seekToFirst();
-    return RocksDbIterator.create(rocksIterator).toStream();
+    columnFamilyResetLock.readLock().lock();
+    try {
+      final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+      rocksIterator.seekToFirst();
+      return RocksDbIterator.create(rocksIterator)
+          .toStream()
+          .onClose(columnFamilyResetLock.readLock()::unlock);
+    } catch (final Exception e) {
+      columnFamilyResetLock.readLock().unlock();
+      throw e;
+    }
   }
 
   @Override
   public Stream<Pair<byte[], byte[]>> streamFromKey(
       final SegmentIdentifier segmentIdentifier, final byte[] startKey) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
-    rocksIterator.seek(startKey);
-    return RocksDbIterator.create(rocksIterator).toStream();
+    columnFamilyResetLock.readLock().lock();
+    try {
+      final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+      rocksIterator.seek(startKey);
+      return RocksDbIterator.create(rocksIterator)
+          .toStream()
+          .onClose(columnFamilyResetLock.readLock()::unlock);
+    } catch (final Exception e) {
+      columnFamilyResetLock.readLock().unlock();
+      throw e;
+    }
   }
 
   @Override
   public Stream<Pair<byte[], byte[]>> streamFromKey(
       final SegmentIdentifier segmentIdentifier, final byte[] startKey, final byte[] endKey) {
     final Bytes endKeyBytes = Bytes.wrap(endKey);
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
-    rocksIterator.seek(startKey);
-    return RocksDbIterator.create(rocksIterator)
-        .toStream()
-        .takeWhile(e -> endKeyBytes.compareTo(Bytes.wrap(e.getKey())) >= 0);
+    columnFamilyResetLock.readLock().lock();
+    try {
+      final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+      rocksIterator.seek(startKey);
+      return RocksDbIterator.create(rocksIterator)
+          .toStream()
+          .takeWhile(e -> endKeyBytes.compareTo(Bytes.wrap(e.getKey())) >= 0)
+          .onClose(columnFamilyResetLock.readLock()::unlock);
+    } catch (final Exception e) {
+      columnFamilyResetLock.readLock().unlock();
+      throw e;
+    }
   }
 
   @Override
   public Stream<byte[]> streamKeys(final SegmentIdentifier segmentIdentifier) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
-    rocksIterator.seekToFirst();
-    return RocksDbIterator.create(rocksIterator).toStreamKeys();
+    columnFamilyResetLock.readLock().lock();
+    try {
+      final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+      rocksIterator.seekToFirst();
+      return RocksDbIterator.create(rocksIterator)
+          .toStreamKeys()
+          .onClose(columnFamilyResetLock.readLock()::unlock);
+    } catch (final Exception e) {
+      columnFamilyResetLock.readLock().unlock();
+      throw e;
+    }
   }
 
   @Override
   public boolean tryDelete(final SegmentIdentifier segmentIdentifier, final byte[] key) {
+    columnFamilyResetLock.readLock().lock();
     try {
       getDB().delete(safeColumnHandle(segmentIdentifier), tryDeleteOptions, key);
       return true;
@@ -500,31 +551,40 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
       } else {
         throw new StorageException(e);
       }
+    } finally {
+      columnFamilyResetLock.readLock().unlock();
     }
   }
 
   @Override
   public Set<byte[]> getAllKeysThat(
       final SegmentIdentifier segmentIdentifier, final Predicate<byte[]> returnCondition) {
-    return stream(segmentIdentifier)
-        .filter(pair -> returnCondition.test(pair.getKey()))
-        .map(Pair::getKey)
-        .collect(toUnmodifiableSet());
+    try (final Stream<Pair<byte[], byte[]>> s = stream(segmentIdentifier)) {
+      return s.filter(pair -> returnCondition.test(pair.getKey()))
+          .map(Pair::getKey)
+          .collect(toUnmodifiableSet());
+    }
   }
 
   @Override
   public Set<byte[]> getAllValuesFromKeysThat(
       final SegmentIdentifier segmentIdentifier, final Predicate<byte[]> returnCondition) {
-    return stream(segmentIdentifier)
-        .filter(pair -> returnCondition.test(pair.getKey()))
-        .map(Pair::getValue)
-        .collect(toUnmodifiableSet());
+    try (final Stream<Pair<byte[], byte[]>> s = stream(segmentIdentifier)) {
+      return s.filter(pair -> returnCondition.test(pair.getKey()))
+          .map(Pair::getValue)
+          .collect(toUnmodifiableSet());
+    }
   }
 
   @Override
   public void clear(final SegmentIdentifier segmentIdentifier) {
-    Optional.ofNullable(columnHandlesBySegmentIdentifier.get(segmentIdentifier))
-        .ifPresent(RocksDbSegmentIdentifier::reset);
+    columnFamilyResetLock.writeLock().lock();
+    try {
+      Optional.ofNullable(columnHandlesBySegmentIdentifier.get(segmentIdentifier))
+          .ifPresent(RocksDbSegmentIdentifier::reset);
+    } finally {
+      columnFamilyResetLock.writeLock().unlock();
+    }
   }
 
   @Override

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
@@ -88,7 +88,11 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, metrics),
+            this::safeColumnHandle,
+            db.beginTransaction(writeOptions),
+            writeOptions,
+            metrics,
+            columnFamilyResetLock),
         this.closed::get);
   }
 
@@ -100,7 +104,11 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     writeOptions.setLowPri(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, metrics),
+            this::safeColumnHandle,
+            db.beginTransaction(writeOptions),
+            writeOptions,
+            metrics,
+            columnFamilyResetLock),
         this.closed::get);
   }
 }

--- a/services/kvstore/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SegmentedKeyValueStorage.java
+++ b/services/kvstore/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SegmentedKeyValueStorage.java
@@ -109,6 +109,10 @@ public interface SegmentedKeyValueStorage extends Closeable {
   /**
    * Returns a stream of all keys for the segment.
    *
+   * <p>The caller <strong>must</strong> close the returned stream (e.g. via try-with-resources).
+   * Implementations may hold locks or native resources for the stream's lifetime; failure to close
+   * will cause resource leaks or deadlocks.
+   *
    * @param segmentIdentifier The segment identifier whose keys we want to stream.
    * @return A stream of all keys in the specified segment.
    */
@@ -141,6 +145,10 @@ public interface SegmentedKeyValueStorage extends Closeable {
 
   /**
    * Stream keys.
+   *
+   * <p>The caller <strong>must</strong> close the returned stream (e.g. via try-with-resources).
+   * Implementations may hold locks or native resources for the stream's lifetime; failure to close
+   * will cause resource leaks or deadlocks.
    *
    * @param segmentIdentifier the segment identifier
    * @return the stream

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
@@ -220,14 +219,16 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
 
     PeekingIterator<Map.Entry<Bytes, Optional<byte[]>>> ourIterator =
         new PeekingIterator<>(ourLayerState.entrySet().stream().iterator());
+    final Stream<Pair<byte[], byte[]>> parentStream = parent.stream(segmentId);
     PeekingIterator<Pair<byte[], byte[]>> parentIterator =
-        new PeekingIterator<>(parent.stream(segmentId).iterator());
+        new PeekingIterator<>(parentStream.iterator());
 
     return StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(
                 new LayeredIterator(ourIterator, parentIterator), ORDERED | SORTED | DISTINCT),
             false)
-        .filter(e -> e.getValue() != null);
+        .filter(e -> e.getValue() != null)
+        .onClose(parentStream::close);
   }
 
   private static class LayeredIterator implements Iterator<Pair<byte[], byte[]>> {
@@ -304,12 +305,11 @@ public class LayeredKeyValueStorage extends SegmentedInMemoryKeyValueStorage
               .map(HashMap::new)
               .orElse(new HashMap<>());
 
-      return Streams.concat(
+      // Use Stream.concat (not Guava's Streams.concat) so close() propagates to the parent stream.
+      return Stream.concat(
           ourLayerState.entrySet().stream()
               .filter(entry -> entry.getValue().isPresent())
-              .map(bytesEntry -> bytesEntry.getKey().toArrayUnsafe())
-          // since we are layered, concat a parent stream filtered by our map entries:
-          ,
+              .map(bytesEntry -> bytesEntry.getKey().toArrayUnsafe()),
           parent.streamKeys(segmentId).filter(e -> !ourLayerState.containsKey(Bytes.of(e))));
 
     } finally {


### PR DESCRIPTION
## Summary
fixes #11267

- `RocksDbSegmentIdentifier.reset()` frees the native `ColumnFamilyHandle` inside an `AtomicReference.getAndUpdate()` lambda while concurrent callers may still hold a bare pointer across a JNI boundary — a use-after-free (CWE-416) that can cause a JVM crash.
- Adds a `ReentrantReadWriteLock` (`columnFamilyResetLock`) to `RocksDBColumnarKeyValueStorage`:
  - `get()`, `tryDelete()`, `getNearestBefore()`, `getNearestAfter()`: hold read lock for the duration of each JNI call.
  - `stream*()` / `streamKeys()`: hold read lock across the full stream lifetime via `Stream.onClose()`; release on close or exception. Internal callers (`getAllKeysThat`, `getAllValuesFromKeysThat`) converted to try-with-resources so `onClose` fires.
  - `clear()`: hold write lock for the duration of `reset()`, excluding all concurrent readers while the native handle is replaced.

## Test plan

- [ ] Existing RocksDB unit tests pass: `./gradlew :plugins:rocksdb:test`
- [ ] Manual verification: apply patch, run node through a `debug_resyncWorldstate` cycle, confirm no SIGSEGV under concurrent read traffic

🤖 Generated with [Claude Code](https://claude.ai/code)