### PR TITLE
ci: disable test report generation

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           cache-disabled: true
       - name: List all acceptance tests
-        run: ./gradlew acceptanceTest --test-dry-run -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
+        run: ./gradlew acceptanceTest --test-dry-run -PdisableTestReports -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
       # Scoped to the acceptance suite's own output
       - name: Extract current test list
         shell: bash
@@ -189,7 +189,7 @@ jobs:
           name: test-args-${{ matrix.runner_index }}.txt
           path: '*.txt'
       - name: run acceptance tests
-        run: ./gradlew acceptanceTest `cat gradleArgs.txt` -Dorg.gradle.caching=true
+        run: ./gradlew acceptanceTest `cat gradleArgs.txt` -PdisableTestReports -Dorg.gradle.caching=true
       - name: Remove downloaded test results
         run: rm -rf tmp/junit-xml-reports-downloaded
       - name: Upload Acceptance Test Results
@@ -198,12 +198,6 @@ jobs:
         with:
           name: acceptance-node-${{matrix.runner_index}}-test-results
           path: 'acceptance-tests/tests/build/test-results/**/TEST-*.xml'
-      - name: Upload Acceptance Test HTML Reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: success() || failure()
-        with:
-          name: acceptance-node-${{matrix.runner_index}}-test-html-reports
-          path: 'acceptance-tests/tests/build/reports/tests/**'
 
   acceptanceTestsPassed:
     name: acceptanceTestsPassed

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           cache-disabled: true
       - name: Run integration tests and compile JMH benchmarks
-        run: ./gradlew integrationTest compileJmh
+        run: ./gradlew integrationTest compileJmh -PdisableTestReports
 
   integrationTestsPassed:
     name: integrationTestsPassed

--- a/.github/workflows/reference-tests.yml
+++ b/.github/workflows/reference-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: refTestArgs.txt
         run: cat refTestArgs.txt
       - name: run reference tests
-        run: ./gradlew ethereum:referenceTests:referenceTests `cat refTestArgs.txt`
+        run: ./gradlew ethereum:referenceTests:referenceTests `cat refTestArgs.txt` -PdisableTestReports
       - name: verify test file count matches
         run: |
           listed=$(wc -l < filenames.txt | tr -d ' ')

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           # limit forks to reduce JVM setup overhead (SignatureAlgorithm etc)
           GRADLE_MAX_TEST_FORKS: 2
-        run: ./gradlew test
+        run: ./gradlew test -PdisableTestReports
 
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -46,14 +46,6 @@ jobs:
         with:
           name: unit-test-results
           path: '**/test-results/**/TEST-*.xml'
-          retention-days: 1
-
-      - name: Upload HTML reports
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: success() || failure()
-        with:
-          name: unit-test-html-reports
-          path: '**/build/reports/tests/test/**'
           retention-days: 1
 
   unitTestsPassed:

--- a/build.gradle
+++ b/build.gradle
@@ -416,7 +416,9 @@ configure(allprojects - project(':platform')) {
       }
     }
     useJUnitPlatform {}
-    finalizedBy jacocoTestReport // report is always generated after tests run
+    if (!project.hasProperty('disableTestReports')) {
+      finalizedBy jacocoTestReport // report is always generated after tests run
+    }
   }
 
   javadoc {
@@ -885,6 +887,14 @@ subprojects {
   tasks.withType(Test) {
     // If GRADLE_MAX_TEST_FORKS is not set, use half the available processors
     maxParallelForks = (System.getenv('GRADLE_MAX_TEST_FORKS') ?: (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)).toInteger()
+
+    // -PdisableTestReports drops everything except the JUnit XML, which is the only output CI
+    // reads back. The HTML report and the coverage data behind it are otherwise generated on
+    // every test task and thrown away with the runner.
+    if (project.hasProperty('disableTestReports')) {
+      it.reports.html.required = false
+      it.jacoco.enabled = false
+    }
   }
 
   tasks.withType(JavaCompile) {


### PR DESCRIPTION
## Experiment — do not merge yet

Measuring what per-test-task report generation actually costs in CI. **Results are at the bottom: it saves runner time but not CI wall-clock.**

## Observation

CI reads back only the JUnit XML:

- `acceptance-node-*-test-results` feeds the acceptance timing baseline.
- `unit-test-results` / `reference-test-node-*-results` are debugging aids.

Everything else generated per test task is discarded with the runner:

- the Gradle HTML report (`build/reports/tests/**`), uploaded as `unit-test-html-reports` / `acceptance-node-*-test-html-reports` with 1-day retention, which nothing else consumes;
- the JaCoCo coverage data — `test` is `finalizedBy jacocoTestReport`, so every test JVM runs under the coverage agent and every module writes a coverage report. No workflow runs SonarQube or reads a coverage report.

## Change

`-PdisableTestReports` turns off `reports.html` and `jacoco.enabled` on every `Test` task and drops the `jacocoTestReport` finalizer. The JUnit XML is untouched.

The flag is passed only by the unit, integration, reference and acceptance test workflows, so a local `./gradlew test` still produces the HTML and coverage reports exactly as before.

The two HTML report artifact uploads are removed along with the reports they uploaded. The JUnit XML uploads stay.

## Verified locally

| | HTML report | JUnit XML | JaCoCo exec + report |
|---|---|---|---|
| `./gradlew :util:test` | yes | yes | yes |
| `./gradlew :util:test -PdisableTestReports` | no | yes | no |

A probe over every `Test` task confirms the flag reaches the lazily registered suite tasks too (`acceptanceTest`, `acceptanceTestBftSoak`, `referenceTests`, `referenceTestsDevnet`, `referenceTestsCustom`) — `html=false xml=true jacoco=false` with the flag, all `true` without it.

## Results

Green run: [34486667278](https://github.com/besu-eth/besu/actions/runs/34486667278). Baselines: four recent successful `ci.yml` PR runs on `main` (`34482038323`, `34474900136`, `34472419117`, `34465639197`). The acceptance leg of the first attempt died on an unrelated `:downloadSolc_0_8_25` `SocketException` and was re-run.

Gradle step duration, this PR vs the baseline range:

| step | baseline | this PR | |
|---|---|---|---|
| `Run unit tests` | 823–887s | **696s** | **−17%, outside the baseline range** |
| `Run integration tests and compile JMH benchmarks` | 276–371s | 327s | inside the baseline range — inconclusive |
| `run reference tests` (leg 1) | 214s | 181s | leg composition varies with the split; weak signal |
| `List all acceptance tests` (median of 14) | 332–360s | 354s | no change |
| `run acceptance tests` (median of 14) | 312–322s | 326s | no change |

Acceptance tests are unaffected, which fits: their time goes into spawned Besu processes and network waits, not into the test JVM the coverage agent instruments.

**The artifact uploads were never the cost.** Measured on the baseline run: `Upload test results` 4s, `Upload HTML reports` 5s, `Upload Test Report` 14–20s, acceptance uploads under 3s. All of the saving is generation, and almost all of it is the JaCoCo agent on the unit test JVMs.

### Does it shorten CI?

Not the wall-clock. The merge gate waits on the slowest acceptance runner, which is unchanged:

| | longest job | total runner-seconds |
|---|---|---|
| this PR | 901s (Acceptance Runner 1) | 14430s |
| baselines | 863s / 927s / 922s / 902s | 15059s / 14784s / 13972s / 14254s |

So the honest summary: **~2.5 minutes of runner time saved per PR, concentrated in `unitTests`, and no change to how long a PR waits for CI.** Whether that is worth losing the HTML and coverage reports on the CI path is the open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
