### PR TITLE
Catch IllegalStateException in signature validation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
@@ -371,7 +371,7 @@ public class MainnetTransactionValidator implements TransactionValidator {
     // IllegalArgumentException for "Invalid point compression" for bad signatures.
     try {
       transaction.getSender();
-    } catch (final IllegalArgumentException e) {
+    } catch (final IllegalArgumentException | IllegalStateException e) {
       return ValidationResult.invalid(
           TransactionInvalidReason.INVALID_SIGNATURE,
           "sender could not be extracted from transaction signature");

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
@@ -166,6 +167,24 @@ public class MainnetTransactionValidatorTest extends TrustedSetupClassLoaderExte
                 transaction, Optional.empty(), Optional.empty(), transactionProcessingParams))
         .isEqualTo(
             ValidationResult.invalid(TransactionInvalidReason.INTRINSIC_GAS_EXCEEDS_GAS_LIMIT));
+  }
+
+  @Test
+  public void shouldRejectTransactionWithIllegalStateExceptionAsInvalidSignature() {
+    final TransactionValidator validator =
+        createTransactionValidator(
+            gasCalculator, GasLimitCalculator.constant(), false, Optional.of(BigInteger.ONE));
+
+    final Transaction transaction = mock(Transaction.class);
+    final SECPSignature signature = new SECPSignature(BigInteger.ONE, BigInteger.ONE, (byte) 0);
+    when(transaction.getChainId()).thenReturn(Optional.of(BigInteger.ONE));
+    when(transaction.getSignature()).thenReturn(signature);
+    when(transaction.getSender()).thenThrow(new IllegalStateException("key recovery returned empty"));
+
+    assertThat(
+            validator.validate(
+                transaction, Optional.empty(), Optional.empty(), transactionProcessingParams))
+        .isEqualTo(ValidationResult.invalid(TransactionInvalidReason.INVALID_SIGNATURE));
   }
 
   @Test


### PR DESCRIPTION
## Description

Sender extraction from transaction signatures could throw an `IllegalStateException` that wasn't being caught, causing invalid signatures to show up as internal errors. Added the exception handling and a test.

## Related Issues

Fixes #11278

## Checklist

- [x] Tests added
- [ ] Documentation updated
- [x] Spotless applied