### PR TITLE
Rename regular gas to execution gas

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -337,7 +337,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               .logsBloom(BodyValidation.logsBloom(transactionResults.getReceipts()))
               .gasUsed(
                   Math.max(
-                      transactionResults.getCumulativeRegularGasUsed(),
+                      transactionResults.getCumulativeExecutionGasUsed(),
                       transactionResults.getCumulativeStateGasUsed()))
               .extraData(extraDataCalculator.get(parentHeader))
               .withdrawalsRoot(

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -742,7 +742,7 @@ public class BlockTransactionSelector implements BlockTransactionSelectionServic
         blockSelectionContext
             .protocolSpec()
             .getBlockGasAccountingStrategy()
-            .calculateTransactionRegularGas(transaction, processingResult);
+            .calculateTransactionExecutionGas(transaction, processingResult);
 
     // Receipt gas: Standard post-refund calculation (gasLimit - gasRemaining)
     // This is used for receipt cumulativeGasUsed field

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionSelectionResults.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionSelectionResults.java
@@ -49,9 +49,9 @@ public class TransactionSelectionResults {
       new ConcurrentHashMap<>();
 
   // EIP-7778: Track two separate cumulative gas values
-  // cumulativeRegularGasUsed: For block gas limit enforcement (uses protocol-specific strategy)
+  // cumulativeExecutionGasUsed: For block gas limit enforcement (uses protocol-specific strategy)
   // cumulativeReceiptGasUsed: For receipt cumulativeGasUsed field (always post-refund)
-  private long cumulativeRegularGasUsed = 0;
+  private long cumulativeExecutionGasUsed = 0;
   private long cumulativeReceiptGasUsed = 0;
   // EIP-8037: Track cumulative state gas used for multidimensional gas metering
   private long cumulativeStateGasUsed = 0;
@@ -72,7 +72,7 @@ public class TransactionSelectionResults {
         .computeIfAbsent(transaction.getType(), type -> new ArrayList<>())
         .add(transaction);
     receipts.add(receipt);
-    cumulativeRegularGasUsed += blockGasUsed;
+    cumulativeExecutionGasUsed += blockGasUsed;
     cumulativeReceiptGasUsed += receiptGasUsed;
     cumulativeStateGasUsed += stateGasUsed;
     selectedTxsEvaluationTimeNanos += evaluationTimeNanos;
@@ -81,7 +81,7 @@ public class TransactionSelectionResults {
             "New selected transaction {}, total transactions {}, cumulative block gas {}, cumulative receipt gas {}, cumulative selection time {}ms")
         .addArgument(transaction::toTraceLog)
         .addArgument(selectedTransactions::size)
-        .addArgument(cumulativeRegularGasUsed)
+        .addArgument(cumulativeExecutionGasUsed)
         .addArgument(cumulativeReceiptGasUsed)
         .addArgument(() -> TimeUnit.NANOSECONDS.toMillis(selectedTxsEvaluationTimeNanos))
         .log();
@@ -104,8 +104,8 @@ public class TransactionSelectionResults {
     return receipts;
   }
 
-  public long getCumulativeRegularGasUsed() {
-    return cumulativeRegularGasUsed;
+  public long getCumulativeExecutionGasUsed() {
+    return cumulativeExecutionGasUsed;
   }
 
   public long getCumulativeReceiptGasUsed() {
@@ -157,7 +157,7 @@ public class TransactionSelectionResults {
       return false;
     }
     TransactionSelectionResults that = (TransactionSelectionResults) o;
-    return cumulativeRegularGasUsed == that.cumulativeRegularGasUsed
+    return cumulativeExecutionGasUsed == that.cumulativeExecutionGasUsed
         && cumulativeReceiptGasUsed == that.cumulativeReceiptGasUsed
         && cumulativeStateGasUsed == that.cumulativeStateGasUsed
         && selectedTransactions.equals(that.selectedTransactions)
@@ -171,14 +171,14 @@ public class TransactionSelectionResults {
         selectedTransactions,
         notSelectedTransactions,
         receipts,
-        cumulativeRegularGasUsed,
+        cumulativeExecutionGasUsed,
         cumulativeReceiptGasUsed,
         cumulativeStateGasUsed);
   }
 
   public String toTraceLog() {
-    return "cumulativeRegularGasUsed="
-        + cumulativeRegularGasUsed
+    return "cumulativeExecutionGasUsed="
+        + cumulativeExecutionGasUsed
         + ", cumulativeReceiptGasUsed="
         + cumulativeReceiptGasUsed
         + ", cumulativeStateGasUsed="

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
  * evaluating transactions based on block size. It checks if a transaction is too large for the
  * block and determines the selection result accordingly.
  *
- * <p>For EIP-8037 multidimensional gas, this selector tracks both regular and state gas dimensions.
- * Pre-processing bounds both dimensions by the transaction's gasLimit, since either one could
- * consume the whole limit. Post-processing then re-checks the block against max(regular, state)
- * once execution has revealed the actual split.
+ * <p>For EIP-8037 multidimensional gas, this selector tracks both execution and state gas
+ * dimensions. Pre-processing bounds both dimensions by the transaction's gasLimit, since either one
+ * could consume the whole limit. Post-processing then re-checks the block against max(execution,
+ * state) once execution has revealed the actual split.
  */
 public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSelector<GasState> {
   private static final Logger LOG = LoggerFactory.getLogger(BlockSizeTransactionSelector.class);
@@ -83,8 +83,8 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
   public TransactionSelectionResult evaluateTransactionPostProcessing(
       final TransactionEvaluationContext evaluationContext,
       final TransactionProcessingResult processingResult) {
-    final long txRegularGasUsed =
-        gasAccountingStrategy.calculateTransactionRegularGas(
+    final long txExecutionGasUsed =
+        gasAccountingStrategy.calculateTransactionExecutionGas(
             evaluationContext.getTransaction(), processingResult);
     // EIP-8037: the state dimension is the state gas the transaction actually consumed, which is
     // only known now that it has executed.
@@ -92,18 +92,18 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
 
     final GasState state = getWorkingState();
     final GasState newState =
-        new GasState(state.regularGas() + txRegularGasUsed, state.stateGas() + stateGasUsed);
+        new GasState(state.executionGas() + txExecutionGasUsed, state.stateGas() + stateGasUsed);
     setWorkingState(newState);
 
     final long gasMetered =
-        gasAccountingStrategy.effectiveGasUsed(newState.regularGas(), newState.stateGas());
+        gasAccountingStrategy.effectiveGasUsed(newState.executionGas(), newState.stateGas());
     if (gasMetered > blockGasLimit) {
       LOG.atTrace()
           .setMessage(
               "Transaction {} exceeds block gas limit post-processing:"
-                  + " regularGas={}, stateGas={}, gasMetered={}, blockGasLimit={}")
+                  + " executionGas={}, stateGas={}, gasMetered={}, blockGasLimit={}")
           .addArgument(evaluationContext.getPendingTransaction()::toTraceLog)
-          .addArgument(newState.regularGas())
+          .addArgument(newState.executionGas())
           .addArgument(newState.stateGas())
           .addArgument(gasMetered)
           .addArgument(blockGasLimit)
@@ -115,21 +115,21 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
 
   /**
    * Checks if the transaction is too large for the block using the gas accounting strategy. For 1D
-   * gas this checks the regular gas dimension only; for 2D gas (EIP-8037) it bounds both dimensions
-   * by the transaction's gas limit, since either one could consume the whole limit.
+   * gas this checks the execution gas dimension only; for 2D gas (EIP-8037) it bounds both
+   * dimensions by the transaction's gas limit, since either one could consume the whole limit.
    *
-   * <p>The post-processing check verifies that gas metered (max of regular, state) stays within the
-   * block gas limit after processing reveals the actual regular/state gas split.
+   * <p>The post-processing check verifies that gas metered (max of execution, state) stays within
+   * the block gas limit after processing reveals the actual execution/state gas split.
    *
    * @param transaction The transaction to be checked.
-   * @param state The current gas state with regular and state gas.
+   * @param state The current gas state with execution and state gas.
    * @return True if the transaction is too large for the block, false otherwise.
    */
   private boolean transactionTooLargeForBlock(final Transaction transaction, final GasState state) {
     return !gasAccountingStrategy.hasBlockCapacity(
         transaction.getGasLimit(),
-        stateGasCostCalculator.transactionRegularGasLimit(),
-        state.regularGas(),
+        stateGasCostCalculator.transactionExecutionGasLimit(),
+        state.executionGas(),
         state.stateGas(),
         blockGasLimit);
   }
@@ -142,7 +142,7 @@ public class BlockSizeTransactionSelector extends AbstractStatefulTransactionSel
    */
   private boolean blockFull(final GasState state) {
     final long gasUsed =
-        gasAccountingStrategy.effectiveGasUsed(state.regularGas(), state.stateGas());
+        gasAccountingStrategy.effectiveGasUsed(state.executionGas(), state.stateGas());
     final long gasRemaining = blockGasLimit - gasUsed;
 
     if (gasRemaining < context.gasCalculator().getMinimumTransactionCost()) {

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/GasState.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/GasState.java
@@ -15,15 +15,15 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 /**
- * Tracks cumulative regular gas and state gas used during block building. Used by {@link
+ * Tracks cumulative execution gas and state gas used during block building. Used by {@link
  * BlockSizeTransactionSelector} for multidimensional gas metering (EIP-8037).
  *
  * <p>For pre-EIP-8037, stateGas is always 0.
  *
- * @param regularGas cumulative regular (non-state) gas used
+ * @param executionGas cumulative execution (non-state) gas used
  * @param stateGas cumulative state gas used
  */
-record GasState(long regularGas, long stateGas) {
+record GasState(long executionGas, long stateGas) {
 
   static final GasState ZERO = new GasState(0, 0);
 

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -258,7 +258,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getSelectedTransactions()).isEmpty();
     assertThat(results.getNotSelectedTransactions()).isEmpty();
     assertThat(results.getReceipts()).isEmpty();
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(0);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(0);
   }
 
   @Test
@@ -284,7 +284,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getSelectedTransactions()).containsExactly(transaction);
     assertThat(results.getNotSelectedTransactions()).isEmpty();
     assertThat(results.getReceipts().size()).isEqualTo(1);
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(99995L);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(99995L);
   }
 
   @Test
@@ -312,7 +312,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getNotSelectedTransactions())
         .containsOnly(entry(transaction, TransactionSelectionResult.SELECTION_CANCELLED));
     assertThat(results.getReceipts().size()).isEqualTo(0);
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(0L);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(0L);
   }
 
   @Test
@@ -353,7 +353,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getSelectedTransactions().size()).isEqualTo(4);
     assertThat(results.getSelectedTransactions().contains(invalidTx)).isFalse();
     assertThat(results.getReceipts().size()).isEqualTo(4);
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(400_000);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(400_000);
   }
 
   @Test
@@ -386,7 +386,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
     assertThat(results.getNotSelectedTransactions())
         .containsOnly(entry(transactionsToInject.get(3), TransactionSelectionResult.BLOCK_FULL));
     assertThat(results.getReceipts().size()).isEqualTo(3);
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(300_000);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(300_000);
 
     // Ensure receipts have the correct cumulative gas
     assertThat(results.getReceipts().get(0).getCumulativeGasUsed()).isEqualTo(100_000);
@@ -521,7 +521,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 transactionsToInject.get(1),
                 TransactionSelectionResult.TX_TOO_LARGE_FOR_REMAINING_GAS),
             entry(transactionsToInject.get(4), TransactionSelectionResult.BLOCK_FULL));
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(blockHeader.getGasLimit());
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(blockHeader.getGasLimit());
   }
 
   @Test
@@ -574,7 +574,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
                 transactionsToInject.get(1),
                 TransactionSelectionResult.TX_TOO_LARGE_FOR_REMAINING_GAS),
             entry(transactionsToInject.get(3), TransactionSelectionResult.BLOCK_FULL));
-    assertThat(blockHeader.getGasLimit() - results.getCumulativeRegularGasUsed())
+    assertThat(blockHeader.getGasLimit() - results.getCumulativeExecutionGasUsed())
         .isLessThan(minTxGasCost);
   }
 
@@ -1474,7 +1474,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         .isTrue();
 
     assertThat(results.getReceipts().size()).isEqualTo(2);
-    assertThat(results.getCumulativeRegularGasUsed()).isEqualTo(200_000);
+    assertThat(results.getCumulativeExecutionGasUsed()).isEqualTo(200_000);
 
     // Ensure receipts have the correct cumulative gas
     assertThat(results.getReceipts().get(0).getCumulativeGasUsed()).isEqualTo(100_000);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelectorTest.java
@@ -79,7 +79,7 @@ class BlockSizeTransactionSelectorTest {
     when(blockSelectionContext.protocolSpec().getBlockGasAccountingStrategy())
         .thenReturn(BlockGasAccountingStrategy.FRONTIER);
     // EIP-8037: ensure the per-dimension check (ethereum/EIPs #11536) sees a meaningful
-    // TX_MAX_GAS_LIMIT so that worstCaseRegular = min(TX_MAX, tx.gas) is not clamped to 0 by
+    // TX_MAX_GAS_LIMIT so that worstCaseExecution = min(TX_MAX, tx.gas) is not clamped to 0 by
     // RETURNS_DEEP_STUBS' primitive default. Lenient since tests using FRONTIER strategy never
     // invoke the per-dimension check.
     lenient()
@@ -87,7 +87,7 @@ class BlockSizeTransactionSelectorTest {
             blockSelectionContext
                 .gasCalculator()
                 .stateGasCostCalculator()
-                .transactionRegularGasLimit())
+                .transactionExecutionGasLimit())
         .thenReturn(Long.MAX_VALUE);
 
     selectorsStateManager = new SelectorsStateManager();
@@ -104,7 +104,7 @@ class BlockSizeTransactionSelectorTest {
     selectorsStateManager.blockSelectionStarted();
     evaluateAndAssertSelected(txEvaluationContext, remainingGas(0));
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(TRANSFER_GAS_LIMIT);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(TRANSFER_GAS_LIMIT);
     assertThat(selector.getWorkingState().stateGas()).isEqualTo(0);
   }
 
@@ -118,7 +118,7 @@ class BlockSizeTransactionSelectorTest {
     selectorsStateManager.blockSelectionStarted();
     evaluateAndAssertNotSelected(txEvaluationContext, TX_TOO_LARGE_FOR_REMAINING_GAS);
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(0);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(0);
   }
 
   @Test
@@ -132,7 +132,7 @@ class BlockSizeTransactionSelectorTest {
     selectorsStateManager.blockSelectionStarted();
     evaluateAndAssertSelected(txEvaluationContext, remainingGas(remainingGas));
 
-    assertThat(selector.getWorkingState().regularGas())
+    assertThat(selector.getWorkingState().executionGas())
         .isEqualTo(TRANSFER_GAS_LIMIT * 2 - remainingGas);
   }
 
@@ -158,7 +158,7 @@ class BlockSizeTransactionSelectorTest {
               evaluateAndAssertSelected(txEvaluationContext, remainingGas(0));
             });
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
   }
 
   @Test
@@ -183,7 +183,7 @@ class BlockSizeTransactionSelectorTest {
               evaluateAndAssertSelected(txEvaluationContext, remainingGas(0));
             });
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
 
     // last tx is too big for the remaining gas
     final long tooBigGasLimit = BLOCK_GAS_LIMIT - (TRANSFER_GAS_LIMIT * txCount) + 1;
@@ -198,7 +198,7 @@ class BlockSizeTransactionSelectorTest {
             NEVER_CANCELLED);
     evaluateAndAssertNotSelected(bigTxEvaluationContext, TX_TOO_LARGE_FOR_REMAINING_GAS);
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(TRANSFER_GAS_LIMIT * txCount);
   }
 
   @Test
@@ -218,7 +218,7 @@ class BlockSizeTransactionSelectorTest {
             blockSelectionContext.pendingBlockHeader(), tx1, null, null, null, NEVER_CANCELLED);
     evaluateAndAssertSelected(txEvaluationContext1, remainingGas(0));
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(fillBlockGasLimit);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(fillBlockGasLimit);
 
     final var tx2 = createPendingTransaction(TRANSFER_GAS_LIMIT);
 
@@ -227,7 +227,7 @@ class BlockSizeTransactionSelectorTest {
             blockSelectionContext.pendingBlockHeader(), tx2, null, null, null, NEVER_CANCELLED);
     evaluateAndAssertNotSelected(txEvaluationContext2, BLOCK_FULL);
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(fillBlockGasLimit);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(fillBlockGasLimit);
   }
 
   /**
@@ -247,12 +247,12 @@ class BlockSizeTransactionSelectorTest {
     final var tx = createPendingTransaction(txGasLimit);
 
     // An SSTORE refund makes gasRemaining larger than the gas actually consumed; EIP-7778 must
-    // account for the block on the unfloored regular gas instead.
+    // account for the block on the unfloored execution gas instead.
     final long preRefundGasUsed = 40_000L;
 
     final var txProcessingResult = mock(TransactionProcessingResult.class);
     when(txProcessingResult.getStateGasUsed()).thenReturn(0L);
-    when(txProcessingResult.getRegularGasUsedForBlock()).thenReturn(preRefundGasUsed);
+    when(txProcessingResult.getExecutionGasUsedForBlock()).thenReturn(preRefundGasUsed);
     final var txEvaluationContext =
         new TransactionEvaluationContext(
             blockSelectionContext.pendingBlockHeader(), tx, null, null, null, NEVER_CANCELLED);
@@ -260,7 +260,7 @@ class BlockSizeTransactionSelectorTest {
     evaluateAndAssertSelected(txEvaluationContext, txProcessingResult);
 
     // EIP-7778: Should use pre-refund gas (40,000), NOT post-refund (30,000)
-    assertThat(selector.getWorkingState().regularGas())
+    assertThat(selector.getWorkingState().executionGas())
         .as("EIP-7778 should use pre-refund gas for block accounting")
         .isEqualTo(preRefundGasUsed);
   }
@@ -292,7 +292,7 @@ class BlockSizeTransactionSelectorTest {
     evaluateAndAssertSelected(txEvaluationContext, txProcessingResult);
 
     // FRONTIER: Should use post-refund gas (30,000)
-    assertThat(selector.getWorkingState().regularGas())
+    assertThat(selector.getWorkingState().executionGas())
         .as("FRONTIER should use post-refund gas for block accounting")
         .isEqualTo(expectedPostRefundUsed);
   }
@@ -300,8 +300,8 @@ class BlockSizeTransactionSelectorTest {
   /**
    * EIP-8037 2D gas: Pre-processing uses per-dimension capacity check.
    *
-   * <p>Scenario: block limit=30M, regular=25M used, state=5M used. The tighter dimension is regular
-   * with 5M remaining, so txGasLimit must be <= 5M to pass.
+   * <p>Scenario: block limit=30M, execution=25M used, state=5M used. The tighter dimension is
+   * execution with 5M remaining, so txGasLimit must be <= 5M to pass.
    */
   @Test
   void eip8037TwoDimensionalPreProcessingChecksPerDimension() {
@@ -311,11 +311,11 @@ class BlockSizeTransactionSelectorTest {
     selector = new BlockSizeTransactionSelector(blockSelectionContext, selectorsStateManager);
     selectorsStateManager.blockSelectionStarted();
 
-    // First tx: uses 25M regular, 5M state
+    // First tx: uses 25M execution, 5M state
     final var tx1 = createPendingTransaction(30_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
     when(result1.getStateGasUsed()).thenReturn(5_000_000L);
-    when(result1.getRegularGasUsedForBlock()).thenReturn(25_000_000L);
+    when(result1.getExecutionGasUsedForBlock()).thenReturn(25_000_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(
@@ -323,18 +323,18 @@ class BlockSizeTransactionSelectorTest {
     assertThat(selector.evaluateTransactionPreProcessing(ctx1)).isEqualTo(SELECTED);
     assertThat(selector.evaluateTransactionPostProcessing(ctx1, result1)).isEqualTo(SELECTED);
 
-    // State: regular=25M, state=5M
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(25_000_000L);
+    // State: execution=25M, state=5M
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(25_000_000L);
     assertThat(selector.getWorkingState().stateGas()).isEqualTo(5_000_000L);
 
-    // tx with gasLimit=5M fits: remaining_regular = 30M - 25M = 5M >= 5M
+    // tx with gasLimit=5M fits: remaining_execution = 30M - 25M = 5M >= 5M
     final var tx2 = createPendingTransaction(5_000_000L);
     final var ctx2 =
         new TransactionEvaluationContext(
             blockSelectionContext.pendingBlockHeader(), tx2, null, null, null, NEVER_CANCELLED);
     assertThat(selector.evaluateTransactionPreProcessing(ctx2)).isEqualTo(SELECTED);
 
-    // tx with gasLimit=5M+1 doesn't fit: exceeds tighter (regular) dimension
+    // tx with gasLimit=5M+1 doesn't fit: exceeds tighter (execution) dimension
     final var tx3 = createPendingTransaction(5_000_001L);
     final var ctx3 =
         new TransactionEvaluationContext(
@@ -355,11 +355,11 @@ class BlockSizeTransactionSelectorTest {
     selector = new BlockSizeTransactionSelector(blockSelectionContext, selectorsStateManager);
     selectorsStateManager.blockSelectionStarted();
 
-    // First tx: gasLimit=30M, uses 20M regular + 10M state = 30M total
+    // First tx: gasLimit=30M, uses 20M execution + 10M state = 30M total
     final var tx1 = createPendingTransaction(30_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
     when(result1.getStateGasUsed()).thenReturn(10_000_000L);
-    when(result1.getRegularGasUsedForBlock()).thenReturn(20_000_000L);
+    when(result1.getExecutionGasUsedForBlock()).thenReturn(20_000_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(
@@ -367,18 +367,18 @@ class BlockSizeTransactionSelectorTest {
     assertThat(selector.evaluateTransactionPreProcessing(ctx1)).isEqualTo(SELECTED);
     assertThat(selector.evaluateTransactionPostProcessing(ctx1, result1)).isEqualTo(SELECTED);
 
-    // State: regular=20M, state=10M, gasMetered=max(20M,10M)=20M <= 30M ok
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(20_000_000L);
+    // State: execution=20M, state=10M, gasMetered=max(20M,10M)=20M <= 30M ok
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(20_000_000L);
     assertThat(selector.getWorkingState().stateGas()).isEqualTo(10_000_000L);
 
-    // Second tx with gasLimit=10M fits: remaining_regular = 30M - 20M = 10M >= 10M
+    // Second tx with gasLimit=10M fits: remaining_execution = 30M - 20M = 10M >= 10M
     final var tx2 = createPendingTransaction(10_000_000L);
     final var ctx2 =
         new TransactionEvaluationContext(
             blockSelectionContext.pendingBlockHeader(), tx2, null, null, null, NEVER_CANCELLED);
     assertThat(selector.evaluateTransactionPreProcessing(ctx2)).isEqualTo(SELECTED);
 
-    // Third tx with gasLimit=10M+1 doesn't fit: exceeds tighter (regular) dimension
+    // Third tx with gasLimit=10M+1 doesn't fit: exceeds tighter (execution) dimension
     final var tx3 = createPendingTransaction(10_000_001L);
     final var ctx3 =
         new TransactionEvaluationContext(
@@ -388,7 +388,7 @@ class BlockSizeTransactionSelectorTest {
   }
 
   /**
-   * EIP-8037 2D gas: effectiveGasUsed drives occupancy/blockFull checks using max(regular,state).
+   * EIP-8037 2D gas: effectiveGasUsed drives occupancy/blockFull checks using max(execution,state).
    * When the tighter dimension has less remaining than min tx cost, the block is full.
    */
   @Test
@@ -401,11 +401,11 @@ class BlockSizeTransactionSelectorTest {
     selector = new BlockSizeTransactionSelector(blockSelectionContext, selectorsStateManager);
     selectorsStateManager.blockSelectionStarted();
 
-    // Fill block with regular dimension nearly full: gasLimit=1M, uses 990K regular + 10K state
+    // Fill block with execution dimension nearly full: gasLimit=1M, uses 990K execution + 10K state
     final var tx1 = createPendingTransaction(1_000_000L);
     final var result1 = mock(TransactionProcessingResult.class);
     when(result1.getStateGasUsed()).thenReturn(10_000L);
-    when(result1.getRegularGasUsedForBlock()).thenReturn(990_000L);
+    when(result1.getExecutionGasUsedForBlock()).thenReturn(990_000L);
 
     final var ctx1 =
         new TransactionEvaluationContext(
@@ -413,10 +413,10 @@ class BlockSizeTransactionSelectorTest {
     assertThat(selector.evaluateTransactionPreProcessing(ctx1)).isEqualTo(SELECTED);
     assertThat(selector.evaluateTransactionPostProcessing(ctx1, result1)).isEqualTo(SELECTED);
 
-    assertThat(selector.getWorkingState().regularGas()).isEqualTo(990_000L);
+    assertThat(selector.getWorkingState().executionGas()).isEqualTo(990_000L);
     assertThat(selector.getWorkingState().stateGas()).isEqualTo(10_000L);
 
-    // tx2 gasLimit=21K > remaining_regular = 1M - 990K = 10K
+    // tx2 gasLimit=21K > remaining_execution = 1M - 990K = 10K
     // transactionTooLargeForBlock=true; effectiveGasUsed=max(990K,10K)=990K, remaining=10K < 21K
     // result in blockFull
     final var tx2 = createPendingTransaction(TRANSFER_GAS_LIMIT);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/GasLimitCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/GasLimitCalculator.java
@@ -90,9 +90,9 @@ public interface GasLimitCalculator {
    * Return the cap on the transaction intrinsic gas.
    *
    * <p>EIP-8037 (Amsterdam) relaxes the EIP-7825 cap on {@code tx.gas} itself and instead caps
-   * {@code max(intrinsic_regular, calldata_floor)} at the same value. Forks that cap {@code tx.gas}
-   * directly leave this uncapped, since the intrinsic gas is then implicitly bounded by {@code
-   * tx.gas}.
+   * {@code max(intrinsic_execution, calldata_floor)} at the same value. Forks that cap {@code
+   * tx.gas} directly leave this uncapped, since the intrinsic gas is then implicitly bounded by
+   * {@code tx.gas}.
    *
    * @return the transaction intrinsic gas cap.
    */

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -212,11 +212,11 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final PreprocessingFunction preprocessingBlockFunction) {
     final List<TransactionReceipt> receipts = new ArrayList<>();
     // EIP-7778: Track two separate cumulative gas values
-    // cumulativeRegularGasUsed: For block gas limit enforcement (uses protocol-specific strategy)
+    // cumulativeExecutionGasUsed: For block gas limit enforcement (uses protocol-specific strategy)
     //   - Pre-Amsterdam: gasLimit - gasRemaining (post-refund)
     //   - Amsterdam+: pre-refund gas (prevents block gas limit circumvention via refunds)
     // cumulativeReceiptGasUsed: For receipt cumulativeGasUsed field (always post-refund)
-    long cumulativeRegularGasUsed = 0;
+    long cumulativeExecutionGasUsed = 0;
     long cumulativeReceiptGasUsed = 0;
     long cumulativeStateGasUsed = 0;
     long currentBlobGasUsed = 0;
@@ -303,11 +303,11 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
           transactionUpdater = blockUpdater;
         }
         // EIP-8037: per-dimension 2D-aware budget check using
-        // worst-case regular and state consumption derived from transaction intrinsics.
+        // worst-case execution and state consumption derived from transaction intrinsics.
         if (!hasAvailableBlockBudget(
             blockHeader,
             transaction,
-            cumulativeRegularGasUsed,
+            cumulativeExecutionGasUsed,
             cumulativeStateGasUsed,
             protocolSpec)) {
           return new BlockProcessingResult(Optional.empty(), "provided gas insufficient");
@@ -352,10 +352,10 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
 
         // EIP-7778: Update both cumulative gas values
         // Block gas uses protocol-specific strategy (pre-refund for Amsterdam+)
-        cumulativeRegularGasUsed +=
+        cumulativeExecutionGasUsed +=
             protocolSpec
                 .getBlockGasAccountingStrategy()
-                .calculateTransactionRegularGas(transaction, transactionProcessingResult);
+                .calculateTransactionExecutionGas(transaction, transactionProcessingResult);
         // Receipt gas always uses standard post-refund calculation
         cumulativeReceiptGasUsed +=
             BlockGasAccountingStrategy.calculateReceiptGas(
@@ -366,7 +366,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         final long gasMeteredSoFar =
             protocolSpec
                 .getBlockGasAccountingStrategy()
-                .effectiveGasUsed(cumulativeRegularGasUsed, cumulativeStateGasUsed);
+                .effectiveGasUsed(cumulativeExecutionGasUsed, cumulativeStateGasUsed);
         if (gasMeteredSoFar > blockHeader.getGasLimit()) {
           return new BlockProcessingResult(Optional.empty(), "gas metered exceeds block gas limit");
         }
@@ -558,8 +558,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         return new BlockProcessingResult(Optional.empty(), e);
       }
 
-      // EIP-8037: gas_metered = max(cumulative_regular, cumulative_state)
-      final long gasMetered = Math.max(cumulativeRegularGasUsed, cumulativeStateGasUsed);
+      // EIP-8037: gas_metered = max(cumulative_execution, cumulative_state)
+      final long gasMetered = Math.max(cumulativeExecutionGasUsed, cumulativeStateGasUsed);
 
       return new BlockProcessingResult(
           Optional.of(
@@ -613,22 +613,22 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   protected boolean hasAvailableBlockBudget(
       final BlockHeader blockHeader,
       final Transaction transaction,
-      final long cumulativeRegularGasUsed,
+      final long cumulativeExecutionGasUsed,
       final long cumulativeStateGasUsed,
       final ProtocolSpec protocolSpec) {
     final BlockGasAccountingStrategy strategy = protocolSpec.getBlockGasAccountingStrategy();
     final var gasCalculator = protocolSpec.getGasCalculator();
     if (!strategy.hasBlockCapacity(
         transaction.getGasLimit(),
-        gasCalculator.stateGasCostCalculator().transactionRegularGasLimit(),
-        cumulativeRegularGasUsed,
+        gasCalculator.stateGasCostCalculator().transactionExecutionGasLimit(),
+        cumulativeExecutionGasUsed,
         cumulativeStateGasUsed,
         blockHeader.getGasLimit())) {
       LOG.info(
           "Block processing error: transaction gas limit {} exceeds available block budget"
-              + " (regular={}, state={}, limit={}). Block {} Transaction {}",
+              + " (execution={}, state={}, limit={}). Block {} Transaction {}",
           transaction.getGasLimit(),
-          cumulativeRegularGasUsed,
+          cumulativeExecutionGasUsed,
           cumulativeStateGasUsed,
           blockHeader.getGasLimit(),
           blockHeader.getHash().getBytes().toHexString(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AmsterdamTargetingGasLimitCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AmsterdamTargetingGasLimitCalculator.java
@@ -21,7 +21,7 @@ import java.util.OptionalInt;
 
 /**
  * EIP-8037: Amsterdam relaxes the EIP-7825 cap on {@code tx.gas} itself and instead caps {@code
- * max(intrinsic_regular, calldata_floor)} at the former cap value.
+ * max(intrinsic_execution, calldata_floor)} at the former cap value.
  */
 public class AmsterdamTargetingGasLimitCalculator extends OsakaTargetingGasLimitCalculator {
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategy.java
@@ -24,30 +24,32 @@ import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
  * <p>Prior to Amsterdam: Block gas is calculated POST-refund (gasLimit - gasRemaining), which
  * includes the benefit of gas refunds from SSTORE operations.
  *
- * <p>Amsterdam (EIP-7778 + EIP-8037): Block gas is calculated PRE-refund and split into regular and
- * state dimensions, preventing block gas limit circumvention through refund credits.
+ * <p>Amsterdam (EIP-7778 + EIP-8037): Block gas is calculated PRE-refund and split into execution
+ * and state dimensions, preventing block gas limit circumvention through refund credits.
  */
 public interface BlockGasAccountingStrategy {
 
   /**
-   * Calculate a transaction's regular gas contribution to the block's cumulative gas used.
+   * Calculate a transaction's execution gas contribution to the block's cumulative gas used.
    *
    * @param transaction the transaction being processed
    * @param result the transaction processing result
-   * @return the regular gas used by the transaction for block accounting
+   * @return the execution gas used by the transaction for block accounting
    */
-  long calculateTransactionRegularGas(Transaction transaction, TransactionProcessingResult result);
+  long calculateTransactionExecutionGas(
+      Transaction transaction, TransactionProcessingResult result);
 
   /**
    * Check whether the block has capacity for a transaction. The default (1D, pre-EIP-8037)
-   * implementation checks the regular gas dimension only: the tx gas limit must fit within the
-   * block's remaining regular-gas budget (capped at zero defensively). EIP-8037 strategies override
-   * this to bound both dimensions by the transaction's gas limit, since either one could consume
-   * the whole limit (regular gas additionally runtime-capped at {@code TX_MAX_GAS_LIMIT}).
+   * implementation checks the execution gas dimension only: the tx gas limit must fit within the
+   * block's remaining execution-gas budget (capped at zero defensively). EIP-8037 strategies
+   * override this to bound both dimensions by the transaction's gas limit, since either one could
+   * consume the whole limit (execution gas additionally runtime-capped at {@code
+   * TX_MAX_GAS_LIMIT}).
    *
    * @param txGasLimit the gas limit of the candidate transaction
-   * @param txMaxGasLimit runtime cap on regular gas per tx (EIP-7825 TX_MAX_GAS_LIMIT)
-   * @param cumulativeRegularGas cumulative regular gas used in the block so far
+   * @param txMaxGasLimit runtime cap on execution gas per tx (EIP-7825 TX_MAX_GAS_LIMIT)
+   * @param cumulativeExecutionGas cumulative execution gas used in the block so far
    * @param cumulativeStateGas cumulative state gas used in the block so far
    * @param blockGasLimit the block gas limit
    * @return true if the block has capacity for this transaction
@@ -55,23 +57,23 @@ public interface BlockGasAccountingStrategy {
   default boolean hasBlockCapacity(
       final long txGasLimit,
       final long txMaxGasLimit,
-      final long cumulativeRegularGas,
+      final long cumulativeExecutionGas,
       final long cumulativeStateGas,
       final long blockGasLimit) {
-    final long remainingRegular = Math.max(0, blockGasLimit - cumulativeRegularGas);
-    return txGasLimit <= remainingRegular;
+    final long remainingExecution = Math.max(0, blockGasLimit - cumulativeExecutionGas);
+    return txGasLimit <= remainingExecution;
   }
 
   /**
    * Calculate the effective gas used for occupancy and fullness checks. For 1D gas, this is just
-   * the regular gas. For 2D gas (EIP-8037), this is max(regular, state).
+   * the execution gas. For 2D gas (EIP-8037), this is max(execution, state).
    *
-   * @param cumulativeRegularGas cumulative regular gas used
+   * @param cumulativeExecutionGas cumulative execution gas used
    * @param cumulativeStateGas cumulative state gas used
    * @return the effective gas used
    */
-  default long effectiveGasUsed(final long cumulativeRegularGas, final long cumulativeStateGas) {
-    return cumulativeRegularGas;
+  default long effectiveGasUsed(final long cumulativeExecutionGas, final long cumulativeStateGas) {
+    return cumulativeExecutionGas;
   }
 
   /**
@@ -81,45 +83,45 @@ public interface BlockGasAccountingStrategy {
   BlockGasAccountingStrategy FRONTIER = (tx, result) -> tx.getGasLimit() - result.getGasRemaining();
 
   /**
-   * Amsterdam (EIP-7778 + EIP-8037): Uses pre-refund gas split into regular and state dimensions.
+   * Amsterdam (EIP-7778 + EIP-8037): Uses pre-refund gas split into execution and state dimensions.
    *
    * <p>EIP-7778: Block gas is calculated pre-refund (estimateGasUsedByTransaction), preventing
    * block gas limit circumvention through refund credits.
    *
-   * <p>EIP-8037: Gas is split into regular and state portions. Regular gas =
-   * estimateGasUsedByTransaction - stateGasUsed. Block gas_metered = max(cumulative_regular,
+   * <p>EIP-8037: Gas is split into execution and state portions. Execution gas =
+   * estimateGasUsedByTransaction - stateGasUsed. Block gas_metered = max(cumulative_execution,
    * cumulative_state).
    */
   BlockGasAccountingStrategy AMSTERDAM =
       new BlockGasAccountingStrategy() {
         @Override
-        public long calculateTransactionRegularGas(
+        public long calculateTransactionExecutionGas(
             final Transaction transaction, final TransactionProcessingResult result) {
           // EIP-8037: the calldata floor binds this dimension, so the sender cannot buy block
-          // regular-gas space below the floor by spending on state.
-          return result.getRegularGasUsedForBlock();
+          // execution-gas space below the floor by spending on state.
+          return result.getExecutionGasUsedForBlock();
         }
 
         @Override
         public boolean hasBlockCapacity(
             final long txGasLimit,
             final long txMaxGasLimit,
-            final long cumulativeRegularGas,
+            final long cumulativeExecutionGas,
             final long cumulativeStateGas,
             final long blockGasLimit) {
           // The full tx gas limit bounds both dimensions, since either one could consume the
-          // whole limit. Regular gas is additionally capped at TX_MAX_GAS_LIMIT (EIP-7825).
-          final long regularAvailable = Math.max(0L, blockGasLimit - cumulativeRegularGas);
+          // whole limit. Execution gas is additionally capped at TX_MAX_GAS_LIMIT (EIP-7825).
+          final long executionAvailable = Math.max(0L, blockGasLimit - cumulativeExecutionGas);
           final long stateAvailable = Math.max(0L, blockGasLimit - cumulativeStateGas);
-          final long worstCaseRegular = Math.min(txMaxGasLimit, txGasLimit);
+          final long worstCaseExecution = Math.min(txMaxGasLimit, txGasLimit);
           final long worstCaseState = txGasLimit;
-          return worstCaseRegular <= regularAvailable && worstCaseState <= stateAvailable;
+          return worstCaseExecution <= executionAvailable && worstCaseState <= stateAvailable;
         }
 
         @Override
         public long effectiveGasUsed(
-            final long cumulativeRegularGas, final long cumulativeStateGas) {
-          return Math.max(cumulativeRegularGas, cumulativeStateGas);
+            final long cumulativeExecutionGas, final long cumulativeStateGas) {
+          return Math.max(cumulativeExecutionGas, cumulativeStateGas);
         }
       };
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -1269,8 +1269,7 @@ public abstract class MainnetProtocolSpecs {
             .blockAccessListValidatorBuilder(MainnetBlockAccessListValidator::create)
             .stateRootCommitterFactory(new StateRootCommitterFactory(balConfiguration))
             // EIP-8037: Disable validation-time TX_MAX_GAS_LIMIT cap (enforced at runtime on
-            // regular
-            // gas)
+            // execution gas)
             .gasLimitCalculatorBuilder(
                 (feeMarket, gasCalculator, blobSchedule) -> {
                   final long londonForkBlock =
@@ -1288,7 +1287,7 @@ public abstract class MainnetProtocolSpecs {
             .gasCalculator(AmsterdamGasCalculator::new)
             // Amsterdam (EIP-7778 + EIP-8037): Pre-refund 2D gas accounting
             .blockGasAccountingStrategy(BlockGasAccountingStrategy.AMSTERDAM)
-            // Amsterdam: Validator uses pre-refund gas_metered = max(regular, state) from
+            // Amsterdam: Validator uses pre-refund gas_metered = max(execution, state) from
             // processing
             .blockGasUsedValidator(BlockGasUsedValidator.AMSTERDAM)
             // EIP-7843: slotNumber is the last header field, so a header omitting it still

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -283,23 +283,24 @@ public class MainnetTransactionProcessor {
         eip2930WarmAddressList.add(miningBeneficiary);
       }
 
-      final long intrinsicRegularGas = gasCalculator.transactionIntrinsicRegularGas(transaction);
+      final long intrinsicExecutionGas =
+          gasCalculator.transactionIntrinsicExecutionGas(transaction);
       final var stateGasCalc = gasCalculator.stateGasCostCalculator();
 
       // EIP-2780 charges every state-dependent cost at the top frame, so the intrinsic is
-      // entirely regular gas and an unaffordable charge halts the frame rather than invalidating
+      // entirely execution gas and an unaffordable charge halts the frame rather than invalidating
       // the transaction. Checked before frame construction to reject at the intrinsic level.
-      if (transaction.getGasLimit() < intrinsicRegularGas) {
+      if (transaction.getGasLimit() < intrinsicExecutionGas) {
         LOG.trace(
             "Insufficient gas for intrinsic cost: gasLimit={}, intrinsic={}",
             transaction.getGasLimit(),
-            intrinsicRegularGas);
+            intrinsicExecutionGas);
         return TransactionProcessingResult.invalid(
             ValidationResult.invalid(
                 TransactionInvalidReason.INTRINSIC_GAS_EXCEEDS_GAS_LIMIT,
                 String.format(
                     "intrinsic gas cost %d exceeds gas limit %d",
-                    intrinsicRegularGas, transaction.getGasLimit())));
+                    intrinsicExecutionGas, transaction.getGasLimit())));
       }
 
       // Amsterdam charges authorizations at the top frame with no refund; pre-Amsterdam reserves
@@ -338,19 +339,20 @@ public class MainnetTransactionProcessor {
       final WorldUpdater frameWorldState =
           deferredDelegationUpdater != null ? deferredDelegationUpdater : worldState;
 
-      final long gasAvailable = transaction.getGasLimit() - intrinsicRegularGas;
+      final long gasAvailable = transaction.getGasLimit() - intrinsicExecutionGas;
       LOG.trace(
           "Gas available for execution {} = {} - {} (limit - intrinsic)",
           gasAvailable,
           transaction.getGasLimit(),
-          intrinsicRegularGas);
+          intrinsicExecutionGas);
 
-      // EIP-8037: regular gas is capped at TX_MAX_GAS_LIMIT, so anything bought above that cap can
+      // EIP-8037: execution gas is capped at TX_MAX_GAS_LIMIT, so anything bought above that cap
+      // can
       // only ever be spent as state gas and starts in the reservoir. Pre-Amsterdam the cap is
-      // Long.MAX_VALUE, leaving the whole budget regular.
-      final long regularBudget =
-          Math.max(0L, stateGasCalc.transactionRegularGasLimit() - intrinsicRegularGas);
-      final long initialGas = Math.min(regularBudget, gasAvailable);
+      // Long.MAX_VALUE, leaving the whole budget as execution gas.
+      final long executionBudget =
+          Math.max(0L, stateGasCalc.transactionExecutionGasLimit() - intrinsicExecutionGas);
+      final long initialGas = Math.min(executionBudget, gasAvailable);
       final long initialStateGasReservoir = gasAvailable - initialGas;
 
       final WorldUpdater worldUpdater = frameWorldState.updater();
@@ -454,24 +456,24 @@ public class MainnetTransactionProcessor {
       }
 
       // Under two-dimensional gas, tx.gasLimit may exceed TX_MAX_GAS_LIMIT to accommodate state
-      // gas, so the cap on regular gas has to be enforced separately here.
+      // gas, so the cap on execution gas has to be enforced separately here.
       final long totalRemaining =
           initialFrame.getRemainingGas() + initialFrame.getStateGasReservoir();
       final long totalConsumed = transaction.getGasLimit() - totalRemaining;
-      final long regularConsumed = totalConsumed - initialFrame.getStateGasUsed();
-      final boolean regularGasLimitExceeded =
-          regularConsumed > stateGasCalc.transactionRegularGasLimit();
-      if (regularGasLimitExceeded) {
+      final long executionConsumed = totalConsumed - initialFrame.getStateGasUsed();
+      final boolean executionGasLimitExceeded =
+          executionConsumed > stateGasCalc.transactionExecutionGasLimit();
+      if (executionGasLimitExceeded) {
         LOG.debug(
-            "Transaction {} regular gas {} exceeds TX_MAX_GAS_LIMIT {}, reverting",
+            "Transaction {} execution gas {} exceeds TX_MAX_GAS_LIMIT {}, reverting",
             transaction.getHash(),
-            regularConsumed,
-            stateGasCalc.transactionRegularGasLimit());
+            executionConsumed,
+            stateGasCalc.transactionExecutionGasLimit());
       }
 
       final boolean txSucceeded =
           initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS
-              && !regularGasLimitExceeded;
+              && !executionGasLimitExceeded;
 
       if (txSucceeded) {
         worldUpdater.commit();
@@ -492,18 +494,18 @@ public class MainnetTransactionProcessor {
               ValidationResult.invalid(
                   TransactionInvalidReason.EXECUTION_HALTED,
                   initialFrame.getExceptionalHaltReason().get().getDescription());
-        } else if (regularGasLimitExceeded) {
+        } else if (executionGasLimitExceeded) {
           validationResult =
               ValidationResult.invalid(
                   TransactionInvalidReason.EXECUTION_HALTED,
-                  "Regular gas consumption exceeds TX_MAX_GAS_LIMIT");
+                  "Execution gas consumption exceeds TX_MAX_GAS_LIMIT");
         }
         // EIP-8037: no leaf the creation or the value transfer would have added survives a failed
         // transaction, so their charges come back. Only what was actually charged: refilling a
         // charge that ran out of gas would inflate the reservoir and drive state gas negative.
         if (stateGasCalc.isActive()) {
           final boolean burnsAllGas =
-              initialFrame.getExceptionalHaltReason().isPresent() || regularGasLimitExceeded;
+              initialFrame.getExceptionalHaltReason().isPresent() || executionGasLimitExceeded;
           refundRolledBackStateGas(initialFrame, prepCharges.create(), burnsAllGas);
           refundRolledBackStateGas(initialFrame, prepCharges.recipient(), burnsAllGas);
           // The whole preparation shares one snapshot, so any charge running out of gas rolls the
@@ -525,7 +527,7 @@ public class MainnetTransactionProcessor {
       // Refund the sender by what we should and pay the miner fee (note that we're doing them one
       // after the other so that if it is the same account somehow, we end up with the right result)
       final long refundedGas =
-          regularGasLimitExceeded
+          executionGasLimitExceeded
               ? 0L
               : gasCalculator.calculateGasRefund(transaction, initialFrame, codeDelegationRefund);
       final Wei refundedWei = transactionGasPrice.multiply(refundedGas);
@@ -551,7 +553,7 @@ public class MainnetTransactionProcessor {
               .stateGasUsed(initialFrame.getStateGasUsed())
               .refundedGas(refundedGas)
               .floorCost(floorCost)
-              .regularGasLimitExceeded(regularGasLimitExceeded)
+              .executionGasLimitExceeded(executionGasLimitExceeded)
               .build()
               .calculate();
       final long stateGasUsed = gasResult.effectiveStateGas();
@@ -607,7 +609,7 @@ public class MainnetTransactionProcessor {
       }
 
       // For a failed transaction all selfDestructs must have been rolled back by the frame.
-      // Guard here as defense-in-depth: if any leak path (e.g. regularGasLimitExceeded) leaves
+      // Guard here as defense-in-depth: if any leak path (e.g. executionGasLimitExceeded) leaves
       // stale markers, we must not permanently delete accounts from the world state.
       final Set<Address> effectiveSelfDestructs =
           txSucceeded ? initialFrame.getSelfDestructs() : Set.of();
@@ -650,7 +652,7 @@ public class MainnetTransactionProcessor {
                 initialFrame.getOutputData(),
                 partialBlockAccessView,
                 validationResult);
-        successResult.setRegularGasUsedForBlock(gasResult.regularGas());
+        successResult.setExecutionGasUsedForBlock(gasResult.executionGas());
         return successResult;
       } else {
         if (initialFrame.getExceptionalHaltReason().isPresent()) {
@@ -675,7 +677,7 @@ public class MainnetTransactionProcessor {
                 initialFrame.getRevertReason(),
                 initialFrame.getExceptionalHaltReason(),
                 partialBlockAccessView);
-        failedResult.setRegularGasUsedForBlock(gasResult.regularGas());
+        failedResult.setExecutionGasUsedForBlock(gasResult.executionGas());
         return failedResult;
       }
     } catch (final MerkleTrieException re) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
@@ -258,7 +258,7 @@ public class MainnetTransactionValidator implements TransactionValidator {
             gasCalculator.transactionIntrinsicGasCost(transaction, baselineGas),
             gasCalculator.transactionFloorCost(transaction));
 
-    // EIP-8037: cap max(intrinsic_regular, calldata_floor) rather than tx.gas itself.
+    // EIP-8037: cap max(intrinsic_execution, calldata_floor) rather than tx.gas itself.
     final long intrinsicGasLimitCap = gasLimitCalculator.transactionIntrinsicGasLimitCap();
     if (!transactionValidationParams.isAllowExceedingGasLimit()
         && Long.compareUnsigned(intrinsicGasCostOrFloor, intrinsicGasLimitCap) > 0) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/OsakaTargetingGasLimitCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/OsakaTargetingGasLimitCalculator.java
@@ -31,7 +31,7 @@ public class OsakaTargetingGasLimitCalculator extends CancunTargetingGasLimitCal
   /**
    * The EIP-7825 transaction gas limit cap value (2^24). Through Osaka this caps {@code tx.gas}
    * itself; EIP-8037 (Amsterdam) repurposes the same value as the cap on {@code
-   * max(intrinsic_regular, calldata_floor)}. See {@link #transactionGasLimitCap()} and {@link
+   * max(intrinsic_execution, calldata_floor)}. See {@link #transactionGasLimitCap()} and {@link
    * #transactionIntrinsicGasLimitCap()}.
    */
   public static final long EIP_7825_TRANSACTION_GAS_LIMIT_CAP = 16_777_216L;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccounting.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccounting.java
@@ -38,13 +38,14 @@ public abstract class TransactionGasAccounting {
    * Result of the gas accounting calculation.
    *
    * @param effectiveStateGas the state gas dimension
-   * @param gasUsedByTransaction floored 2D gas (max(regular, floor) + state) for
+   * @param gasUsedByTransaction floored 2D gas (max(execution, floor) + state) for
    *     estimation/receipts
    * @param usedGas post-refund gas the sender pays
-   * @param regularGas the regular gas dimension for block accounting: max(execution - state, floor)
+   * @param executionGas the execution gas dimension for block accounting: max(consumed - state,
+   *     floor)
    */
   public record GasResult(
-      long effectiveStateGas, long gasUsedByTransaction, long usedGas, long regularGas) {}
+      long effectiveStateGas, long gasUsedByTransaction, long usedGas, long executionGas) {}
 
   /** The transaction gas limit. */
   public abstract long txGasLimit();
@@ -64,8 +65,8 @@ public abstract class TransactionGasAccounting {
   /** Transaction floor cost (EIP-7623), 0 for pre-Prague. */
   public abstract long floorCost();
 
-  /** Whether the regular gas limit was exceeded (EIP-8037). */
-  public abstract boolean regularGasLimitExceeded();
+  /** Whether the execution gas limit was exceeded (EIP-8037). */
+  public abstract boolean executionGasLimitExceeded();
 
   /** Creates a new builder. */
   public static ImmutableTransactionGasAccounting.Builder builder() {
@@ -76,10 +77,10 @@ public abstract class TransactionGasAccounting {
    * Calculate gas accounting for a completed transaction.
    *
    * @return the gas result containing effectiveStateGas, gasUsedByTransaction, usedGas and
-   *     regularGas
+   *     executionGas
    */
   public GasResult calculate() {
-    if (regularGasLimitExceeded()) {
+    if (executionGasLimitExceeded()) {
       return new GasResult(
           stateGasUsed(),
           txGasLimit(),
@@ -87,21 +88,21 @@ public abstract class TransactionGasAccounting {
           Math.max(txGasLimit() - stateGasUsed(), floorCost()));
     }
 
-    final long executionGas = txGasLimit() - remainingGas() - stateGasReservoir();
+    final long consumedGas = txGasLimit() - remainingGas() - stateGasReservoir();
     final long stateGas = stateGasUsed();
-    final long regularGas = executionGas - stateGas;
-    if (regularGas < 0) {
+    final long executionGas = consumedGas - stateGas;
+    if (executionGas < 0) {
       LOG.error(
-          "Negative regularGas={} (executionGas={}, stateGas={})",
-          regularGas,
+          "Negative executionGas={} (consumedGas={}, stateGas={})",
           executionGas,
+          consumedGas,
           stateGas);
     }
-    // EIP-8037: the floor binds the regular-gas dimension, and state gas is out of regularGas
+    // EIP-8037: the floor binds the execution-gas dimension, and state gas is out of executionGas
     // before the max is taken, so state spending cannot discount the floor.
-    final long flooredRegularGas = Math.max(regularGas, floorCost());
-    final long gasUsedByTransaction = flooredRegularGas + stateGas;
+    final long flooredExecutionGas = Math.max(executionGas, floorCost());
+    final long gasUsedByTransaction = flooredExecutionGas + stateGas;
     final long usedGas = txGasLimit() - refundedGas();
-    return new GasResult(stateGas, gasUsedByTransaction, usedGas, flooredRegularGas);
+    return new GasResult(stateGas, gasUsedByTransaction, usedGas, flooredExecutionGas);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/processing/TransactionProcessingResult.java
@@ -52,8 +52,8 @@ public class TransactionProcessingResult
 
   private final long stateGasUsed;
 
-  /** EIP-8037 block-accounting regular gas; {@link Long#MIN_VALUE} means "not set". */
-  private long regularGasUsedForBlock = Long.MIN_VALUE;
+  /** EIP-8037 block-accounting execution gas; {@link Long#MIN_VALUE} means "not set". */
+  private long executionGasUsedForBlock = Long.MIN_VALUE;
 
   private final List<Log> logs;
 
@@ -352,8 +352,8 @@ public class TransactionProcessingResult
    *
    * <p>This represents the gas consumed by state-creation operations (CREATE, SSTORE 0→nonzero,
    * CALL to new accounts, code deposits, EIP-7702 delegations). State gas is tracked separately
-   * from regular gas for multidimensional gas metering. EIP-7702 authorization refunds are already
-   * reflected in this value, so per-tx and block-level accounting use the same figure.
+   * from execution gas for multidimensional gas metering. EIP-7702 authorization refunds are
+   * already reflected in this value, so per-tx and block-level accounting use the same figure.
    *
    * @return the state gas used
    */
@@ -362,27 +362,27 @@ public class TransactionProcessingResult
   }
 
   /**
-   * Returns the regular gas dimension for EIP-8037 block accounting: {@code max(execution - state,
-   * calldata floor)}. State gas is out of the regular figure before the max is taken, so state
+   * Returns the execution gas dimension for EIP-8037 block accounting: {@code max(consumed - state,
+   * calldata floor)}. State gas is out of the execution figure before the max is taken, so state
    * spending cannot discount the floor. The fallback is equivalent while the floor is not binding.
    *
-   * @return the regular gas used for block accounting
+   * @return the execution gas used for block accounting
    */
-  public long getRegularGasUsedForBlock() {
-    return regularGasUsedForBlock == Long.MIN_VALUE
+  public long getExecutionGasUsedForBlock() {
+    return executionGasUsedForBlock == Long.MIN_VALUE
         ? estimateGasUsedByTransaction - stateGasUsed
-        : regularGasUsedForBlock;
+        : executionGasUsedForBlock;
   }
 
   /**
-   * Sets the regular gas dimension for EIP-8037 block accounting: {@code max(execution - state,
+   * Sets the execution gas dimension for EIP-8037 block accounting: {@code max(consumed - state,
    * calldata floor)}.
    *
-   * @param regularGasUsedForBlock the regular gas used for block accounting
+   * @param executionGasUsedForBlock the execution gas used for block accounting
    */
   @SuppressWarnings("checkstyle:HiddenField")
-  public void setRegularGasUsedForBlock(final long regularGasUsedForBlock) {
-    this.regularGasUsedForBlock = regularGasUsedForBlock;
+  public void setExecutionGasUsedForBlock(final long executionGasUsedForBlock) {
+    this.executionGasUsedForBlock = executionGasUsedForBlock;
   }
 
   /**

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorBalValidationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorBalValidationTest.java
@@ -101,7 +101,7 @@ class AbstractBlockProcessorBalValidationTest {
     lenient().when(gasCalculator.getBlobGasPerBlob()).thenReturn(1L);
     final StateGasCostCalculator stateGasCalc = mock(StateGasCostCalculator.class);
     lenient().when(gasCalculator.stateGasCostCalculator()).thenReturn(stateGasCalc);
-    lenient().when(stateGasCalc.transactionRegularGasLimit()).thenReturn(Long.MAX_VALUE);
+    lenient().when(stateGasCalc.transactionExecutionGasLimit()).thenReturn(Long.MAX_VALUE);
     lenient().when(protocolSpec.getWithdrawalsProcessor()).thenReturn(Optional.empty());
     lenient().when(protocolSpec.getRequestProcessorCoordinator()).thenReturn(Optional.empty());
     lenient()

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorTest.java
@@ -140,22 +140,22 @@ abstract class AbstractBlockProcessorTest {
     final GasCalculator gasCalculator = mock(GasCalculator.class);
     final StateGasCostCalculator stateGasCalc = mock(StateGasCostCalculator.class);
     when(gasCalculator.stateGasCostCalculator()).thenReturn(stateGasCalc);
-    when(stateGasCalc.transactionRegularGasLimit()).thenReturn(Long.MAX_VALUE);
+    when(stateGasCalc.transactionExecutionGasLimit()).thenReturn(Long.MAX_VALUE);
     when(protocolSpec.getGasCalculator()).thenReturn(gasCalculator);
 
-    // Regular=60k, State=40k. Per-dimension: worstCaseRegular = min(MAX, 50k) = 50k.
-    // regularAvailable = 100k - 60k = 40k. 50k > 40k → fails AMSTERDAM per-dimension check.
+    // Execution=60k, State=40k. Per-dimension: worstCaseExecution = min(MAX, 50k) = 50k.
+    // executionAvailable = 100k - 60k = 40k. 50k > 40k → fails AMSTERDAM per-dimension check.
     when(protocolSpec.getBlockGasAccountingStrategy())
         .thenReturn(BlockGasAccountingStrategy.AMSTERDAM);
     assertThat(blockProcessor.hasAvailableBlockBudget(header, tx, 60_000L, 40_000L, protocolSpec))
         .isFalse();
 
-    // txGasLimit=40k: worstCaseRegular=40k <= 40k, worstCaseState=40k <= 60k → passes AMSTERDAM.
+    // txGasLimit=40k: worstCaseExecution=40k <= 40k, worstCaseState=40k <= 60k → passes AMSTERDAM.
     when(tx.getGasLimit()).thenReturn(40_000L);
     assertThat(blockProcessor.hasAvailableBlockBudget(header, tx, 60_000L, 40_000L, protocolSpec))
         .isTrue();
 
-    // Same scenario with FRONTIER (1D check, only regular): 40k <= 100k-60k=40k → passes
+    // Same scenario with FRONTIER (1D check, only execution): 40k <= 100k-60k=40k → passes
     when(protocolSpec.getBlockGasAccountingStrategy())
         .thenReturn(BlockGasAccountingStrategy.FRONTIER);
     assertThat(blockProcessor.hasAvailableBlockBudget(header, tx, 60_000L, 40_000L, protocolSpec))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BlockGasAccountingStrategyTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  *
  * <ul>
  *   <li>Pre-Amsterdam (FRONTIER): Block gas = gasLimit - gasRemaining (post-refund)
- *   <li>Amsterdam: Block gas = pre-refund gas, split into regular and state dimensions
+ *   <li>Amsterdam: Block gas = pre-refund gas, split into execution and state dimensions
  * </ul>
  */
 public class BlockGasAccountingStrategyTest {
@@ -52,7 +52,7 @@ public class BlockGasAccountingStrategyTest {
 
     // Frontier strategy: gasLimit - gasRemaining = 100,000 - 30,000 = 70,000
     final long blockGas =
-        BlockGasAccountingStrategy.FRONTIER.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.FRONTIER.calculateTransactionExecutionGas(tx, result);
 
     assertThat(blockGas).isEqualTo(PRE_REFUND_GAS);
   }
@@ -67,10 +67,10 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(GAS_REMAINING);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(PRE_REFUND_GAS);
     when(result.getStateGasUsed()).thenReturn(0L);
-    when(result.getRegularGasUsedForBlock()).thenReturn(PRE_REFUND_GAS);
+    when(result.getExecutionGasUsedForBlock()).thenReturn(PRE_REFUND_GAS);
 
     final long blockGas =
-        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionExecutionGas(tx, result);
 
     assertThat(blockGas).isEqualTo(PRE_REFUND_GAS);
   }
@@ -92,14 +92,14 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(gasRemainingAfterRefund);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(preRefundGasUsed);
     when(result.getStateGasUsed()).thenReturn(0L);
-    when(result.getRegularGasUsedForBlock()).thenReturn(preRefundGasUsed);
+    when(result.getExecutionGasUsedForBlock()).thenReturn(preRefundGasUsed);
 
     // Frontier: 100,000 - 40,000 = 60,000 (benefits from refund)
     final long frontierGas =
-        BlockGasAccountingStrategy.FRONTIER.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.FRONTIER.calculateTransactionExecutionGas(tx, result);
     // Amsterdam: 70,000 (no refund benefit for block accounting)
     final long amsterdamGas =
-        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionExecutionGas(tx, result);
 
     assertThat(frontierGas).isEqualTo(60_000L);
     assertThat(amsterdamGas).isEqualTo(70_000L);
@@ -120,12 +120,12 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(gasRemaining);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(gasUsed);
     when(result.getStateGasUsed()).thenReturn(0L);
-    when(result.getRegularGasUsedForBlock()).thenReturn(gasUsed);
+    when(result.getExecutionGasUsedForBlock()).thenReturn(gasUsed);
 
     final long frontierGas =
-        BlockGasAccountingStrategy.FRONTIER.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.FRONTIER.calculateTransactionExecutionGas(tx, result);
     final long amsterdamGas =
-        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionExecutionGas(tx, result);
 
     assertThat(frontierGas).isEqualTo(gasUsed);
     assertThat(amsterdamGas).isEqualTo(gasUsed);
@@ -140,36 +140,36 @@ public class BlockGasAccountingStrategyTest {
     when(result.getGasRemaining()).thenReturn(GAS_REMAINING);
     when(result.getEstimateGasUsedByTransaction()).thenReturn(PRE_REFUND_GAS);
     when(result.getStateGasUsed()).thenReturn(10_000L);
-    when(result.getRegularGasUsedForBlock()).thenReturn(60_000L);
+    when(result.getExecutionGasUsedForBlock()).thenReturn(60_000L);
 
     final long blockGas =
-        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionRegularGas(tx, result);
+        BlockGasAccountingStrategy.AMSTERDAM.calculateTransactionExecutionGas(tx, result);
     assertThat(blockGas).isEqualTo(60_000L);
   }
 
   @Test
   public void amsterdamStrategy_effectiveGasUsedIsMaxOfDimensions() {
-    // max(regular=50k, state=80k) = 80k
+    // max(execution=50k, state=80k) = 80k
     assertThat(BlockGasAccountingStrategy.AMSTERDAM.effectiveGasUsed(50_000L, 80_000L))
         .isEqualTo(80_000L);
-    // max(regular=80k, state=50k) = 80k
+    // max(execution=80k, state=50k) = 80k
     assertThat(BlockGasAccountingStrategy.AMSTERDAM.effectiveGasUsed(80_000L, 50_000L))
         .isEqualTo(80_000L);
-    // Frontier always returns regular gas only
+    // Frontier always returns execution gas only
     assertThat(BlockGasAccountingStrategy.FRONTIER.effectiveGasUsed(50_000L, 80_000L))
         .isEqualTo(50_000L);
   }
 
   @Test
-  public void defaultStrategy_hasBlockCapacityChecksRegularGasOnly() {
+  public void defaultStrategy_hasBlockCapacityChecksExecutionGasOnly() {
     final long blockGasLimit = 100_000L;
-    // Regular used: 60k, remaining regular = 40k. The 1D (FRONTIER) check ignores state gas and
-    // the per-tx cap, looking only at the regular-gas headroom.
+    // Execution used: 60k, remaining execution = 40k. The 1D (FRONTIER) check ignores state gas and
+    // the per-tx cap, looking only at the execution-gas headroom.
     assertThat(
             BlockGasAccountingStrategy.FRONTIER.hasBlockCapacity(
                 40_000L, Long.MAX_VALUE, 60_000L, 0L, blockGasLimit))
         .isTrue();
-    // txGasLimit=40001 > remaining_regular=40k, exceeds regular capacity
+    // txGasLimit=40001 > remaining_execution=40k, exceeds execution capacity
     assertThat(
             BlockGasAccountingStrategy.FRONTIER.hasBlockCapacity(
                 40_001L, Long.MAX_VALUE, 60_000L, 0L, blockGasLimit))
@@ -179,7 +179,7 @@ public class BlockGasAccountingStrategyTest {
             BlockGasAccountingStrategy.FRONTIER.hasBlockCapacity(
                 40_000L, Long.MAX_VALUE, 60_000L, 90_000L, blockGasLimit))
         .isTrue();
-    // Over-committed regular gas caps remaining at zero, never negative.
+    // Over-committed execution gas caps remaining at zero, never negative.
     assertThat(
             BlockGasAccountingStrategy.FRONTIER.hasBlockCapacity(
                 1L, Long.MAX_VALUE, 120_000L, 0L, blockGasLimit))
@@ -190,26 +190,28 @@ public class BlockGasAccountingStrategyTest {
   public void amsterdamStrategy_hasBlockCapacityChecksBothDimensions() {
     final long blockGasLimit = 100_000L;
     final long txMaxGasLimit = Long.MAX_VALUE;
-    // Regular used 60k (40k left), state used 50k (50k left). Worst-case regular and state
+    // Execution used 60k (40k left), state used 50k (50k left). Worst-case execution and state
     // consumption both equal txGasLimit. txGasLimit=40k fits both dimensions.
     assertThat(
             BlockGasAccountingStrategy.AMSTERDAM.hasBlockCapacity(
                 40_000L, txMaxGasLimit, 60_000L, 50_000L, blockGasLimit))
         .isTrue();
-    // txGasLimit=40001 exceeds the 40k regular headroom.
+    // txGasLimit=40001 exceeds the 40k execution headroom.
     assertThat(
             BlockGasAccountingStrategy.AMSTERDAM.hasBlockCapacity(
                 40_001L, txMaxGasLimit, 60_000L, 50_000L, blockGasLimit))
         .isFalse();
-    // State dimension can be the binding constraint: regular headroom 90k, state headroom 30k,
-    // worst-case state = txGasLimit = 35k > 30k → rejected even though regular fits.
+    // State dimension can be the binding constraint: execution headroom 90k, state headroom 30k,
+    // worst-case state = txGasLimit = 35k > 30k → rejected even though execution fits.
     assertThat(
             BlockGasAccountingStrategy.AMSTERDAM.hasBlockCapacity(
                 35_000L, txMaxGasLimit, 10_000L, 70_000L, blockGasLimit))
         .isFalse();
-    // TX_MAX_GAS_LIMIT caps worst-case regular consumption: regular headroom 40k, txGasLimit 50k
+    // TX_MAX_GAS_LIMIT caps worst-case execution consumption: execution headroom 40k, txGasLimit
+    // 50k
     // but
-    // capped at txMaxGasLimit=40k so regular fits; state headroom 100k easily fits worst-case 50k.
+    // capped at txMaxGasLimit=40k so execution fits; state headroom 100k easily fits worst-case
+    // 50k.
     assertThat(
             BlockGasAccountingStrategy.AMSTERDAM.hasBlockCapacity(
                 50_000L, 40_000L, 60_000L, 0L, blockGasLimit))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/Eip8037GasLimitTest.java
@@ -112,16 +112,16 @@ class Eip8037GasLimitTest {
   void exceptionalHaltPreservesStateGasReservoirForRefund() {
     // EIP-8037: On exceptional halt of the initial frame, the state_gas_reservoir must be
     // preserved for transaction-level refund. This test simulates a child frame having refunded
-    // state gas to the parent's reservoir before the parent runs out of regular gas. The
+    // state gas to the parent's reservoir before the parent runs out of execution gas. The
     // refunded reservoir must not be lost: the total gas used should be
     // txGasLimit - preserved_reservoir, not the full txGasLimit.
     setupCommonMocks(20_000_000L);
 
     // txGasLimit=20M, intrinsic≈21k → gasAvailable≈19,979,000.
-    // regularBudget = TX_MAX_GAS_LIMIT (16,777,216) - intrinsic ≈ 16,756,216.
+    // executionBudget = TX_MAX_GAS_LIMIT (16,777,216) - intrinsic ≈ 16,756,216.
     // gas_left initial = 16,756,216; reservoir initial = 19,979,000 - 16,756,216 = 3,222,784.
     // We simulate: child SSTORE spilled 37,568 into child gas_left, then child halted and the
-    // spill was restored to the reservoir. The initial frame then runs out of regular gas.
+    // spill was restored to the reservoir. The initial frame then runs out of execution gas.
     final long childRefund = 37_568L;
 
     doAnswer(
@@ -129,7 +129,7 @@ class Eip8037GasLimitTest {
               final MessageFrame frame = invocation.getArgument(0);
               // Simulate a child frame halt having added state gas back to the reservoir.
               frame.incrementStateGasReservoir(childRefund);
-              // Now simulate the initial frame running out of regular gas.
+              // Now simulate the initial frame running out of execution gas.
               frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
               frame.setGasRemaining(0);
               frame.getMessageFrameStack().pop();
@@ -159,7 +159,7 @@ class Eip8037GasLimitTest {
   }
 
   @Test
-  void regularGasWithinTxMaxGasLimitSucceeds() {
+  void executionGasWithinTxMaxGasLimitSucceeds() {
     setupCommonMocks(20_000_000L);
 
     doAnswer(
@@ -167,7 +167,7 @@ class Eip8037GasLimitTest {
               final MessageFrame frame = invocation.getArgument(0);
               frame.setState(MessageFrame.State.COMPLETED_SUCCESS);
               // totalConsumed = 20M - 5M = 15M
-              // regularConsumed = 15M - 0 = 15M < TX_MAX_GAS_LIMIT (16,777,216) -> passes
+              // executionConsumed = 15M - 0 = 15M < TX_MAX_GAS_LIMIT (16,777,216) -> passes
               frame.setGasRemaining(5_000_000L);
               frame.getMessageFrameStack().pop();
               return null;
@@ -193,7 +193,7 @@ class Eip8037GasLimitTest {
   void exceptionalHaltShouldNotDeleteAccountsViaSelfDestructs() {
     // Regression test: a failed transaction once deleted the accounts its selfdestruct markers
     // named, wiping pre-existing accounts from world state. EXCEPTIONAL_HALT is the cheapest way
-    // to reach that failure branch — driving regular gas past TX_MAX_GAS_LIMIT reaches the same
+    // to reach that failure branch — driving execution gas past TX_MAX_GAS_LIMIT reaches the same
     // one.
     setupCommonMocks(20_000_000L);
 
@@ -232,7 +232,7 @@ class Eip8037GasLimitTest {
 
   @Test
   void stateGasCanPushTotalBeyondTxMaxGasLimitWithoutRevert() {
-    // Total gas > TX_MAX_GAS_LIMIT but regular gas portion is within limit
+    // Total gas > TX_MAX_GAS_LIMIT but execution gas portion is within limit
     setupCommonMocks(20_000_000L);
 
     doAnswer(
@@ -241,10 +241,10 @@ class Eip8037GasLimitTest {
               frame.setState(MessageFrame.State.COMPLETED_SUCCESS);
               // totalConsumed = 20M - 1M = 19M (exceeds TX_MAX_GAS_LIMIT)
               // stateGas = 5M
-              // regularConsumed = 19M - 5M = 14M < TX_MAX_GAS_LIMIT -> passes
+              // executionConsumed = 19M - 5M = 14M < TX_MAX_GAS_LIMIT -> passes
               frame.setGasRemaining(1_000_000L);
               // Simulate 5M of state gas consumed: seed the reservoir and draw it down so
-              // stateGasUsed reaches 5M without touching the 1M of regular gas left.
+              // stateGasUsed reaches 5M without touching the 1M of execution gas left.
               frame.setStateGasReservoir(5_000_000L);
               frame.consumeStateGas(5_000_000L);
               frame.getMessageFrameStack().pop();
@@ -264,7 +264,7 @@ class Eip8037GasLimitTest {
                 ImmutableTransactionValidationParams.builder().build(),
                 Wei.ZERO);
 
-    // Total gas exceeds TX_MAX_GAS_LIMIT but only regular gas is checked
+    // Total gas exceeds TX_MAX_GAS_LIMIT but only execution gas is checked
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStateGasUsed()).isEqualTo(5_000_000L);
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccountingTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TransactionGasAccountingTest.java
@@ -31,11 +31,11 @@ public class TransactionGasAccountingTest {
         .stateGasUsed(0L)
         .refundedGas(0L)
         .floorCost(0L)
-        .regularGasLimitExceeded(false);
+        .executionGasLimitExceeded(false);
   }
 
   @Test
-  public void normalPath_regularGasComputedCorrectly() {
+  public void normalPath_executionGasComputedCorrectly() {
     // Simple execution: 100k gas limit, 30k remaining, no reservoir, no state gas
     final var result =
         baseBuilder()
@@ -45,8 +45,8 @@ public class TransactionGasAccountingTest {
             .build()
             .calculate();
 
-    // executionGas = 100k - 30k - 0 = 70k
-    // stateGas = 0, regularGas = 70k
+    // consumedGas = 100k - 30k - 0 = 70k
+    // stateGas = 0, executionGas = 70k
     // gasUsedByTransaction = max(70k, 0) + 0 = 70k
     // usedGas = 100k - 5k = 95k
     assertThat(result.gasUsedByTransaction()).isEqualTo(70_000L);
@@ -66,8 +66,8 @@ public class TransactionGasAccountingTest {
             .build()
             .calculate();
 
-    // executionGas = 100k - 20k - 10k = 70k
-    // stateGas = 10k, regularGas = 70k - 10k = 60k
+    // consumedGas = 100k - 20k - 10k = 70k
+    // stateGas = 10k, executionGas = 70k - 10k = 60k
     // gasUsedByTransaction = max(60k, 0) + 10k = 70k
     // usedGas = 100k - 5k = 95k
     assertThat(result.gasUsedByTransaction()).isEqualTo(70_000L);
@@ -75,8 +75,8 @@ public class TransactionGasAccountingTest {
   }
 
   @Test
-  public void floorCostOverridesRegularGas() {
-    // Floor cost higher than actual regular gas
+  public void floorCostOverridesExecutionGas() {
+    // Floor cost higher than actual execution gas
     final var result =
         baseBuilder()
             .txGasLimit(100_000L)
@@ -85,8 +85,8 @@ public class TransactionGasAccountingTest {
             .build()
             .calculate();
 
-    // executionGas = 100k - 60k - 0 = 40k
-    // regularGas = 40k, floorCost = 50k -> max(40k, 50k) = 50k
+    // consumedGas = 100k - 60k - 0 = 40k
+    // executionGas = 40k, floorCost = 50k -> max(40k, 50k) = 50k
     // gasUsedByTransaction = 50k + 0 = 50k
     assertThat(result.gasUsedByTransaction()).isEqualTo(50_000L);
     assertThat(result.usedGas()).isEqualTo(100_000L);
@@ -102,8 +102,8 @@ public class TransactionGasAccountingTest {
             .build()
             .calculate();
 
-    // executionGas = 100k - 40k = 60k
-    // regularGas = 60k, gasUsedByTransaction = 60k, usedGas = 100k - 10k = 90k
+    // consumedGas = 100k - 40k = 60k
+    // executionGas = 60k, gasUsedByTransaction = 60k, usedGas = 100k - 10k = 90k
     assertThat(result.gasUsedByTransaction()).isEqualTo(60_000L);
     assertThat(result.usedGas()).isEqualTo(90_000L);
   }

--- a/ethereum/referencetests/src/main/resources/block-exception-mapping.json
+++ b/ethereum/referencetests/src/main/resources/block-exception-mapping.json
@@ -85,8 +85,8 @@
     "TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM":            "transaction invalid Transaction gas limit must be at most \\d+",
     "TransactionException.INITCODE_SIZE_EXCEEDED":               "transaction invalid Initcode size of \\d+ exceeds maximum size of \\d+",
     "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS":           "transaction invalid transaction up-front cost 0x[0-9a-f]+ exceeds transaction sender account balance 0x[0-9a-f]+|Header validation failed \\(LIGHT\\)",
-    "TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST":  "transaction invalid intrinsic gas cost \\d+( \\(regular \\d+ \\+ state \\d+\\))? exceeds gas limit \\d+",
-    "TransactionException.INTRINSIC_GAS_TOO_LOW":                "transaction invalid intrinsic gas cost \\d+( \\(regular \\d+ \\+ state \\d+\\))? exceeds gas limit \\d+",
+    "TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST":  "transaction invalid intrinsic gas cost \\d+( \\(execution \\d+ \\+ state \\d+\\))? exceeds gas limit \\d+",
+    "TransactionException.INTRINSIC_GAS_TOO_LOW":                "transaction invalid intrinsic gas cost \\d+( \\(execution \\d+ \\+ state \\d+\\))? exceeds gas limit \\d+",
 
     "_comment_tx_nonce": "Transaction nonce errors",
     "TransactionException.NONCE_MISMATCH_TOO_HIGH":              "transaction invalid transaction nonce \\d+ does not match sender account nonce \\d+",

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/TxValues.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/TxValues.java
@@ -290,7 +290,7 @@ public class TxValues {
   }
 
   /**
-   * Returns the accumulated regular-gas refund counter.
+   * Returns the accumulated execution-gas refund counter.
    *
    * @return the gas refunds
    */

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculator.java
@@ -33,9 +33,9 @@ import org.apache.tuweni.units.bigints.UInt256;
  * Gas Calculator for Amsterdam hard fork.
  *
  * <p>Introduces EIP-8037 multidimensional gas metering with state gas costs that depend on the
- * block gas limit. All state-creation costs that were previously charged as regular gas are split:
- * the state portion is charged as state gas (drawn from the reservoir), while the regular portion
- * is reduced.
+ * block gas limit. All state-creation costs that were previously charged as execution gas are
+ * split: the state portion is charged as state gas (drawn from the reservoir), while the execution
+ * portion is reduced.
  *
  * <UL>
  *   <LI>EIP-8038: state-access gas repricing (cold access, account/storage write, CALL value,
@@ -95,7 +95,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
       (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800L / 5000L;
 
   /**
-   * Regular-gas state-access cost for {@code CREATE}/{@code CREATE2}: {@code ACCOUNT_WRITE +
+   * Execution-gas state-access cost for {@code CREATE}/{@code CREATE2}: {@code ACCOUNT_WRITE +
    * COLD_ACCOUNT_ACCESS}. The new-account state creation cost is charged separately as state gas
    * (see {@link Eip8037StateGasCostCalculator}).
    */
@@ -125,12 +125,12 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
   private static final long TX_VALUE_COST = 6_000L;
 
   /**
-   * EIP-2780: state-independent regular gas per EIP-7702 authorization, charged in intrinsic gas:
+   * EIP-2780: state-independent execution gas per EIP-7702 authorization, charged in intrinsic gas:
    * AUTH_TUPLE_BYTES(101) * TX_DATA_TOKEN_FLOOR(16) + ECRECOVER(3000) + COLD_ACCOUNT_ACCESS(3000) +
    * 2 * WARM_ACCESS(100) = 7,816. The state-dependent {@link #ACCOUNT_WRITE} is charged at the top
    * frame instead.
    */
-  private static final long REGULAR_PER_AUTH_BASE_COST =
+  private static final long EXECUTION_PER_AUTH_BASE_COST =
       101L * 16L + 3_000L + COLD_ACCOUNT_ACCESS + 2L * 100L;
 
   /** EIP-3860 init code word cost (2 gas per 32-byte word), charged in intrinsic for creations. */
@@ -189,10 +189,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
         transaction.getAccessList().map(AmsterdamGasCalculator::accessListBytes).orElse(0L);
     // EIP-3120: anchoring on the decomposed EIP-2780 base rather than TX_BASE alone keeps the
     // floor from undercutting the transaction's own intrinsic base.
-    final long baseRegularGas =
-        clampedAdd(getMinimumTransactionCost(), baseRecipientRegularGas(transaction));
+    final long baseExecutionGas =
+        clampedAdd(getMinimumTransactionCost(), baseRecipientExecutionGas(transaction));
     return clampedAdd(
-        baseRegularGas,
+        baseExecutionGas,
         clampedMultiply(clampedAdd(calldataBytes, accessListBytes), TOTAL_COST_FLOOR_PER_BYTE));
   }
 
@@ -219,10 +219,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long transactionIntrinsicGasCost(final Transaction transaction, final long baselineGas) {
-    // EIP-2780: regular intrinsic gas =
-    //   TX_BASE + data_cost + recipient_regular + access_list_cost + auth_regular
-    // where baselineGas already carries access_list_cost + auth_regular (accessListGasCost +
-    // delegateCodeGasCost from transactionIntrinsicRegularGas).
+    // EIP-2780: intrinsic execution gas =
+    //   TX_BASE + data_cost + recipient_execution + access_list_cost + auth_execution
+    // where baselineGas already carries access_list_cost + auth_execution (accessListGasCost +
+    // delegateCodeGasCost from transactionIntrinsicExecutionGas).
     final int payloadSize = transaction.getPayload().size();
     final long zeroBytes = transaction.getPayloadZeroBytes();
     final long nonZeroBytes = payloadSize - zeroBytes;
@@ -230,21 +230,21 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
     final long tokens = clampedAdd(zeroBytes, nonZeroBytes * 4L);
     final long dataCost = tokens * TX_DATA_TOKEN_STANDARD;
 
-    // EIP-3860 init code is added here rather than inside baseRecipientRegularGas() because it is
+    // EIP-3860 init code is added here rather than inside baseRecipientExecutionGas() because it is
     // not part of the EIP-3120 floor anchor.
-    final long recipientRegular =
-        baseRecipientRegularGas(transaction)
+    final long recipientExecution =
+        baseRecipientExecutionGas(transaction)
             + (transaction.isContractCreation() ? initCodeCost(payloadSize) : 0L);
 
-    return clampedAdd(clampedAdd(TX_BASE, dataCost), clampedAdd(recipientRegular, baselineGas));
+    return clampedAdd(clampedAdd(TX_BASE, dataCost), clampedAdd(recipientExecution, baselineGas));
   }
 
   /**
-   * EIP-2780/EIP-3120: the recipient's share of the regular-gas intrinsic base — its access and
+   * EIP-2780/EIP-3120: the recipient's share of the execution-gas intrinsic base — its access and
    * value primitives, nothing else. Shared with the calldata floor, which anchors on it so it
    * cannot undercut the transaction's own intrinsic base.
    */
-  private static long baseRecipientRegularGas(final Transaction transaction) {
+  private static long baseRecipientExecutionGas(final Transaction transaction) {
     if (transaction.isContractCreation()) {
       // CREATE_ACCESS covers the recipient balance write, and the EIP-7708 transfer log is now
       // folded into TX_VALUE_COST rather than charged on its own, so a creation costs the same
@@ -329,7 +329,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
 
   @Override
   public long txCreateCost() {
-    // EIP-8038: regular gas only; the new-account creation cost is charged as state gas.
+    // EIP-8038: execution gas only; the new-account creation cost is charged as state gas.
     return TX_CREATE_COST;
   }
 
@@ -366,10 +366,10 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
       final UInt256 newValue,
       final Supplier<UInt256> currentValue,
       final Supplier<UInt256> originalValue) {
-    // Regular gas only: the warm access base is always charged, plus a flat STORAGE_WRITE on the
+    // Execution gas only: the warm access base is always charged, plus a flat STORAGE_WRITE on the
     // first change to the slot this transaction (its current value still equals the original).
     // Dirty re-writes and no-ops pay the access base only. The set-from-zero surcharge is state
-    // gas, not regular. (originalValue is only read when the value actually changes.)
+    // gas, not execution gas. (originalValue is only read when the value actually changes.)
     final UInt256 localCurrentValue = currentValue.get();
     final boolean firstChange =
         !localCurrentValue.equals(newValue) && originalValue.get().equals(localCurrentValue);
@@ -401,7 +401,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
     // EIP-2780: only the state-independent part is intrinsic. ACCOUNT_WRITE, NEW_ACCOUNT and
     // AUTH_BASE are charged at the top frame against the authority's pre-transaction state, so
     // nothing worst-case is reserved and there is no refund to override.
-    return REGULAR_PER_AUTH_BASE_COST * delegateCodeListLength;
+    return EXECUTION_PER_AUTH_BASE_COST * delegateCodeListLength;
   }
 
   @Override
@@ -425,7 +425,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
         getSelfDestructRefundAmount() * initialFrame.getSelfDestructs().size();
     final long executionRefund =
         initialFrame.getGasRefund() + selfDestructRefund + codeDelegationRefund;
-    // 1/5 cap on total consumed gas (regular + state)
+    // 1/5 cap on total consumed gas (execution + state)
     final long maxRefundAllowance = totalConsumed / getMaxRefundQuotient();
     final long refundAllowance = Math.min(executionRefund, maxRefundAllowance);
 
@@ -439,7 +439,7 @@ public class AmsterdamGasCalculator extends OsakaGasCalculator {
       final UInt256 newValue,
       final Supplier<UInt256> currentValue,
       final Supplier<UInt256> originalValue) {
-    // Regular-gas refunds (credited to the refund counter): the storage-clear refund is granted
+    // Execution-gas refunds (credited to the refund counter): the storage-clear refund is granted
     // when a slot is first cleared and reversed if that clear is later undone, and the flat
     // STORAGE_WRITE is refunded when the slot ends up back at its original value. There is no
     // per-set/reset distinction.

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculator.java
@@ -29,23 +29,23 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
   static final int STATE_BYTES_PER_AUTH = 23;
 
   /**
-   * Regular gas for storage set (GAS_STORAGE_UPDATE - GAS_COLD_SLOAD = 5000 - 2100 = 2900). The
+   * Execution gas for storage set (GAS_STORAGE_UPDATE - GAS_COLD_SLOAD = 5000 - 2100 = 2900). The
    * state portion ({@code STATE_BYTES_PER_STORAGE_SLOT * cpsb}) is charged separately.
    */
-  static final long STORAGE_SET_REGULAR_GAS = 2_900L;
+  static final long STORAGE_SET_EXECUTION_GAS = 2_900L;
 
   /**
-   * Regular gas for EIP-7702 auth base (calldata + ecrecover + cold access + warm write ≈ 7500).
+   * Execution gas for EIP-7702 auth base (calldata + ecrecover + cold access + warm write ≈ 7500).
    * The state portion ({@code STATE_BYTES_PER_AUTH * cpsb}) is charged separately.
    */
-  static final long AUTH_BASE_REGULAR_GAS = 7_500L;
+  static final long AUTH_BASE_EXECUTION_GAS = 7_500L;
 
   /** Keccak256 word gas cost for code deposit hashing. */
   static final long KECCAK256_WORD_GAS_COST = 6L;
 
   /**
-   * The mainnet transaction gas limit cap from EIP-7825 (2^24), enforced at runtime on regular gas.
-   * Mirrors {@code OsakaTargetingGasLimitCalculator.EIP_7825_TRANSACTION_GAS_LIMIT_CAP} in the
+   * The mainnet transaction gas limit cap from EIP-7825 (2^24), enforced at runtime on execution
+   * gas. Mirrors {@code OsakaTargetingGasLimitCalculator.EIP_7825_TRANSACTION_GAS_LIMIT_CAP} in the
    * ethereum/core module; the value is duplicated here because the evm module cannot depend on
    * ethereum/core. Keep the two in sync.
    */
@@ -93,8 +93,8 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
   }
 
   @Override
-  public long authBaseRegularGas() {
-    return AUTH_BASE_REGULAR_GAS;
+  public long authBaseExecutionGas() {
+    return AUTH_BASE_EXECUTION_GAS;
   }
 
   @Override
@@ -103,7 +103,7 @@ public class Eip8037StateGasCostCalculator implements StateGasCostCalculator {
   }
 
   @Override
-  public long transactionRegularGasLimit() {
+  public long transactionExecutionGasLimit() {
     return TX_MAX_GAS_LIMIT;
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -463,16 +463,16 @@ public interface GasCalculator {
       UInt256 newValue, Supplier<UInt256> currentValue, Supplier<UInt256> originalValue);
 
   /**
-   * Returns the regular-gas cost of an SSTORE, i.e. the portion charged as regular gas (as opposed
-   * to state gas). Through Osaka this is the whole SSTORE cost, so it delegates to {@link
-   * #calculateStorageCost}. EIP-8038 (Amsterdam) splits the cost into regular and state gas and
-   * overrides this to return only the regular portion; a future fork that moves the remaining
-   * regular portion to state gas can zero it out.
+   * Returns the execution-gas cost of an SSTORE, i.e. the portion charged as execution gas (as
+   * opposed to state gas). Through Osaka this is the whole SSTORE cost, so it delegates to {@link
+   * #calculateStorageCost}. EIP-8038 (Amsterdam) splits the cost into execution and state gas and
+   * overrides this to return only the execution portion; a future fork that moves the remaining
+   * execution portion to state gas can zero it out.
    *
    * @param newValue the new value to be stored
    * @param currentValue the supplier of the current value
    * @param originalValue the supplier of the original value
-   * @return the regular-gas cost for the SSTORE operation
+   * @return the execution-gas cost for the SSTORE operation
    */
   default long slotAccessCost(
       final UInt256 newValue,
@@ -529,11 +529,11 @@ public interface GasCalculator {
   }
 
   /**
-   * Returns the regular gas charged for the first write to an account leaf (EIP-2780
+   * Returns the execution gas charged for the first write to an account leaf (EIP-2780
    * ACCOUNT_WRITE), used for the top-frame EIP-7702 authorization charge. Zero for forks without
    * state-gas metering.
    *
-   * @return the ACCOUNT_WRITE regular gas cost
+   * @return the ACCOUNT_WRITE execution gas cost
    */
   default long getAccountWriteGasCost() {
     return 0L;
@@ -589,18 +589,18 @@ public interface GasCalculator {
   long transactionIntrinsicGasCost(Transaction transaction, long baselineGas);
 
   /**
-   * Returns the regular-dimension intrinsic gas cost of a transaction, including the gas for its
+   * Returns the execution-dimension intrinsic gas cost of a transaction, including the gas for its
    * access list and EIP-7702 code-delegation authorizations.
    *
    * <p>This is the single entry point for callers that have a {@link Transaction} and want the full
-   * regular intrinsic cost: it derives the access-list and code-delegation baseline internally and
-   * delegates to {@link #transactionIntrinsicGasCost(Transaction, long)}, so the summing lives in
-   * one place rather than at every call site.
+   * intrinsic execution cost: it derives the access-list and code-delegation baseline internally
+   * and delegates to {@link #transactionIntrinsicGasCost(Transaction, long)}, so the summing lives
+   * in one place rather than at every call site.
    *
    * @param transaction the transaction
-   * @return the transaction's regular intrinsic gas cost
+   * @return the transaction's intrinsic execution gas cost
    */
-  default long transactionIntrinsicRegularGas(final Transaction transaction) {
+  default long transactionIntrinsicExecutionGas(final Transaction transaction) {
     final long accessListGas = accessListGasCost(transaction.getAccessList().orElse(List.of()));
     final long codeDelegationGas = delegateCodeGasCost(transaction.codeDelegationListSize());
     return transactionIntrinsicGasCost(transaction, clampedAdd(accessListGas, codeDelegationGas));

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/StateGasCostCalculator.java
@@ -17,10 +17,11 @@ package org.hyperledger.besu.evm.gascalculator;
 /**
  * Strategy interface for EIP-8037 state-creation gas cost calculations.
  *
- * <p>EIP-8037 introduces multidimensional gas metering, splitting gas into regular gas and state
+ * <p>EIP-8037 introduces multidimensional gas metering, splitting gas into execution gas and state
  * gas. State-creation operations (CREATE, SSTORE 0→nonzero, CALL to new accounts, code deposits,
- * EIP-7702 delegations) have their costs split into a regular gas portion and a state gas portion,
- * where state gas depends on a fixed {@code cost_per_state_byte} (cpsb) for the active fork.
+ * EIP-7702 delegations) have their costs split into an execution gas portion and a state gas
+ * portion, where state gas depends on a fixed {@code cost_per_state_byte} (cpsb) for the active
+ * fork.
  *
  * <p>This interface is intentionally a pure cost calculator: it returns gas amounts only. Charging
  * (and refunding) is the responsibility of the operation or transaction processor that issues the
@@ -53,10 +54,10 @@ public interface StateGasCostCalculator {
   long codeDepositStateGas(int codeSize);
 
   /**
-   * Returns the regular gas for code deposit hashing (6 * ceil(codeSize/32)).
+   * Returns the execution gas for code deposit hashing (6 * ceil(codeSize/32)).
    *
    * @param codeSize the size of the code in bytes
-   * @return the regular gas for code deposit hashing
+   * @return the execution gas for code deposit hashing
    */
   long codeDepositHashGas(int codeSize);
 
@@ -82,11 +83,11 @@ public interface StateGasCostCalculator {
   long authBaseStateGas();
 
   /**
-   * Returns the regular gas for EIP-7702 auth base.
+   * Returns the execution gas for EIP-7702 auth base.
    *
-   * @return the regular gas for auth base
+   * @return the execution gas for auth base
    */
-  long authBaseRegularGas();
+  long authBaseExecutionGas();
 
   /**
    * Returns the state gas for empty account delegation (120 * cpsb).
@@ -96,13 +97,13 @@ public interface StateGasCostCalculator {
   long emptyAccountDelegationStateGas();
 
   /**
-   * Returns the maximum regular gas allowed per transaction (TX_MAX_GAS_LIMIT from EIP-7825).
-   * EIP-8037 changes this from a validation condition to a runtime revert condition on regular gas
-   * only. Returns {@code Long.MAX_VALUE} when state gas metering is not active.
+   * Returns the maximum execution gas allowed per transaction (TX_MAX_GAS_LIMIT from EIP-7825).
+   * EIP-8037 changes this from a validation condition to a runtime revert condition on execution
+   * gas only. Returns {@code Long.MAX_VALUE} when state gas metering is not active.
    *
-   * @return the maximum regular gas per transaction
+   * @return the maximum execution gas per transaction
    */
-  long transactionRegularGasLimit();
+  long transactionExecutionGasLimit();
 
   /**
    * Returns whether multidimensional gas metering (EIP-8037) is active.
@@ -152,7 +153,7 @@ public interface StateGasCostCalculator {
         }
 
         @Override
-        public long authBaseRegularGas() {
+        public long authBaseExecutionGas() {
           return 0L;
         }
 
@@ -162,7 +163,7 @@ public interface StateGasCostCalculator {
         }
 
         @Override
-        public long transactionRegularGasLimit() {
+        public long transactionExecutionGasLimit() {
           return Long.MAX_VALUE;
         }
       };

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -134,7 +134,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
       targetExists = existingTarget != null && !existingTarget.isEmpty();
     }
 
-    // EIP-8037: regular gas is deducted before state gas is charged (ordering requirement).
+    // EIP-8037: execution gas is deducted before state gas is charged (ordering requirement).
     frame.decrementRemainingGas(cost);
     if (!targetExists && !frame.consumeStateGas(stateGasCalc.newContractStateGas())) {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -114,8 +114,8 @@ public class SStoreOperation extends AbstractOperation {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
-    // EIP-8037: Deduct regular gas before charging state gas (ordering requirement).
-    // State gas draws from the reservoir first, then from gasRemaining; deducting regular
+    // EIP-8037: Deduct execution gas before charging state gas (ordering requirement).
+    // State gas draws from the reservoir first, then from gasRemaining; deducting execution
     // gas first ensures the reservoir/gasRemaining split is correct.
     frame.decrementRemainingGas(cost);
 
@@ -148,7 +148,7 @@ public class SStoreOperation extends AbstractOperation {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
-    // Add regular gas back — the EVM loop will deduct it via the OperationResult.
+    // Add execution gas back — the EVM loop will deduct it via the OperationResult.
     frame.incrementRemainingGas(cost);
 
     account.setStorageValue(key, newValue);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
@@ -103,7 +103,7 @@ public class SelfDestructOperation extends AbstractOperation {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
-    // EIP-8037: Deduct regular gas before charging state gas (ordering requirement).
+    // EIP-8037: Deduct execution gas before charging state gas (ordering requirement).
     frame.decrementRemainingGas(cost);
 
     // EIP-8037: Charge state gas when SELFDESTRUCT forces creation of an empty beneficiary.
@@ -113,7 +113,7 @@ public class SelfDestructOperation extends AbstractOperation {
       return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
     }
 
-    // Add regular gas back — the EVM loop will deduct it via the OperationResult.
+    // Add execution gas back — the EVM loop will deduct it via the OperationResult.
     frame.incrementRemainingGas(cost);
 
     // We passed preliminary checks, get mutable accounts.

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
@@ -192,7 +192,7 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
       return;
     }
 
-    // Check and charge code deposit gas (regular gas) before state gas
+    // Check and charge code deposit gas (execution gas) before state gas
     final long depositFee = evm.getGasCalculator().codeDepositGasCost(contractCode.size());
     if (frame.getRemainingGas() < depositFee) {
       LOG.trace(

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/AmsterdamGasCalculatorTest.java
@@ -54,7 +54,7 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void transactionFloorCostShouldBeAtLeastTransactionBaseCost() {
-    // EIP-3120: the floor is anchored on the decomposed EIP-2780 regular base, which for a
+    // EIP-3120: the floor is anchored on the decomposed EIP-2780 execution base, which for a
     // zero-value simple call is TX_BASE (12000) + COLD_ACCOUNT_ACCESS (3000) = 15000.
     assertThat(amsterdamGasCalculator.transactionFloorCost(callWith(Bytes.EMPTY, List.of())))
         .isEqualTo(15000L);
@@ -94,7 +94,7 @@ class AmsterdamGasCalculatorTest {
 
   @Test
   void eip8038CreateAccessGasCost() {
-    // EIP-8038: CREATE/CREATE2 regular-gas cost = CREATE_ACCESS = ACCOUNT_WRITE (9,000)
+    // EIP-8038: CREATE/CREATE2 execution-gas cost = CREATE_ACCESS = ACCOUNT_WRITE (9,000)
     // + COLD_ACCOUNT_ACCESS (3,000) = 12,000.
     assertThat(amsterdamGasCalculator.txCreateCost()).isEqualTo(12_000L);
   }
@@ -127,13 +127,13 @@ class AmsterdamGasCalculatorTest {
   }
 
   /**
-   * The "Transaction reference cases" table of EIP-2780, intrinsic (regular) column. Rows that
+   * The "Transaction reference cases" table of EIP-2780, intrinsic (execution) column. Rows that
    * differ only in their runtime charges collapse to the same intrinsic cost — they are listed
    * separately anyway so the table can be read against the EIP row by row.
    */
   static Stream<Arguments> eip2780ReferenceCases() {
     return Stream.of(
-        // description, to, value, expected intrinsic regular gas
+        // description, to, value, expected intrinsic execution gas
         Arguments.of("self-transfer", SENDER, Wei.ONE, 12_000L),
         Arguments.of("no-transfer to EOA", RECIPIENT, Wei.ZERO, 15_000L),
         Arguments.of("no-transfer to contract", RECIPIENT, Wei.ZERO, 15_000L),
@@ -155,7 +155,7 @@ class AmsterdamGasCalculatorTest {
   void eip2780IntrinsicGasMatchesReferenceCases(
       final String description, final Address to, final Wei value, final long expected) {
     final Transaction tx = transactionWith(to, value, Bytes.EMPTY, 0);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(expected);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicExecutionGas(tx)).isEqualTo(expected);
   }
 
   @Test
@@ -164,7 +164,7 @@ class AmsterdamGasCalculatorTest {
     // (3 + 8) * 4 = 44, on top of the 15,000 for a zero-value call to another account.
     final Transaction tx =
         transactionWith(RECIPIENT, Wei.ZERO, Bytes.fromHexString("0x0000000102"), 0);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(15_044L);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicExecutionGas(tx)).isEqualTo(15_044L);
   }
 
   @Test
@@ -172,19 +172,19 @@ class AmsterdamGasCalculatorTest {
     // Creation of a 33-byte init code: 24,000 + CODE_INIT_PER_WORD (2) * ceil(33/32) = 24,004.
     // All non-zero bytes, so data_cost = 33 * 4 * 4 = 528.
     final Transaction tx = transactionWith(null, Wei.ZERO, Bytes.repeat((byte) 0x1, 33), 0);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(24_532L);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicExecutionGas(tx)).isEqualTo(24_532L);
   }
 
   @Test
   void eip2780AuthorizationIntrinsicChargesOnlyTheStateIndependentBase() {
-    // EIP-2780: the intrinsic charges only REGULAR_PER_AUTH_BASE_COST (7,816) per authorization;
+    // EIP-2780: the intrinsic charges only EXECUTION_PER_AUTH_BASE_COST (7,816) per authorization;
     // ACCOUNT_WRITE is charged at the top frame on the authority's pre-state.
     assertThat(amsterdamGasCalculator.delegateCodeGasCost(1)).isEqualTo(7_816L);
     assertThat(amsterdamGasCalculator.delegateCodeGasCost(3)).isEqualTo(23_448L);
 
     // A zero-value 7702 transaction with one authorization: 15,000 + 7,816 = 22,816.
     final Transaction tx = transactionWith(RECIPIENT, Wei.ZERO, Bytes.EMPTY, 1);
-    assertThat(amsterdamGasCalculator.transactionIntrinsicRegularGas(tx)).isEqualTo(22_816L);
+    assertThat(amsterdamGasCalculator.transactionIntrinsicExecutionGas(tx)).isEqualTo(22_816L);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/Eip8037StateGasCostCalculatorTest.java
@@ -73,9 +73,9 @@ class Eip8037StateGasCostCalculatorTest {
   }
 
   @Test
-  void constantRegularGasCosts() {
-    assertThat(calculator.authBaseRegularGas()).isEqualTo(7_500L);
-    assertThat(calculator.transactionRegularGasLimit()).isEqualTo(16_777_216L);
+  void constantExecutionGasCosts() {
+    assertThat(calculator.authBaseExecutionGas()).isEqualTo(7_500L);
+    assertThat(calculator.transactionExecutionGasLimit()).isEqualTo(16_777_216L);
   }
 
   @Test
@@ -89,7 +89,7 @@ class Eip8037StateGasCostCalculatorTest {
     assertThat(none.newAccountStateGas()).isEqualTo(0L);
     assertThat(none.authBaseStateGas()).isEqualTo(0L);
     assertThat(none.emptyAccountDelegationStateGas()).isEqualTo(0L);
-    assertThat(none.authBaseRegularGas()).isEqualTo(0L);
-    assertThat(none.transactionRegularGasLimit()).isEqualTo(Long.MAX_VALUE);
+    assertThat(none.authBaseExecutionGas()).isEqualTo(0L);
+    assertThat(none.transactionExecutionGasLimit()).isEqualTo(Long.MAX_VALUE);
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
@@ -222,7 +222,7 @@ class SStoreOperationTest {
 
     // EIP-8037: state gas refund is credited directly to
     // state_gas_reservoir (not refund_counter, bypassing the 20% cap) and stateGasUsed is
-    // decremented. EIP-8038: the regular refund for 0→X→0 is the flat STORAGE_WRITE (10,000)
+    // decremented. EIP-8038: the execution-gas refund for 0→X→0 is the flat STORAGE_WRITE (10,000)
     // charged on the first change, refunded when the slot is restored to its original (zero) value;
     // it still goes via refund_counter.
     assertThat(frame.getGasRefund()).isEqualTo(10_000L);
@@ -297,7 +297,7 @@ class SStoreOperationTest {
             .address(address)
             .worldUpdater(txUpdater)
             .blockValues(new FakeBlockValues(1337))
-            // EIP-8038: the regular SSTORE cost for a cold 0->nonzero set is now 13,000
+            // EIP-8038: the execution-gas SSTORE cost for a cold 0->nonzero set is now 13,000
             // (2,900 cold access + 100 warm base + 10,000 STORAGE_WRITE), up from 5,000. The frame
             // must retain enough gas after that deduction to absorb the state-gas spill
             // (97,920 - 10,000 = 87,920), so initialGas is raised accordingly.
@@ -309,7 +309,7 @@ class SStoreOperationTest {
     final long gasBeforeSstore = frame.getRemainingGas();
 
     // SSTORE 0 -> nonzero: state gas demand exceeds the 10k reservoir, the excess must spill to
-    // regular gas.
+    // execution gas.
     frame.pushStackItem(UInt256.valueOf(42));
     frame.pushStackItem(UInt256.ONE);
     final OperationResult result = operation.execute(frame, null);
@@ -322,7 +322,7 @@ class SStoreOperationTest {
     assertThat(frame.getStateGasReservoir()).isEqualTo(0L);
     // Total state gas consumed
     assertThat(frame.getStateGasUsed()).isEqualTo(expectedStateGas);
-    // gasRemaining decreased by the spill amount only (regular SSTORE cost is deducted by the
+    // gasRemaining decreased by the spill amount only (execution-gas SSTORE cost is deducted by the
     // EVM after execute returns, not by the operation itself)
     final long expectedRemainingGas = gasBeforeSstore - expectedSpill;
     assertThat(frame.getRemainingGas()).isEqualTo(expectedRemainingGas);

--- a/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
@@ -162,7 +162,7 @@ class ContractCreationProcessorTest
         Bytes.fromHexString("00".repeat(EvmSpecVersion.AMSTERDAM.getMaxCodeSize()));
     final MessageFrame messageFrame = new TestMessageFrameBuilder().build();
     messageFrame.setOutputData(contractCode);
-    // EIP-7954: 64KiB code deposit costs 200 * 0x10000 = 13_107_200 regular gas.
+    // EIP-7954: 64KiB code deposit costs 200 * 0x10000 = 13_107_200 execution gas.
     messageFrame.setGasRemaining(15_000_000L);
 
     processor.codeSuccess(messageFrame, OperationTracer.NO_TRACING);


### PR DESCRIPTION
## PR description

In the first version of eip 8037 the term regular gas was used to mean gas that is not state gas. The code reflects this and uses the same term. Recently this term was changed to Execution Gas to be prepared for a future where other gas dimensions besides the existing ones will be introduced. This PR reflects this change and renames the respective code parts and comments. No other changes are introduced.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


